### PR TITLE
Fix doc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/build
+docs/jupyter_execute
 docs/source/api/generated
 
 # PyBuilder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ funding = "https://opencollective.com/arviz"
 
 [project.optional-dependencies]
 xarray = [
-  "arviz-base @ git+https://github.com/arviz-devs/arviz-base",
+  "arviz-base @ git+https://github.com/arviz-devs/arviz-base@eager_load",
   "xarray-einstats",
   "numba",
 ]


### PR DESCRIPTION
It appears the doc build is failing on main right now.
The first commit is unrelated to docs and should show it does,
after that I will depend on https://github.com/arviz-devs/arviz-base/pull/51
which will hopefully fix the issue (note that commit should not be merged, if it works the PR in
arviz-base will be merged and arviz-stats will continue to depend on main)


<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--112.org.readthedocs.build/en/112/

<!-- readthedocs-preview arviz-stats end -->