### PR TITLE
Improvements to multimodal HDI

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -79,10 +79,9 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             if is_discrete:
                 func_kwargs.pop("circular")
                 func_kwargs.pop("skipna")
-                func_kwargs["bins"] = None
             else:
                 func_kwargs["bw"] = "isj" if not circular else "taylor"
-                func_kwargs.update(kwargs)
+            func_kwargs.update(kwargs)
 
         result = hdi_array(ary, **func_kwargs)
         if method == "multimodal":

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -47,6 +47,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         circular=False,
         max_modes=10,
         skipna=False,
+        **kwargs,
     ):
         """Compute HDI function on array-like input."""
         if not 1 >= prob > 0:
@@ -80,6 +81,9 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             if is_discrete:
                 func_kwargs.pop("skipna")
                 func_kwargs["bins"] = None
+            else:
+                func_kwargs["bw"] = "isj"
+                func_kwargs.update(kwargs)
 
         result = hdi_array(ary, **func_kwargs)
         if method == "multimodal":

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -54,11 +54,15 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             raise ValueError("The value of `prob` must be in the (0, 1] interval.")
         ary, axes = process_ary_axes(ary, axes)
         is_discrete = np.issubdtype(ary.dtype, np.integer) or np.issubdtype(ary.dtype, np.bool_)
-        if method == "multimodal" and circular and is_discrete:
+        is_multimodal = method.startswith("multimodal")
+        if is_multimodal and circular and is_discrete:
             raise ValueError("Multimodal hdi not supported for discrete circular data.")
         hdi_func = {
             "nearest": self._hdi_nearest,
             "multimodal": (
+                self._hdi_multimodal_discrete if is_discrete else self._hdi_multimodal_continuous
+            ),
+            "multimodal_nearest": (
                 self._hdi_multimodal_discrete if is_discrete else self._hdi_multimodal_continuous
             ),
         }[method]
@@ -71,10 +75,10 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         func_kwargs = {
             "prob": prob,
             "skipna": skipna,
-            "out_shape": (max_modes, 2) if method == "multimodal" else (2,),
+            "out_shape": (max_modes, 2) if is_multimodal else (2,),
             "circular": circular,
         }
-        if method == "multimodal":
+        if is_multimodal:
             func_kwargs["max_modes"] = max_modes
             if is_discrete:
                 func_kwargs.pop("circular")
@@ -83,8 +87,11 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
                 func_kwargs["bw"] = "isj" if not circular else "taylor"
             func_kwargs.update(kwargs)
 
+        if method == "multimodal_nearest":
+            func_kwargs["nearest"] = True
+
         result = hdi_array(ary, **func_kwargs)
-        if method == "multimodal":
+        if is_multimodal:
             mode_mask = [np.all(np.isnan(result[..., i, :])) for i in range(result.shape[-2])]
             result = result[..., ~np.array(mode_mask), :]
         return result

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -62,7 +62,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             "multimodal": (
                 self._hdi_multimodal_discrete if is_discrete else self._hdi_multimodal_continuous
             ),
-            "multimodal_nearest": (
+            "multimodal_sample": (
                 self._hdi_multimodal_discrete if is_discrete else self._hdi_multimodal_continuous
             ),
         }[method]
@@ -87,8 +87,8 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
                 func_kwargs["bw"] = "isj" if not circular else "taylor"
             func_kwargs.update(kwargs)
 
-        if method == "multimodal_nearest":
-            func_kwargs["nearest"] = True
+        if method == "multimodal_sample":
+            func_kwargs["from_sample"] = True
 
         result = hdi_array(ary, **func_kwargs)
         if is_multimodal:

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -48,7 +48,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         max_modes=10,
         skipna=False,
     ):
-        """Compute of HDI function on array-like input."""
+        """Compute HDI function on array-like input."""
         if not 1 >= prob > 0:
             raise ValueError("The value of `prob` must be in the (0, 1] interval.")
         if method == "multimodal" and circular:

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -74,6 +74,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             func_kwargs["circular"] = circular
         else:
             func_kwargs["max_modes"] = max_modes
+            func_kwargs["bins"] = None
 
         result = hdi_array(ary, **func_kwargs)
         if method == "multimodal":

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -282,6 +282,28 @@ class _CoreBase:
 
         return self._pad_hdi_to_maxmodes(hdi_intervals, interval_probs, max_modes)
 
+    def _hdi_from_point_densities(self, points, densities, prob, circular):
+        if circular:
+            points = self._circular_standardize(points)
+
+        sorted_idx = np.argsort(points)
+        points = points[sorted_idx]
+        densities = densities[sorted_idx]
+
+        # find idx of points in the interval
+        interval_size = int(np.ceil(prob * len(points)))
+        sorted_idx = np.argsort(densities)[::-1]
+        idx_in_interval = sorted_idx[:interval_size]
+        idx_in_interval.sort()
+
+        # find idx of interval bounds
+        probs_in_interval = np.full(idx_in_interval.shape, 1 / len(points))
+        interval_bounds_idx, interval_probs = self._interval_points_to_bounds(
+            idx_in_interval, probs_in_interval, 1, circular, period=len(points)
+        )
+
+        return points[interval_bounds_idx], interval_probs
+
     def _hdi_from_bin_probabilities(self, bins, bin_probs, prob, circular, dx):
         if circular:
             bins = self._circular_standardize(bins)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -282,10 +282,9 @@ class _CoreBase:
 
         return self._pad_hdi_to_maxmodes(hdi_intervals, interval_probs, max_modes)
 
-    def _hdi_from_bin_probabilities(self, bins, bin_probs, prob, circular, dx):  # pylint: disable=no-self-use
+    def _hdi_from_bin_probabilities(self, bins, bin_probs, prob, circular, dx):
         if circular:
-            # standardize bins to [-pi, pi]
-            bins = np.fmod(bins + np.pi, 2 * np.pi) - np.pi
+            bins = self._circular_standardize(bins)
             sorted_idx = np.argsort(bins)
             bins = bins[sorted_idx]
             bin_probs = bin_probs[sorted_idx]

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -85,7 +85,7 @@ class _CoreBase:
         The result is between -pi and pi.
         """
         return circmean(ary, high=np.pi, low=-np.pi)
-    
+
     def _circular_standardize(self, ary):  # pylint: disable=no-self-use
         """Standardize circular data to the interval [-pi, pi]."""
         return np.mod(ary + np.pi, 2 * np.pi) - np.pi
@@ -211,7 +211,7 @@ class _CoreBase:
             bins = self._get_bins(ary)
         return np.histogram(ary, bins=bins, range=range, weights=weights, density=density)
 
-    def _hdi_linear_nearest_common(self, ary, prob):
+    def _hdi_linear_nearest_common(self, ary, prob):  # pylint: disable=no-self-use
         n = len(ary)
 
         ary = np.sort(ary)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -278,8 +278,8 @@ class _CoreBase:
             dx = 1
         else:
             bins = self._get_bins(ary)
-            density, _ = self._histogram(ary, bins=bins)
-            dx = np.diff(bins)[0]
+            density, bins = self._histogram(ary, bins=bins)
+            dx = bins[1] - bins[0]
 
         hdi_intervals, interval_probs = self._hdi_from_bin_probabilities(
             bins, density, prob, False, dx

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -88,7 +88,7 @@ class _CoreBase:
     
     def _circular_standardize(self, ary):  # pylint: disable=no-self-use
         """Standardize circular data to the interval [-pi, pi]."""
-        return np.fmod(ary + np.pi, 2 * np.pi) - np.pi
+        return np.mod(ary + np.pi, 2 * np.pi) - np.pi
 
     def quantile(self, ary, quantile, **kwargs):  # pylint: disable=no-self-use
         """Compute the quantile of an array of samples.

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -259,9 +259,7 @@ class _CoreBase:
             ary = ary[~np.isnan(ary)]
 
         bins, density, _ = self.kde(ary, circular=circular, **kwargs)
-        lower, upper = bins[0], bins[-1]
-        range_x = upper - lower
-        dx = range_x / len(density)
+        dx = (bins[-1] - bins[0]) / len(density)
 
         hdi_intervals, interval_probs = self._hdi_from_bin_probabilities(
             bins, density, prob, circular, dx

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -260,9 +260,10 @@ class _CoreBase:
 
         bins, density, _ = self.kde(ary, circular=circular, **kwargs)
         dx = (bins[-1] - bins[0]) / len(density)
+        bin_probs = density * dx
 
         hdi_intervals, interval_probs = self._hdi_from_bin_probabilities(
-            bins, density, prob, circular, dx
+            bins, bin_probs, prob, circular, dx
         )
 
         return self._pad_hdi_to_maxmodes(hdi_intervals, interval_probs, max_modes)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -247,7 +247,7 @@ class _CoreBase:
         return hdi_interval
 
     def _hdi_multimodal_continuous(
-        self, ary, prob, skipna, max_modes, circular, nearest=False, **kwargs
+        self, ary, prob, skipna, max_modes, circular, from_sample=False, **kwargs
     ):
         """Compute HDI if the distribution is multimodal."""
         ary = ary.flatten()
@@ -255,7 +255,7 @@ class _CoreBase:
             ary = ary[~np.isnan(ary)]
 
         bins, density, _ = self.kde(ary, circular=circular, **kwargs)
-        if nearest:
+        if from_sample:
             ary_density = np.interp(ary, bins, density)
             hdi_intervals, interval_probs = self._hdi_from_point_densities(
                 ary, ary_density, prob, circular

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -252,13 +252,13 @@ class _CoreBase:
 
         return hdi_interval
 
-    def _hdi_multimodal_continuous(self, ary, prob, skipna, max_modes):
+    def _hdi_multimodal_continuous(self, ary, prob, skipna, max_modes, **kwargs):
         """Compute HDI if the distribution is multimodal."""
         ary = ary.flatten()
         if skipna:
             ary = ary[~np.isnan(ary)]
 
-        bins, density, _ = self.kde(ary)
+        bins, density, _ = self.kde(ary, **kwargs)
         lower, upper = bins[0], bins[-1]
         range_x = upper - lower
         dx = range_x / len(density)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -271,7 +271,8 @@ class _CoreBase:
             bin_probs = counts / len(ary)
             dx = 1
         else:
-            counts, bins = self._histogram(ary, bins=bins)
+            counts, edges = self._histogram(ary, bins=bins)
+            bins = 0.5 * (edges[1:] + edges[:-1])
             bin_probs = counts / counts.sum()
             dx = bins[1] - bins[0]
 

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -274,7 +274,8 @@ class _CoreBase:
         ary = ary.flatten()
 
         if bins is None:
-            bins, density = np.unique(ary, return_counts=True)
+            bins, counts = np.unique(ary, return_counts=True)
+            density = counts / len(ary)
             dx = 1
         else:
             bins = self._get_bins(ary)
@@ -297,7 +298,6 @@ class _CoreBase:
 
         # find idx of bins in the interval
         sorted_idx = np.argsort(bin_probs)[::-1]
-        bin_probs = bin_probs / bin_probs.sum()
         cum_probs = bin_probs[sorted_idx].cumsum()
         interval_size = np.searchsorted(cum_probs, prob, side="left") + 1
         idx_in_interval = sorted_idx[:interval_size]

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -300,22 +300,23 @@ class _CoreBase:
         # get points in intervals
         intervals = bins[idx_in_interval]
         probs_in_interval = bin_probs[idx_in_interval]
-        cum_probs_intervals = probs_in_interval.cumsum()
 
-        # get interval bounds
-        is_bound = np.diff(intervals) > dx * 1.01
+        return self._interval_points_to_bounds(intervals, probs_in_interval, dx, circular)
+
+    def _interval_points_to_bounds(self, points, probs, dx, circular, period=2 * np.pi):  # pylint: disable=no-self-use
+        cum_probs = probs.cumsum()
+
+        is_bound = np.diff(points) > dx * 1.01
         is_lower_bound = np.insert(is_bound, 0, True)
         is_upper_bound = np.append(is_bound, True)
-        interval_bounds = np.column_stack([intervals[is_lower_bound], intervals[is_upper_bound]])
+        interval_bounds = np.column_stack([points[is_lower_bound], points[is_upper_bound]])
         interval_probs = (
-            cum_probs_intervals[is_upper_bound]
-            - cum_probs_intervals[is_lower_bound]
-            + probs_in_interval[is_lower_bound]
+            cum_probs[is_upper_bound] - cum_probs[is_lower_bound] + probs[is_lower_bound]
         )
 
         if (
             circular
-            and np.fmod(dx * 1.01 + interval_bounds[-1, -1] - interval_bounds[0, 0], 2 * np.pi)
+            and np.mod(dx * 1.01 + interval_bounds[-1, -1] - interval_bounds[0, 0], period)
             <= dx * 1.01
         ):
             interval_bounds[-1, 1] = interval_bounds[0, 1]

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -268,21 +268,21 @@ class _CoreBase:
 
         return self._pad_hdi_to_maxmodes(hdi_intervals, interval_probs, max_modes)
 
-    def _hdi_multimodal_discrete(self, ary, prob, bins, max_modes):
+    def _hdi_multimodal_discrete(self, ary, prob, max_modes, bins=None):
         """Compute HDI if the distribution is multimodal."""
         ary = ary.flatten()
 
         if bins is None:
             bins, counts = np.unique(ary, return_counts=True)
-            density = counts / len(ary)
+            bin_probs = counts / len(ary)
             dx = 1
         else:
-            bins = self._get_bins(ary)
-            density, bins = self._histogram(ary, bins=bins)
+            counts, bins = self._histogram(ary, bins=bins)
+            bin_probs = counts / counts.sum()
             dx = bins[1] - bins[0]
 
         hdi_intervals, interval_probs = self._hdi_from_bin_probabilities(
-            bins, density, prob, False, dx
+            bins, bin_probs, prob, False, dx
         )
 
         return self._pad_hdi_to_maxmodes(hdi_intervals, interval_probs, max_modes)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -287,7 +287,7 @@ class _CoreBase:
         sorted_idx = np.argsort(bin_probs)[::-1]
         cum_scaled_prob = bin_probs[sorted_idx].cumsum()
         scaled_prob = prob * cum_scaled_prob[-1]
-        interval_size = np.searchsorted(cum_scaled_prob, scaled_prob, side="right")
+        interval_size = np.searchsorted(cum_scaled_prob, scaled_prob, side="left") + 1
         idx_in_interval = sorted_idx[:interval_size]
         idx_in_interval.sort()
 

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -46,7 +46,7 @@ class BaseDataArray:
             da,
             prob,
             input_core_dims=[dims, []],
-            output_core_dims=[[mode_dim, "hdi"] if method == "multimodal" else ["hdi"]],
+            output_core_dims=[[mode_dim, "hdi"] if method.startswith("multimodal") else ["hdi"]],
             kwargs={
                 "axes": np.arange(-len(dims), 0, 1),
                 "method": method,

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -34,9 +34,7 @@ class BaseDataArray:
             kwargs={"axis": np.arange(-len(dims), 0, 1), "method": method},
         )
 
-    def hdi(
-        self, da, prob=None, dims=None, method="nearest", circular=False, max_modes=10, skipna=False
-    ):
+    def hdi(self, da, prob=None, dims=None, method="nearest", **kwargs):
         """Compute hdi on DataArray input."""
         dims = validate_dims(dims)
         prob = validate_ci_prob(prob)
@@ -50,11 +48,9 @@ class BaseDataArray:
             input_core_dims=[dims, []],
             output_core_dims=[[mode_dim, "hdi"] if method == "multimodal" else ["hdi"]],
             kwargs={
-                "method": method,
-                "circular": circular,
-                "skipna": skipna,
-                "max_modes": max_modes,
                 "axes": np.arange(-len(dims), 0, 1),
+                "method": method,
+                **kwargs,
             },
         ).assign_coords({"hdi": hdi_coord})
 

--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -238,7 +238,7 @@ class _DensityBase(_CoreBase):
         return 1 / (x**3 - 4 * x**2 + 3 * x)
 
     def _kappa_mle(self, x):
-        mean = self._circular_mean(x)
+        mean = self.circular_mean(x)
         kappa = self._a1inv(np.mean(np.cos(x - mean)))
         return kappa
 
@@ -633,7 +633,7 @@ class _DensityBase(_CoreBase):
             raise ValueError(f"Numeric `bw` must be positive.\nInput: {bw:.4f}.")
         if isinstance(bw, str):
             if bw == "taylor":
-                bw = self._bw_taylor(x)
+                bw = self.bw_taylor(x)
             else:
                 raise ValueError(f"`bw` must be a positive numeric or `taylor`, not {bw}")
         bw *= bw_fct

--- a/tests/base/test_stats.py
+++ b/tests/base/test_stats.py
@@ -92,7 +92,7 @@ def test_hdi_coords(centered_eight):
 @pytest.mark.parametrize("prob", [0.56, 0.83])
 @pytest.mark.parametrize("nearest", [True, False])
 def test_hdi_multimodal_continuous(prob, nearest):
-    method = "multimodal_nearest" if nearest else "multimodal"
+    method = "multimodal_sample" if nearest else "multimodal"
     rng = np.random.default_rng(43)
     dist1 = norm(loc=-30, scale=0.5)
     dist2 = norm(loc=30, scale=0.5)
@@ -176,7 +176,8 @@ def test_hdi_multimodal_max_modes():
     sample = ndarray_to_dataarray(x, "x", sample_dims=["sample"])
     intervals = sample.azstats.hdi(dims="sample", method="multimodal", prob=0.9)
     assert intervals.sizes["mode"] == 2
-    intervals2 = sample.azstats.hdi(dims="sample", method="multimodal", prob=0.9, max_modes=1)
+    with pytest.warns(UserWarning, match="found more modes"):
+        intervals2 = sample.azstats.hdi(dims="sample", method="multimodal", prob=0.9, max_modes=1)
     assert intervals2.sizes["mode"] == 1
     assert intervals2.equals(intervals.isel(mode=[1]))
 
@@ -194,7 +195,7 @@ def test_hdi_multimodal_circular(nearest):
         "x",
         sample_dims=["sample"],
     )
-    method = "multimodal_nearest" if nearest else "multimodal"
+    method = "multimodal_sample" if nearest else "multimodal"
     interval = normal_sample.azstats.hdi(circular=True, method=method, prob=0.83, dims="sample")
     assert interval.sizes["mode"] == 2
     assert interval.sel(mode=0)[0] <= np.pi / 2 <= interval.sel(mode=0)[1]

--- a/tests/base/test_stats.py
+++ b/tests/base/test_stats.py
@@ -137,6 +137,10 @@ def test_hdi_circular():
     )
     interval = normal_sample.azstats.hdi(circular=True, prob=0.83, dims="sample")
     assert_array_almost_equal(interval, [1.3, -1.4], 1)
+    interval_multi = normal_sample.azstats.hdi(
+        circular=True, prob=0.83, dims="sample", method="multimodal"
+    )
+    assert_array_almost_equal(interval_multi, [[1.3, -1.4]], 1)
 
 
 def test_hdi_bad_ci():

--- a/tests/base/test_stats.py
+++ b/tests/base/test_stats.py
@@ -119,6 +119,17 @@ def test_hdi_multimodal_multivars():
     assert "var2_mode" in intervals.var2.dims
 
 
+def test_hdi_multimodal_max_modes():
+    rng = np.random.default_rng(42)
+    x = np.concatenate([rng.normal(0, 1, 250_000), rng.normal(30, 1, 2_500_000)])
+    sample = ndarray_to_dataarray(x, "x", sample_dims=["sample"])
+    intervals = sample.azstats.hdi(dims="sample", method="multimodal", prob=0.9)
+    assert intervals.sizes["mode"] == 2
+    intervals2 = sample.azstats.hdi(dims="sample", method="multimodal", prob=0.9, max_modes=1)
+    assert intervals2.sizes["mode"] == 1
+    assert intervals2.equals(intervals.isel(mode=[1]))
+
+
 def test_hdi_circular():
     rng = np.random.default_rng(43)
     normal_sample = ndarray_to_dataarray(


### PR DESCRIPTION
This PR implements the improvements to HDI suggested in https://github.com/arviz-devs/arviz/issues/2394, with a few differences:
- Supporting passing an array of HDI probabilities is left for a future PR.
- Circular support for continuous multimodal HDI is included.
- When more intervals than `max_modes` are computed, now the `max_modes` highest probability intervals are returned instead of just the ones that are lowest on the real line.

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--28.org.readthedocs.build/en/28/

<!-- readthedocs-preview arviz-stats end -->