### PR TITLE
Add summary function

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -24,6 +24,7 @@
    arviz_stats.psense_summary
    arviz_stats.rhat
    arviz_stats.thin
+   arisz_stats.summary
 ```
 
 ## Accessors

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -23,8 +23,8 @@
    arviz_stats.psense
    arviz_stats.psense_summary
    arviz_stats.rhat
+   arviz_stats.summary
    arviz_stats.thin
-   arisz_stats.summary
 ```
 
 ## Accessors

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -6,6 +6,7 @@ try:
     from arviz_stats.accessors import *
     from arviz_stats.psense import psense, psense_summary
     from arviz_stats.sampling_diagnostics import ess, mcse, rhat
+    from arviz_stats.summary import summary
     from arviz_stats.manipulation import thin
 
 except ModuleNotFoundError:

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -104,7 +104,11 @@ class _CoreBase:
         "Sample quantiles in statistical packages,"
         The American Statistician, 50(4), pp. 361-365, 1996
         """
-        result = np.quantile(ary, quantile, **kwargs)
+        skipna = kwargs.pop("skipna", False)
+        if skipna:
+            result = np.nanquantile(ary, quantile, **kwargs)
+        else:
+            result = np.quantile(ary, quantile, **kwargs)
         if np.ndim(quantile) == 0:
             return result
         return np.moveaxis(result, 0, -1)

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -20,7 +20,7 @@ class BaseDataArray:
     def __init__(self, array_class=None):
         self.array_class = array_stats if array_class is None else array_class
 
-    def eti(self, da, prob=None, dims=None, method="linear"):
+    def eti(self, da, prob=None, dims=None, method="linear", **kwargs):
         """Compute eti on DataArray input."""
         dims = validate_dims(dims)
         prob = validate_ci_prob(prob)
@@ -31,7 +31,7 @@ class BaseDataArray:
             prob,
             input_core_dims=[dims, []],
             output_core_dims=[["quantile"]],
-            kwargs={"axis": np.arange(-len(dims), 0, 1), "method": method},
+            kwargs={"axis": np.arange(-len(dims), 0, 1), "method": method, **kwargs},
         )
 
     def hdi(self, da, prob=None, dims=None, method="nearest", **kwargs):

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -24,6 +24,7 @@ class BaseDataArray:
         """Compute eti on DataArray input."""
         dims = validate_dims(dims)
         prob = validate_ci_prob(prob)
+        eti_coord = DataArray(["lower", "higher"], dims=["quantile"], attrs={"eti_prob": prob})
 
         return apply_ufunc(
             self.array_class.eti,
@@ -32,7 +33,7 @@ class BaseDataArray:
             input_core_dims=[dims, []],
             output_core_dims=[["quantile"]],
             kwargs={"axis": np.arange(-len(dims), 0, 1), "method": method, **kwargs},
-        )
+        ).assign_coords({"quantile": eti_coord})
 
     def hdi(self, da, prob=None, dims=None, method="nearest", **kwargs):
         """Compute hdi on DataArray input."""

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -143,18 +143,18 @@ def summary(
 
     if kind in ["stats", "all"]:
         mean = dataset.mean(dim=sample_dims, skipna=skipna).expand_dims(summary=["mean"])
-        std = dataset.std(dim=sample_dims, skipna=skipna).expand_dims(summary=["std"])
+        std = dataset.std(dim=sample_dims, skipna=skipna).expand_dims(summary=["sd"])
         if ci_kind == "eti":
             ci = (
                 dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna)
                 .rename({"quantile": "summary"})
-                .assign_coords(summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"])
+                .assign_coords(summary=[f"eti{ci_perc}_", f"eti{ci_perc}^"])
             )
         else:
             ci = (
                 dataset.azstats.hdi(prob=ci_prob, dims=sample_dims, skipna=skipna)
                 .rename({"hdi": "summary"})
-                .assign_coords(summary=[f"hdi_{ci_perc}_lb", f"hdi_{ci_perc}_ub"])
+                .assign_coords(summary=[f"hdi{ci_perc}_", f"hdi{ci_perc}^"])
             )
         to_concat.extend((mean, std, ci))
 
@@ -165,7 +165,7 @@ def summary(
         ess_tail = dataset.azstats.ess(dims=sample_dims, method="tail").expand_dims(
             summary=["ess_tail"]
         )
-        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["rhat"])
+        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["R̂"])
         mcse_mean = dataset.azstats.mcse(dims=sample_dims, method="mean").expand_dims(
             summary=["mcse_mean"]
         )
@@ -183,7 +183,7 @@ def summary(
         ci = (
             dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna)
             .rename({"quantile": "summary"})
-            .assign_coords(summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"])
+            .assign_coords(summary=[f"eti{ci_perc}_", f"eti{ci_perc}^"])
         )
 
         to_concat.extend((median, mad, ci))
@@ -195,7 +195,7 @@ def summary(
         ess_tail = dataset.azstats.ess(dims=sample_dims, method="tail").expand_dims(
             summary=["ess_tail"]
         )
-        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["rhat"])
+        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["R̂"])
         mcse_median = dataset.azstats.mcse(dims=sample_dims, method="median").expand_dims(
             summary=["mcse_median"]
         )

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -107,7 +107,7 @@ def summary(
     if ci_kind not in ("hdi", "eti", None):
         raise ValueError("ci_kind must be either 'hdi' or 'eti'")
 
-    if kind not in [
+    kinds = [
         "all",
         "stats",
         "diagnostics",
@@ -115,10 +115,10 @@ def summary(
         "stats_median",
         "diagnostics_median",
         "mc_diagnostics",
-    ]:
+    ]
+    if kind not in kinds:
         raise ValueError(
-            """kind must be either 'all', 'stats', 'diagnostics', 'all_median',
-            'stats_median', 'diagnostics_median', 'mc_diagnostics'"""
+            "valid options for kind are: " + ", ".join(kinds[:-1]) + " or " + kinds[-1]
         )
 
     if ci_prob is None:

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -76,16 +76,17 @@ def summary(
     --------
     .. ipython::
 
-        In [1]: import arviz as az
-           ...: data = az.load_arviz_data("centered_eight")
-           ...: az.summary(data, var_names=["mu", "tau"])
+        In [1]: from arviz_base import load_arviz_data
+           ...: import arviz_stats as azs
+           ...: data = load_arviz_data("centered_eight")
+           ...: azs.summary(data, var_names=["mu", "tau"])
 
     You can use ``filter_vars`` to select variables without having to specify all the exact
     names. Use ``filter_vars="like"`` to select based on partial naming:
 
     .. ipython::
 
-        In [1]: az.summary(data, var_names=["the"], filter_vars="like")
+        In [1]: azs.summary(data, var_names=["the"], filter_vars="like")
 
     Use ``filter_vars="regex"`` to select based on regular expressions, and prefix the variables
     you want to exclude by ``~``. Here, we exclude from the summary all the variables
@@ -93,7 +94,7 @@ def summary(
 
     .. ipython::
 
-        In [1]: az.summary(data, var_names=["~^t"], filter_vars="regex")
+        In [1]: azs.summary(data, var_names=["~^t"], filter_vars="regex")
 
     """
     if ci_kind not in ("hdi", "eti", None):

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -1,0 +1,200 @@
+"""Summaries for various statistics and diagnostics."""
+
+import xarray as xr
+from arviz_base import extract, rcParams
+from xarray_einstats import stats
+
+__all__ = ["summary"]
+
+
+def summary(
+    dt,
+    var_names=None,
+    filter_vars=None,
+    group="posterior",
+    coords=None,
+    sample_dims=None,
+    kind="all",
+    ci_prob=None,
+    ci_kind=None,
+):
+    """
+    Create a data frame with summary statistics and or diagnostics.
+
+    Parameters
+    ----------
+    dt : obj
+        Any object that can be converted to an :class:`arviz.InferenceData` object.
+        Refer to documentation of :func:`arviz.convert_to_dataset` for details.
+        For ndarray: shape = (chain, draw).
+        For n-dimensional ndarray transform first to dataset with ``az.convert_to_dataset``.
+    var_names : list of str, optional
+        Names of posterior variables to include in the power scaling sensitivity diagnostic
+    filter_vars: {None, "like", "regex"}, default None
+        Used for `var_names` only.
+        If ``None`` (default), interpret var_names as the real variables names.
+        If "like", interpret var_names as substrings of the real variables names.
+        If "regex", interpret var_names as regular expressions on the real variables names.
+    group : {"prior", "likelihood"}, default "prior"
+        If "likelihood", the pointsize log likelihood values are retrieved
+        from the ``log_likelihood`` group and added together.
+        If "prior", the log prior values are retrieved from the ``log_prior`` group.
+    coords : dict, optional
+        Coordinates defining a subset over the posterior. Only these variables will
+        be used when computing the prior sensitivity.
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    kind: {'all', 'stats', 'diagnostics', 'all_median', 'stats_median',
+    'diagnostics_median', 'mc_diagnostics'}, default 'all'
+        * ``all``: `mean`, `sd`, `ci`, `ess_bulk`, `ess_tail`, `r_hat`, `mcse_mean`, `mcse_sd`.
+        * ``stats``: `mean`, `sd`, and `ci`.
+        * ``diagnostics``: `ess_bulk`, `ess_tail`, `r_hat`, `mcse_mean`, `mcse_sd`.
+        * ``all_median``: `median`, `mad`, `ci`, `ess_median`, `ess_tail`, `r_hat`, `mcse_median`.
+        * ``stats_median``: `median`, `mad`, and `ci`.
+        * ``diagnostics_median``: `ess_median`, `ess_tail`, `r_hat`, `mcse_median`.
+        * ``mc_diagnostics``: `mcse_mean`, `ess_mean`, and `min_ss`.
+    ci_prob : float, optional
+        Probability for the credible interval. Defaults to ``rcParams["stats.ci_prob"]``.
+    ci_kind : {"hdi", "eti"}, optional
+        Type of credible interval. Defaults to ``rcParams["stats.ci_kind"]``.
+
+    Returns
+    -------
+    pandas.DataFrame or xarray.Dataset
+
+    See Also
+    --------
+    arviz.rhat : Compute estimate of rank normalized split R-hat for a set of traces.
+    arviz.ess : Calculate the effective sample size of a set of traces.
+    arviz.mcse : Calculate Markov Chain Standard Error statistic.
+    plot_ess : Plot quantile, local or evolution of effective sample sizes (ESS).
+    plot_mcse : Plot quantile, local or evolution of Markov Chain Standard Error (MCSE).
+
+
+    Examples
+    --------
+    .. ipython::
+
+        In [1]: import arviz as az
+           ...: data = az.load_arviz_data("centered_eight")
+           ...: az.summary(data, var_names=["mu", "tau"])
+
+    You can use ``filter_vars`` to select variables without having to specify all the exact
+    names. Use ``filter_vars="like"`` to select based on partial naming:
+
+    .. ipython::
+
+        In [1]: az.summary(data, var_names=["the"], filter_vars="like")
+
+    Use ``filter_vars="regex"`` to select based on regular expressions, and prefix the variables
+    you want to exclude by ``~``. Here, we exclude from the summary all the variables
+    starting with the letter t:
+
+    .. ipython::
+
+        In [1]: az.summary(data, var_names=["~^t"], filter_vars="regex")
+
+    """
+    if ci_kind not in ("hdi", "eti", None):
+        raise ValueError("ci_kind must be either 'hdi' or 'eti'")
+
+    if ci_prob is None:
+        ci_prob = rcParams["stats.ci_prob"]
+    if ci_kind is None:
+        ci_kind = rcParams["stats.ci_kind"] if "stats.ci_kind" in rcParams else "eti"
+
+    ci_perc = int(ci_prob * 100)
+
+    dataset = extract(
+        dt,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        group=group,
+        combined=False,
+        keep_dataset=True,
+    )
+    if coords is not None:
+        dataset = dataset.sel(coords)
+
+    to_concat = []
+
+    if kind == "stats" or kind == "all":
+        mean = dataset.mean(dim=sample_dims).expand_dims(summary=["mean"])
+        std = dataset.std(dim=sample_dims).expand_dims(summary=["std"])
+        if ci_kind == "eti":
+            ci = dataset.azstats.eti(prob=ci_prob, dims=sample_dims).expand_dims(
+                summary=[f"eti_{ci_perc}"]
+            )
+            # ci = dataset.azstats.eti(prob=ci_prob, dims=dims).assign_coords(summary=["lb", "ub"])
+        elif ci_kind == "hdi":
+            ci = dataset.azstats.hdi(prob=ci_prob, dims=sample_dims).expand_dims(
+                summary=[f"hdi_{ci_perc}"]
+            )
+
+        to_concat.extend((mean, std, ci))
+
+    if kind == "diagnostics" or kind == "all":
+        ess_bulk = dataset.azstats.ess(dims=sample_dims, method="bulk").expand_dims(
+            summary=["ess_bulk"]
+        )
+        ess_tail = dataset.azstats.ess(dims=sample_dims, method="tail").expand_dims(
+            summary=["ess_tail"]
+        )
+        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["rhat"])
+        mcse_mean = dataset.azstats.mcse(dims=sample_dims, method="mean").expand_dims(
+            summary=["mcse_mean"]
+        )
+        mcse_sd = dataset.azstats.mcse(dims=sample_dims, method="sd").expand_dims(
+            summary=["mcse_sd"]
+        )
+
+        to_concat.extend((ess_bulk, ess_tail, rhat, mcse_mean, mcse_sd))
+
+    if kind == "stats_median" or kind == "all_median":
+        median = dataset.median(dim=sample_dims).expand_dims(summary=["median"])
+        mad = stats.median_abs_deviation(dataset.to_dataset(), dims=("chain", "draw")).expand_dims(
+            summary=["mad"]
+        )
+        if ci_kind == "eti":
+            ci = dataset.azstats.eti(prob=ci_prob, dims=sample_dims).expand_dims(
+                summary=[f"eti_{ci_perc}"]
+            )
+            # ci = dataset.azstats.eti(prob=ci_prob, dims=dims).assign_coords(summary=["lb", "ub"])
+        elif ci_kind == "hdi":
+            ci = dataset.azstats.hdi(prob=ci_prob, dims=sample_dims).expand_dims(
+                summary=[f"hdi_{ci_perc}"]
+            )
+
+        to_concat.extend((median, mad, ci))
+
+    if kind == "diagnostics_median" or kind == "all_median":
+        ess_median = dataset.azstats.ess(dims=sample_dims, method="median").expand_dims(
+            summary=["ess_median"]
+        )
+        ess_tail = dataset.azstats.ess(dims=sample_dims, method="tail").expand_dims(
+            summary=["ess_tail"]
+        )
+        rhat = dataset.azstats.rhat(dims=sample_dims).expand_dims(summary=["rhat"])
+        mcse_median = dataset.azstats.mcse(dims=sample_dims, method="median").expand_dims(
+            summary=["mcse_median"]
+        )
+
+        to_concat.extend((ess_median, ess_tail, rhat, mcse_median))
+
+    if kind == "mc_diagnostics":
+        mcse_mean = dataset.azstats.mcse(dims=sample_dims, method="mean").expand_dims(
+            summary=["mcse_mean"]
+        )
+        ess_mean = dataset.azstats.ess(dims=sample_dims, method="mean").expand_dims(
+            summary=["ess_mean"]
+        )
+        min_ss = dataset.azstats.pareto_min_ss(dims=sample_dims).expand_dims(summary=["min_ss"])
+
+        to_concat.extend((mcse_mean, ess_mean, min_ss))
+
+    summaries = xr.concat(to_concat, dim="summary")
+
+    # Uncomment once we have https://github.com/arviz-devs/arviz-base/pull/25
+    # dataset_to_dataframe(summaries, sample_dims=["summary"]).T
+    return summaries

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -1,7 +1,10 @@
 """Summaries for various statistics and diagnostics."""
 
+from typing import Hashbale, Literal, Sequence
+
 import xarray as xr
 from arviz_base import dataset_to_dataframe, extract, rcParams
+from xarray.core.datatree import DataTree
 from xarray_einstats import stats
 
 __all__ = ["summary"]

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -1,54 +1,46 @@
 """Summaries for various statistics and diagnostics."""
 
-from typing import Hashbale, Literal, Sequence
+from typing import Any
 
 import xarray as xr
 from arviz_base import dataset_to_dataframe, extract, rcParams
-from xarray.core.datatree import DataTree
+from pandas import DataFrame
 from xarray_einstats import stats
 
 __all__ = ["summary"]
 
 
 def summary(
-    dt,
-    var_names=None,
-    filter_vars=None,
-    group="posterior",
-    coords=None,
-    sample_dims=None,
-    kind="all",
-    ci_prob=None,
-    ci_kind=None,
-    round_to=2,
-    skipna=False,
-):
+    data: Any,
+    var_names: list[str] | None = None,
+    filter_vars: str | None = None,
+    group: str = "posterior",
+    coords: list[str, Any] | None = None,
+    sample_dims: str | list[str] | None = None,
+    kind: str = "all",
+    ci_prob: float | None = None,
+    ci_kind: str | None = None,
+    round_to: int | str | None = 2,
+    skipna: bool = False,
+) -> DataFrame:
     """
     Create a data frame with summary statistics and or diagnostics.
 
     Parameters
     ----------
-    dt : obj
-        Any object that can be converted to an :class:`arviz.InferenceData` object.
-        Refer to documentation of :func:`arviz.convert_to_dataset` for details.
-        For ndarray: shape = (chain, draw).
-        For n-dimensional ndarray transform first to dataset with ``az.convert_to_dataset``.
+    data : DataTree, DataSet or InferenceData
     var_names : list of str, optional
-        Names of posterior variables to include in the power scaling sensitivity diagnostic
+        Names of variables to include in summary. If None all variables are included.
     filter_vars: {None, "like", "regex"}, default None
         Used for `var_names` only.
         If ``None`` (default), interpret var_names as the real variables names.
         If "like", interpret var_names as substrings of the real variables names.
         If "regex", interpret var_names as regular expressions on the real variables names.
-    group : {"prior", "likelihood"}, default "prior"
-        If "likelihood", the pointsize log likelihood values are retrieved
-        from the ``log_likelihood`` group and added together.
-        If "prior", the log prior values are retrieved from the ``log_prior`` group.
+    group: str
+        Select a group for summary. Defaults to “posterior”.
     coords : dict, optional
-        Coordinates defining a subset over the posterior. Only these variables will
-        be used when computing the prior sensitivity.
+        Coordinates defining a subset over the selected group.
     sample_dims : str or sequence of hashable, optional
-        Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
     kind: {'all', 'stats', 'diagnostics', 'all_median', 'stats_median',
     'diagnostics_median', 'mc_diagnostics'}, default 'all'
@@ -71,7 +63,7 @@ def summary(
 
     Returns
     -------
-    pandas.DataFrame or xarray.Dataset
+    pandas.DataFrame
 
     See Also
     --------
@@ -132,7 +124,7 @@ def summary(
     ci_perc = int(ci_prob * 100)
 
     dataset = extract(
-        dt,
+        data,
         var_names=var_names,
         filter_vars=filter_vars,
         group=group,

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -127,12 +127,10 @@ def summary(
                 summary=[f"eti_{ci_perc}"]
             )
             # ci = dataset.azstats.eti(prob=ci_prob, dims=dims).assign_coords(summary=["lb", "ub"])
-        elif ci_kind == "hdi":
+        else:
             ci = dataset.azstats.hdi(prob=ci_prob, dims=sample_dims).expand_dims(
                 summary=[f"hdi_{ci_perc}"]
             )
-        else:
-            raise ValueError("ci_kind must be either 'hdi' or 'eti'")
 
         to_concat.extend((mean, std, ci))
 

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -145,8 +145,10 @@ def summary(
         mean = dataset.mean(dim=sample_dims, skipna=skipna).expand_dims(summary=["mean"])
         std = dataset.std(dim=sample_dims, skipna=skipna).expand_dims(summary=["std"])
         if ci_kind == "eti":
-            ci = dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna).assign_coords(
-                summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"]
+            ci = (
+                dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna)
+                .rename({"quantile": "summary"})
+                .assign_coords(summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"])
             )
         else:
             ci = (
@@ -178,8 +180,10 @@ def summary(
         mad = stats.median_abs_deviation(
             dataset, dims=("chain", "draw"), nan_policy="omit" if skipna else "propagate"
         ).expand_dims(summary=["mad"])
-        ci = dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna).assign_coords(
-            summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"]
+        ci = (
+            dataset.azstats.eti(prob=ci_prob, dims=sample_dims, skipna=skipna)
+            .rename({"quantile": "summary"})
+            .assign_coords(summary=[f"eti_{ci_perc}_lb", f"eti_{ci_perc}_ub"])
         )
 
         to_concat.extend((median, mad, ci))

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -119,7 +119,7 @@ def summary(
 
     to_concat = []
 
-    if kind == "stats" or kind == "all":
+    if kind in ["stats", "all"]:
         mean = dataset.mean(dim=sample_dims).expand_dims(summary=["mean"])
         std = dataset.std(dim=sample_dims).expand_dims(summary=["std"])
         if ci_kind == "eti":
@@ -131,10 +131,12 @@ def summary(
             ci = dataset.azstats.hdi(prob=ci_prob, dims=sample_dims).expand_dims(
                 summary=[f"hdi_{ci_perc}"]
             )
+        else:
+            raise ValueError("ci_kind must be either 'hdi' or 'eti'")
 
         to_concat.extend((mean, std, ci))
 
-    if kind == "diagnostics" or kind == "all":
+    if kind in ["diagnostics", "all"]:
         ess_bulk = dataset.azstats.ess(dims=sample_dims, method="bulk").expand_dims(
             summary=["ess_bulk"]
         )
@@ -151,7 +153,7 @@ def summary(
 
         to_concat.extend((ess_bulk, ess_tail, rhat, mcse_mean, mcse_sd))
 
-    if kind == "stats_median" or kind == "all_median":
+    if kind in ["stats_median", "all_median"]:
         median = dataset.median(dim=sample_dims).expand_dims(summary=["median"])
         mad = stats.median_abs_deviation(dataset.to_dataset(), dims=("chain", "draw")).expand_dims(
             summary=["mad"]
@@ -168,7 +170,7 @@ def summary(
 
         to_concat.extend((median, mad, ci))
 
-    if kind == "diagnostics_median" or kind == "all_median":
+    if kind in ["diagnostics_median", "all_median"]:
         ess_median = dataset.azstats.ess(dims=sample_dims, method="median").expand_dims(
             summary=["ess_median"]
         )


### PR DESCRIPTION
Closes #11 

This adds the basic functionality for the `summary` function. It is still not on par with the `summary` function from old ArviZ, but it is better than nothing. ~Currently, the output is a dataset. To get a Pandas' DataFrame we need arviz-devs/arviz-base#25~

In the old arviz we had a `kind` argument and a `stat_focus` argument. The combination of both specifies which stats/diagnostics were computed. Now we achieve the same with just the `kind` argument. For instance `kind="all"` is the equivalent of the old `kind=all` and `stats_focus="mean"` and kind  `kind="all_median"` is the equivalent of the old `kind=all` and `stats_focus="median"`. Having a single argument seems clear to me.
 
One source of inconsistency is that previously we returned the `hdi` if `stat_focus="mean"` and the `eti` if `stat_focus="median` . But in arviz 1.0 whether to compute these two different CI depend on a global `rcparam` value. ~Should we ignore the `rcparam` specification and return what the `kind` argument dictates?~ If "stats_median", or "all_median" we return `eti` irrespective of the value of `ci_kind` (or the value in rcparams).


<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--51.org.readthedocs.build/en/51/

<!-- readthedocs-preview arviz-stats end -->