### PR TITLE
Adding rank normalisation methods to rhat_nested

### DIFF
--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -98,7 +98,9 @@ class _BaseAccessor:
 
     def rhat_nested(self, dims=None, method="rank", superchain_ids=None, **kwargs):
         """Compute nested rhat of all the variables in the dataset."""
-        return self._apply("rhat_nested", dims=dims, method=method, superchain_ids=superchain_ids, **kwargs)
+        return self._apply(
+            "rhat_nested", dims=dims, method=method, superchain_ids=superchain_ids, **kwargs
+        )
 
     def mcse(self, dims=None, method="mean", prob=None, **kwargs):
         """Compute the mcse of all the variables in the dataset."""

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -96,9 +96,9 @@ class _BaseAccessor:
         """Compute the rhat of all the variables in the dataset."""
         return self._apply("rhat", dims=dims, method=method, **kwargs)
 
-    def rhat_nested(self, dims=None, superchain_ids=None, **kwargs):
+    def rhat_nested(self, dims=None, method="rank", superchain_ids=None, **kwargs):
         """Compute nested rhat of all the variables in the dataset."""
-        return self._apply("rhat_nested", dims=dims, superchain_ids=superchain_ids, **kwargs)
+        return self._apply("rhat_nested", dims=dims, method=method, superchain_ids=superchain_ids, **kwargs)
 
     def mcse(self, dims=None, method="mean", prob=None, **kwargs):
         """Compute the mcse of all the variables in the dataset."""

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -132,13 +132,18 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         rhat_array = make_ufunc(rhat_func, n_output=1, n_input=1, n_dims=2, ravel=False)
         return rhat_array(ary)
 
-    def rhat_nested(self, ary, superchain_ids, chain_axis=-2, draw_axis=-1):
+    def rhat_nested(self, ary, superchain_ids, method="rank", chain_axis=-2, draw_axis=-1):
         """Compute nested rhat on array-like inputs."""
+        method = method.lower()
+        valid_methods = {"rank", "folded", "z_scale", "split", "identity"}
+        if method not in valid_methods:
+            raise ValueError(f"Requested method '{method}' but it must be one of {valid_methods}")
         if chain_axis is None:
             ary = np.expand_dims(ary, axis=0)
             chain_axis = 0
         ary, _ = process_ary_axes(ary, [chain_axis, draw_axis])
-        rhat_ufunc = make_ufunc(self._rhat_nested, n_output=1, n_input=1, n_dims=2, ravel=False)
+        rhat_func = getattr(self, f"_rhat_nested_{method}")
+        rhat_ufunc = make_ufunc(rhat_func, n_output=1, n_input=1, n_dims=2, ravel=False)
         return rhat_ufunc(ary, superchain_ids=superchain_ids)
 
     def mcse(self, ary, chain_axis=-2, draw_axis=-1, method="mean", prob=None):

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -682,7 +682,8 @@ class _DiagnosticsBase(_CoreBase):
             return np.nan
         return self._rhat_nested(ary, superchain_ids)
 
-    def _rhat_nested(self, ary, superchain_ids):
+    @staticmethod
+    def _rhat_nested(ary, superchain_ids):
         ary = np.asarray(ary)
         nchains, niterations = ary.shape
 

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -639,8 +639,50 @@ class _DiagnosticsBase(_CoreBase):
 
         return np.sqrt((cjs_pq + cjs_qp) / bound)
 
-    @staticmethod
-    def _rhat_nested(ary, superchain_ids):
+    def _rhat_nested_rank(self, ary, superchain_ids):
+        """Compute the rank normalized rhat for 2d array.
+
+        Computation follows https://arxiv.org/abs/1903.08008
+        """
+        ary = np.asarray(ary)
+        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+            return np.nan
+        split_ary = self._split_chains(ary)
+        rhat_bulk = self._rhat_nested(self._z_scale(split_ary), superchain_ids)
+
+        split_ary_folded = abs(split_ary - np.median(split_ary))
+        rhat_tail = self._rhat_nested(self._z_scale(split_ary_folded), superchain_ids)
+
+        rhat_rank = max(rhat_bulk, rhat_tail)
+        return rhat_rank
+
+    def _rhat_nested_folded(self, ary, superchain_ids):
+        """Calculate split-Rhat for folded z-values."""
+        ary = np.asarray(ary)
+        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+            return np.nan
+        ary = self._z_fold(self._split_chains(ary))
+        return self._rhat_nested(ary, superchain_ids)
+
+    def _rhat_nested_z_scale(self, ary, superchain_ids):
+        ary = np.asarray(ary)
+        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+            return np.nan
+        return self._rhat_nested(self._z_scale(self._split_chains(ary)), superchain_ids)
+
+    def _rhat_nested_split(self, ary, superchain_ids):
+        ary = np.asarray(ary)
+        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+            return np.nan
+        return self._rhat_nested(self._split_chains(ary), superchain_ids)
+
+    def _rhat_nested_identity(self, ary, superchain_ids):
+        ary = np.asarray(ary)
+        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+            return np.nan
+        return self._rhat_nested(ary, superchain_ids)
+
+    def _rhat_nested(self, ary, superchain_ids):
         ary = np.asarray(ary)
         nchains, niterations = ary.shape
 

--- a/src/arviz_stats/sampling_diagnostics.py
+++ b/src/arviz_stats/sampling_diagnostics.py
@@ -304,6 +304,7 @@ def rhat_nested(
     group="posterior",
     var_names=None,
     filter_vars=None,
+    method="rank",
     coords=None,
     superchain_ids=None,
     chain_axis=0,
@@ -339,6 +340,13 @@ def rhat_nested(
     var_names : str or list of str, optional
         Names of the variables for which the Rhat should be computed.
     filter_vars : {None, "like", "regex"}, default None
+    method : str, default "rank"
+        Valid methods are:
+        - "rank"        # recommended by Vehtari et al. (2021)
+        - "split"
+        - "folded"
+        - "z_scale"
+        - "identity"
     coords : dict, optional
         Dictionary of dimension/index names to coordinate values defining a subset
         of the data for which to perform the computation.
@@ -403,7 +411,7 @@ def rhat_nested(
     if coords is not None:
         data = data.sel(coords)
 
-    return data.azstats.rhat_nested(dims=sample_dims, superchain_ids=superchain_ids)
+    return data.azstats.rhat_nested(dims=sample_dims, method=method, superchain_ids=superchain_ids)
 
 
 def mcse(

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -105,7 +105,8 @@ def test_deterministic():
     funcs = {
         "rhat_rank": lambda x: array_stats.rhat(x, method="rank"),
         "rhat_raw": lambda x: array_stats.rhat(x, method="identity"),
-        "rhat_nested": lambda x: array_stats.rhat_nested(x, superchain_ids=[0, 0, 1, 1]),
+        "rhat_nested_rank": lambda x: array_stats.rhat_nested(x, method="rank", superchain_ids=[0, 0, 1, 1]),
+        "rhat_nested": lambda x: array_stats.rhat_nested(x, method="identity", superchain_ids=[0, 0, 1, 1]),
         "ess_bulk": lambda x: array_stats.ess(x, method="bulk"),
         "ess_tail": lambda x: array_stats.ess(x, method="tail"),
         "ess_mean": lambda x: array_stats.ess(x, method="mean"),

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -105,8 +105,12 @@ def test_deterministic():
     funcs = {
         "rhat_rank": lambda x: array_stats.rhat(x, method="rank"),
         "rhat_raw": lambda x: array_stats.rhat(x, method="identity"),
-        "rhat_nested_rank": lambda x: array_stats.rhat_nested(x, method="rank", superchain_ids=[0, 0, 1, 1]),
-        "rhat_nested": lambda x: array_stats.rhat_nested(x, method="identity", superchain_ids=[0, 0, 1, 1]),
+        "rhat_nested_rank": lambda x: array_stats.rhat_nested(
+            x, method="rank", superchain_ids=[0, 0, 1, 1]
+        ),
+        "rhat_nested": lambda x: array_stats.rhat_nested(
+            x, method="identity", superchain_ids=[0, 0, 1, 1]
+        ),
         "ess_bulk": lambda x: array_stats.ess(x, method="bulk"),
         "ess_tail": lambda x: array_stats.ess(x, method="tail"),
         "ess_mean": lambda x: array_stats.ess(x, method="mean"),


### PR DESCRIPTION
This extends `rhat_nested` to support all the rank normalisation methods on `rhat`

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--102.org.readthedocs.build/en/102/

<!-- readthedocs-preview arviz-stats end -->