### PR TITLE
Add support for different variable names in loo_pit

### DIFF
--- a/src/arviz_stats/helper_loo.py
+++ b/src/arviz_stats/helper_loo.py
@@ -22,6 +22,7 @@ __all__ = [
     "_check_log_density",
     "_warn_pareto_k",
     "_warn_pointwise_loo",
+    "_process_var_name",
     "_prepare_subsample",
     "_prepare_update_subsample",
     "_select_obs_by_indices",
@@ -567,6 +568,23 @@ def _warn_pointwise_loo(elpd, elpd_i_values):
             "The point-wise LOO is the same with the sum LOO, please double check "
             "the Observed RV in your model to make sure it returns element-wise logp."
         )
+
+
+def _process_var_name(input_names, default_names, arg_name):
+    """Process variable name arguments."""
+    if input_names is None:
+        return default_names
+    if isinstance(input_names, str):
+        return [input_names]
+    if isinstance(input_names, list):
+        if len(input_names) != len(default_names):
+            raise ValueError(
+                f"{arg_name} has length {len(input_names)}, "
+                f"but expected length {len(default_names)} "
+                "to match the number of variables in var_names"
+            )
+        return input_names
+    raise TypeError(f"{arg_name} must be None, a string, or a list of strings")
 
 
 def _check_log_density(log_dens, name, log_likelihood, n_samples, sample_dims):

--- a/src/arviz_stats/helper_loo.py
+++ b/src/arviz_stats/helper_loo.py
@@ -22,7 +22,6 @@ __all__ = [
     "_check_log_density",
     "_warn_pareto_k",
     "_warn_pointwise_loo",
-    "_process_var_name",
     "_prepare_subsample",
     "_prepare_update_subsample",
     "_select_obs_by_indices",
@@ -568,23 +567,6 @@ def _warn_pointwise_loo(elpd, elpd_i_values):
             "The point-wise LOO is the same with the sum LOO, please double check "
             "the Observed RV in your model to make sure it returns element-wise logp."
         )
-
-
-def _process_var_name(input_names, default_names, arg_name):
-    """Process variable name arguments."""
-    if input_names is None:
-        return default_names
-    if isinstance(input_names, str):
-        return [input_names]
-    if isinstance(input_names, list):
-        if len(input_names) != len(default_names):
-            raise ValueError(
-                f"{arg_name} has length {len(input_names)}, "
-                f"but expected length {len(default_names)} "
-                "to match the number of variables in var_names"
-            )
-        return input_names
-    raise TypeError(f"{arg_name} must be None, a string, or a list of strings")
 
 
 def _check_log_density(log_dens, name, log_likelihood, n_samples, sample_dims):

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -464,7 +464,7 @@ def loo_pit(
         )
         type_vars[var] = "discrete" if is_discrete else "continuous"
 
-    pit_vals_dict = {}
+    pit_vals = {}
     if randomize and "discrete" in type_vars.values():
         rng = np.random.default_rng(214)
         for i, var in enumerate(var_names):
@@ -474,16 +474,16 @@ def loo_pit(
             if type_vars[var] == "discrete":
                 vals = posterior_predictive[pp_var] < observed_data[obs_var]
                 urvs = rng.uniform(size=vals.values.shape)
-                pit_vals_dict[var] = urvs * vals + (1 - urvs) * vals
+                pit_vals[var] = urvs * vals + (1 - urvs) * vals
             else:
-                pit_vals_dict[var] = posterior_predictive[pp_var] <= observed_data[obs_var]
+                pit_vals[var] = posterior_predictive[pp_var] <= observed_data[obs_var]
     else:
         for i, var in enumerate(var_names):
             obs_var = observed_var_names[i]
             pp_var = pp_var_names[i]
-            pit_vals_dict[var] = posterior_predictive[pp_var] <= observed_data[obs_var]
+            pit_vals[var] = posterior_predictive[pp_var] <= observed_data[obs_var]
 
-    pit_vals = xr.Dataset(pit_vals_dict)
+    pit_vals = xr.Dataset(pit_vals)
     loo_pit_values = np.exp(logsumexp(log_weights.where(pit_vals, 0), dims=["chain", "draw"]))
     return loo_pit_values
 

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -230,17 +230,53 @@ def test_loo_metrics_invalid_kind(centered_eight):
         {},
         {"var_names": ["obs"]},
         {"log_weights": "arr"},
+        {"var_names": ["obs"], "observed_var_names": ["obs"], "pp_var_names": ["obs"]},
+        {"var_names": "obs", "observed_var_names": "obs", "pp_var_names": "obs"},
     ],
 )
 def test_loo_pit(centered_eight, args):
     var_names = args.get("var_names", None)
     log_weights = args.get("log_weights", None)
+    observed_var_names = args.get("observed_var_names", None)
+    pp_var_names = args.get("pp_var_names", None)
+
     if log_weights == "arr":
         log_weights = get_log_likelihood_dataset(centered_eight, var_names=var_names)
 
-    loo_pit_values = loo_pit(centered_eight, var_names=var_names, log_weights=log_weights)
+    loo_pit_values = loo_pit(
+        centered_eight,
+        var_names=var_names,
+        log_weights=log_weights,
+        observed_var_names=observed_var_names,
+        pp_var_names=pp_var_names,
+    )
     assert np.all(loo_pit_values >= 0)
     assert np.all(loo_pit_values <= 1)
+
+
+def test_loo_pit_different_names(centered_eight):
+    new_dt = azb.from_dict(
+        {
+            "posterior": centered_eight.posterior,
+            "log_likelihood": centered_eight.log_likelihood,
+            "observed_data": {"y_obs": centered_eight.observed_data.obs},
+            "posterior_predictive": {"y_pred": centered_eight.posterior_predictive.obs},
+        }
+    )
+
+    loo_pit_values1 = loo_pit(
+        new_dt, var_names="obs", observed_var_names="y_obs", pp_var_names="y_pred"
+    )
+    assert np.all(loo_pit_values1 >= 0)
+    assert np.all(loo_pit_values1 <= 1)
+
+    loo_pit_values2 = loo_pit(
+        new_dt, var_names=["obs"], observed_var_names=["y_obs"], pp_var_names=["y_pred"]
+    )
+    assert np.all(loo_pit_values2 >= 0)
+    assert np.all(loo_pit_values2 <= 1)
+
+    assert_allclose(loo_pit_values1["obs"].values, loo_pit_values2["obs"].values)
 
 
 def test_loo_pit_discrete(centered_eight):

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -230,15 +230,14 @@ def test_loo_metrics_invalid_kind(centered_eight):
         {},
         {"var_names": ["obs"]},
         {"log_weights": "arr"},
-        {"var_names": ["obs"], "observed_var_names": ["obs"], "pp_var_names": ["obs"]},
-        {"var_names": "obs", "observed_var_names": "obs", "pp_var_names": "obs"},
+        {"var_names": ["obs"], "data_pairs": {"obs": "obs"}},
+        {"var_names": "obs", "data_pairs": {"obs": "obs"}},
     ],
 )
 def test_loo_pit(centered_eight, args):
     var_names = args.get("var_names", None)
     log_weights = args.get("log_weights", None)
-    observed_var_names = args.get("observed_var_names", None)
-    pp_var_names = args.get("pp_var_names", None)
+    data_pairs = args.get("data_pairs", None)
 
     if log_weights == "arr":
         log_weights = get_log_likelihood_dataset(centered_eight, var_names=var_names)
@@ -247,8 +246,7 @@ def test_loo_pit(centered_eight, args):
         centered_eight,
         var_names=var_names,
         log_weights=log_weights,
-        observed_var_names=observed_var_names,
-        pp_var_names=pp_var_names,
+        data_pairs=data_pairs,
     )
     assert np.all(loo_pit_values >= 0)
     assert np.all(loo_pit_values <= 1)
@@ -259,20 +257,16 @@ def test_loo_pit_different_names(centered_eight):
         {
             "posterior": centered_eight.posterior,
             "log_likelihood": centered_eight.log_likelihood,
-            "observed_data": {"y_obs": centered_eight.observed_data.obs},
+            "observed_data": centered_eight.observed_data,
             "posterior_predictive": {"y_pred": centered_eight.posterior_predictive.obs},
         }
     )
 
-    loo_pit_values1 = loo_pit(
-        new_dt, var_names="obs", observed_var_names="y_obs", pp_var_names="y_pred"
-    )
+    loo_pit_values1 = loo_pit(new_dt, var_names="obs", data_pairs={"obs": "y_pred"})
     assert np.all(loo_pit_values1 >= 0)
     assert np.all(loo_pit_values1 <= 1)
 
-    loo_pit_values2 = loo_pit(
-        new_dt, var_names=["obs"], observed_var_names=["y_obs"], pp_var_names=["y_pred"]
-    )
+    loo_pit_values2 = loo_pit(new_dt, var_names=["obs"], data_pairs={"obs": "y_pred"})
     assert np.all(loo_pit_values2 >= 0)
     assert np.all(loo_pit_values2 <= 1)
 


### PR DESCRIPTION
Support for mis-matched variable names in `loo_pit` and corresponding test in `test_loo.py`.

resolves: [86](https://github.com/arviz-devs/arviz-stats/issues/86)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview arviz-stats end -->