### PR TITLE
Add upper bound sphinx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ doc = [
     "myst-nb",
     "sphinx-copybutton",
     "numpydoc",
-    "sphinx>=5",
+    "sphinx<=8.1.3",
     "sphinx-design",
     "jupyter-sphinx",
     "netcdf4",


### PR DESCRIPTION
Documentation building is failing, not sure why at the moment so adding upper bound for sphinx version

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--67.org.readthedocs.build/en/67/

<!-- readthedocs-preview arviz-stats end -->