### PR TITLE
Update KDE computation & Bayes factor implementation (#55)

### DIFF
--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -9,6 +9,7 @@ try:
     from arviz_stats.sampling_diagnostics import ess, mcse, rhat, rhat_nested
     from arviz_stats.summary import summary
     from arviz_stats.manipulation import thin
+    from arviz_stats.bayes_factor import bayes_factor
 
 except ModuleNotFoundError:
     pass


### PR DESCRIPTION
* As you suggested [Link](https://github.com/arviz-devs/arviz-stats/pull/46#issuecomment-2601783660) on Jan 20, this PR replaces the `_DensityBase` instantiation logic with the KDE accessor for density computation.

* Avoided the use of `_DensityBase` for KDE computation.

* Added `.azstats.kde()` accessor to compute densities and grids directly.

* Updated Bayes factor calculation to use the new KDE accessor.

* Simplified posterior/prior extraction using idata.posterior[var_name].

* Closes #55 

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--95.org.readthedocs.build/en/95/

<!-- readthedocs-preview arviz-stats end -->