### PR TITLE
Cap tail at 20%

### DIFF
--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -397,7 +397,7 @@ class _DiagnosticsBase(_CoreBase):
     @staticmethod
     def _get_ps_tails(n_draws, r_eff, tail):
         if n_draws > 255:
-            n_draws_tail = np.ceil(3 * (n_draws / r_eff) ** 0.5).astype(int)
+            n_draws_tail = int(min(n_draws * 0.2, np.ceil(3 * (n_draws / r_eff) ** 0.5)))
         else:
             n_draws_tail = int(n_draws / 5)
 


### PR DESCRIPTION
ps_tail_length can result in a tail length longer than the number of draws if the r_eff is very small. This cap the tail at 20% of the total number of draws.

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--79.org.readthedocs.build/en/79/

<!-- readthedocs-preview arviz-stats end -->