### PR TITLE
Add autocorr accessor to _BaseAccessor class

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -55,6 +55,7 @@ In addition, many functions are also available via accessors:
    xarray.Dataset.azstats.kde
    xarray.Dataset.azstats.histogram
    xarray.Dataset.azstats.ecdf
+   xarray.Dataset.azstats.autocorr
 
 ```
 
@@ -74,6 +75,7 @@ In addition, many functions are also available via accessors:
    arviz_stats.base.dataarray_stats.mcse
    arviz_stats.base.dataarray_stats.histogram
    arviz_stats.base.dataarray_stats.kde
+   arviz_stats.base.dataarray_stats.autocorr
 ```
 
 ### Numba submodule

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -123,6 +123,11 @@ class _BaseAccessor:
     def power_scale_sense(self, dims=None, **kwargs):
         """Compute power-scaling sensitivity."""
         return self._apply("power_scale_sense", dims=dims, **kwargs)
+    
+    def autocorr(self, max_lag=None, dims=None, **kwargs):
+        """Compute autocorrelation for all variables in the dataset."""
+        kwargs["max_lag"] = max_lag
+        return self._apply("autocorr", dims=dims, **kwargs)
 
 
 @xr.register_dataarray_accessor("azstats")

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -123,10 +123,9 @@ class _BaseAccessor:
     def power_scale_sense(self, dims=None, **kwargs):
         """Compute power-scaling sensitivity."""
         return self._apply("power_scale_sense", dims=dims, **kwargs)
-    
-    def autocorr(self, max_lag=None, dims=None, **kwargs):
+
+    def autocorr(self, dims=None, **kwargs):
         """Compute autocorrelation for all variables in the dataset."""
-        kwargs["max_lag"] = max_lag
         return self._apply("autocorr", dims=dims, **kwargs)
 
 

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -312,5 +312,21 @@ class BaseDataArray:
             kwargs={"chain_axis": chain_axis, "draw_axis": draw_axis},
         )
 
+    def autocorr(self, da, dims=None):
+        """Compute autocorrelation on DataArray input."""
+        dims = validate_dims(dims)
+        autocorr_result = apply_ufunc(
+            self.array_class.autocorr,
+            da,
+            input_core_dims=[dims],
+            output_core_dims=[dims],
+        )
+        # Add coordinates for plotting
+        autocorr_result = autocorr_result.assign_coords(
+            {"lag": np.arange(autocorr_result.sizes[dims[0]])}
+        ).rename({dims[0]: "lag"})
+
+        return autocorr_result
+
 
 dataarray_stats = BaseDataArray(array_class=array_stats)


### PR DESCRIPTION
This is related to https://github.com/arviz-devs/arviz-plots/pull/153. 
Added an `autocorr` accessor to the `_BaseAccessor` class, similar to the existing `hdi` and `ess` accessors. 

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--65.org.readthedocs.build/en/65/

<!-- readthedocs-preview arviz-stats end -->