### PR TITLE
Remove HDI method agg_nearest

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -56,7 +56,6 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         ary, axes = process_ary_axes(ary, axes)
         hdi_func = {
             "nearest": self._hdi_nearest,
-            "agg_nearest": self._hdi_agg_nearest,
             "multimodal": self._hdi_multimodal,
         }[method]
         hdi_array = make_ufunc(

--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -779,27 +779,3 @@ class _DensityBase(_CoreBase):
                 contours[idx] = sorted_density[0]
 
         return contours
-
-    def _hdi_agg_nearest(self, ary, prob, skipna):
-        """Approximate the HDI from the kde or histogram."""
-        ary = ary.flatten()
-        if skipna:
-            nans = np.isnan(ary)
-            if not nans.all():
-                ary = ary[~nans]
-
-        if ary.dtype.kind == "f":
-            bins, density, _ = self._kde(ary)
-        else:
-            bins = self._get_bins(ary)
-            density, _ = self._histogram(ary, bins=bins, density=True)
-
-        sorted_idx = np.argsort(density)[::-1]
-        mass_cum = 0
-        indices = []
-        for idx in sorted_idx:
-            mass_cum += density[idx]
-            indices.append(idx)
-            if mass_cum >= prob:
-                break
-        return bins[np.sort(indices)[[0, -1]]]


### PR DESCRIPTION
As discussed in https://github.com/arviz-devs/arviz-stats/pull/28#issuecomment-2414524683, HDI method `agg_nearest` is not very useful as an HDI estimator compared to our other options. From that comment:

> `agg_nearest` seems to be not so similar to `nearest` at all. It will only be similar when `multimodal` would return a single interval. Otherwise, it also includes all the intervals between the HDI intervals and can contain much more probability than the requested "hdi_prob". Personally, I don't see a use for `agg_nearest`; I see it as being similar to reaching for a CDF estimated from a KDE instead of an ECDF. I think the smoothing would in general only make the estimate worse. If something similar to `nearest` that forces contiguity but uses "bin centers" is really what's desired, a JIT-compiled sliding window approach would be quite efficient.

On @OriolAbril 's suggestion, this PR removes the method, which was never in the original ArviZ.

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--31.org.readthedocs.build/en/31/

<!-- readthedocs-preview arviz-stats end -->