### PR TITLE
Add "regular" metrics

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -45,6 +45,7 @@ you should jump to {ref}`array_stats_api` and read forward.
    arviz_stats.kl_divergence
    arviz_stats.loo_expectations
    arviz_stats.loo_metrics
+   arviz_stats.metrics
    arviz_stats.r2_score
    arviz_stats.summary
    arviz_stats.wasserstein

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -15,7 +15,7 @@ try:
         compare,
     )
     from arviz_stats.psense import psense, psense_summary
-    from arviz_stats.metrics import kl_divergence, r2_score, wasserstein
+    from arviz_stats.metrics import kl_divergence, metrics, r2_score, wasserstein
     from arviz_stats.sampling_diagnostics import ess, mcse, rhat, rhat_nested
     from arviz_stats.summary import summary
     from arviz_stats.manipulation import thin

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -525,5 +525,18 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         return r2_ufunc(y_true, y_pred, out_shape=(y_pred.shape[0],))
 
+    def metrics(self, observed, predicted, kind):
+        """Compute metrics for Bayesian regression models."""
+        func = getattr(self, f"_{kind}", None)
+
+        metrics_ufunc = make_ufunc(
+            func,
+            n_output=2,
+            n_input=2,
+            n_dims=1,
+            ravel=False,
+        )
+        return metrics_ufunc(observed, predicted)
+
 
 array_stats = BaseArray()

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -760,3 +760,118 @@ class _DiagnosticsBase(_CoreBase):
         var_e = np.var(y_true - y_pred, axis=1)
         r_squared = var_y_est / (var_y_est + var_e)
         return r_squared
+
+    @staticmethod
+    def _mae(observed, predicted):
+        """Compute the Mean Absolute Error (MAE).
+
+        Parameters
+        ----------
+        observed: array-like of shape = (n_outputs,)
+            Ground truth (correct) target values.
+        predicted: array-like of shape = (n_outputs)
+            Estimated target values.
+
+        Returns
+        -------
+        array-like  (dims)
+        """
+        n_obs = len(observed)
+        abs_e = np.abs(observed - predicted)
+        mean = np.mean(abs_e)
+        std_error = np.std(abs_e) / n_obs**0.5
+        return mean, std_error
+
+    @staticmethod
+    def _mse(observed, predicted):
+        """Compute the Mean Squared Error (MSE).
+
+        Parameters
+        ----------
+        observed: array-like of shape = (n_outputs,)
+            Ground truth (correct) target values.
+        predicted: array-like of shape = (n_outputs)
+            Estimated target values.
+
+        Returns
+        -------
+        array-like  (dims)
+        """
+        n_obs = len(observed)
+        sq_e = (observed - predicted) ** 2
+        mean = np.mean(sq_e)
+        std_error = np.std(sq_e) / n_obs**0.5
+        return mean, std_error
+
+    @staticmethod
+    def _rmse(observed, predicted):
+        """Compute the Root Mean Squared Error (RMSE).
+
+        Parameters
+        ----------
+        observed: array-like of shape = (n_outputs,)
+            Ground truth (correct) target values.
+        predicted: array-like of shape = (n_outputs)
+            Estimated target values.
+
+        Returns
+        -------
+        array-like  (dims)
+        """
+        n_obs = len(observed)
+        sq_e = (observed - predicted) ** 2
+        mean_mse = np.mean(sq_e)
+        var_mse = np.var(sq_e) / n_obs
+        var_rmse = var_mse / mean_mse / 4  # Comes from the first order Taylor approx.
+        mean = mean_mse**0.5
+        std_error = var_rmse**0.5
+
+        return mean, std_error
+
+    @staticmethod
+    def _acc(observed, predicted):
+        """Compute the Accuracy.
+
+        Parameters
+        ----------
+        observed: array-like of shape = (n_outputs,)
+            Ground truth (correct) target values.
+        predicted: array-like of shape = (n_outputs)
+            Estimated target values.
+
+        Returns
+        -------
+        array-like  (dims)
+        """
+        n_obs = len(observed)
+        yhat = predicted > 0.5
+        acc = yhat == observed
+        mean = np.mean(acc)
+        std_error = (mean * (1 - mean) / n_obs) ** 0.5
+        return mean, std_error
+
+    @staticmethod
+    def _acc_balanced(observed, predicted):
+        """Compute the Balanced Accuracy.
+
+        Parameters
+        ----------
+        observed: array-like of shape = (n_outputs,)
+            Ground truth (correct) target values.
+        predicted: array-like of shape = (n_outputs)
+            Estimated target values.
+
+        Returns
+        -------
+        array-like  (dims)
+        """
+        n_obs = len(observed)
+        yhat = predicted > 0.5
+        mask = observed == 0
+        true_neg = np.mean(yhat[mask] == observed[mask])
+        true_pos = np.mean(yhat[~mask] == observed[~mask])
+        mean = (true_pos + true_neg) / 2
+        # This approximation has quite large bias for small samples
+        bls_acc_var = (true_pos * (1 - true_pos) + true_neg * (1 - true_neg)) / 4
+        std_error = bls_acc_var / n_obs**0.5
+        return mean, std_error

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -774,11 +774,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        tuple (mean, std_error)
-            mean: float
-                Mean absolute error.
-            std_error: float
-                Standard error of the mean absolute error.
+        mean: float
+            Mean absolute error.
+        std_error: float
+            Standard error of the mean absolute error.
         """
         n_obs = len(observed)
         abs_e = np.abs(observed - predicted)
@@ -799,11 +798,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        tuple (mean, std_error)
-            mean: float
-                Mean squared error.
-            std_error: float
-                Standard error of the mean squared error.
+        mean: float
+            Mean squared error.
+        std_error: float
+            Standard error of the mean squared error.
         """
         n_obs = len(observed)
         sq_e = (observed - predicted) ** 2
@@ -824,11 +822,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        tuple (mean, std_error)
-            mean: float
-                Root mean squared error.
-            std_error: float
-                Standard error of the root mean squared error.
+        mean: float
+            Root mean squared error.
+        std_error: float
+            Standard error of the root mean squared error.
         """
         n_obs = len(observed)
         sq_e = (observed - predicted) ** 2
@@ -853,11 +850,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        tuple (mean, std_error)
-            mean: float
-                Accuracy.
-            std_error: float
-                Standard error of the accuracy.
+        mean: float
+            Accuracy.
+        std_error: float
+            Standard error of the accuracy.
         """
         n_obs = len(observed)
         yhat = predicted > 0.5
@@ -879,11 +875,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        tuple (mean, std_error)
-            mean: float
-                Balanced accuracy.
-            std_error: float
-                Standard error of the balanced accuracy.
+        mean: float
+            Balanced accuracy.
+        std_error: float
+            Standard error of the balanced accuracy.
         """
         n_obs = len(observed)
         yhat = predicted > 0.5

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -774,7 +774,11 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        array-like  (dims)
+        tuple (mean, std_error)
+            mean: float
+                Mean absolute error.
+            std_error: float
+                Standard error of the mean absolute error.
         """
         n_obs = len(observed)
         abs_e = np.abs(observed - predicted)
@@ -795,7 +799,11 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        array-like  (dims)
+        tuple (mean, std_error)
+            mean: float
+                Mean squared error.
+            std_error: float
+                Standard error of the mean squared error.
         """
         n_obs = len(observed)
         sq_e = (observed - predicted) ** 2
@@ -816,7 +824,11 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        array-like  (dims)
+        tuple (mean, std_error)
+            mean: float
+                Root mean squared error.
+            std_error: float
+                Standard error of the root mean squared error.
         """
         n_obs = len(observed)
         sq_e = (observed - predicted) ** 2
@@ -841,7 +853,11 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        array-like  (dims)
+        tuple (mean, std_error)
+            mean: float
+                Accuracy.
+            std_error: float
+                Standard error of the accuracy.
         """
         n_obs = len(observed)
         yhat = predicted > 0.5
@@ -863,7 +879,11 @@ class _DiagnosticsBase(_CoreBase):
 
         Returns
         -------
-        array-like  (dims)
+        tuple (mean, std_error)
+            mean: float
+                Balanced accuracy.
+            std_error: float
+                Standard error of the balanced accuracy.
         """
         n_obs = len(observed)
         yhat = predicted > 0.5

--- a/src/arviz_stats/metrics.py
+++ b/src/arviz_stats/metrics.py
@@ -504,40 +504,6 @@ def _metrics(observed, predicted, kind, round_to):
         raise ValueError(f"kind must be one of {valid_kind}")
 
     estimate = namedtuple(kind, ["mean", "se"])
-    n_obs = len(observed)
-
-    if kind == "mae":
-        abs_e = np.abs(observed - predicted)
-        mean = np.mean(abs_e)
-        std_error = np.std(abs_e) / n_obs**0.5
-
-    elif kind == "mse":
-        sq_e = (observed - predicted) ** 2
-        mean = np.mean(sq_e)
-        std_error = np.std(sq_e) / n_obs**0.5
-
-    elif kind == "rmse":
-        sq_e = (observed - predicted) ** 2
-        mean_mse = np.mean(sq_e)
-        var_mse = np.var(sq_e) / n_obs
-        var_rmse = var_mse / mean_mse / 4  # Comes from the first order Taylor approx.
-        mean = mean_mse**0.5
-        std_error = var_rmse**0.5
-
-    elif kind == "acc":
-        yhat = predicted > 0.5
-        acc = yhat == observed
-        mean = np.mean(acc)
-        std_error = (mean * (1 - mean) / n_obs) ** 0.5
-
-    else:
-        yhat = predicted > 0.5
-        mask = observed == 0
-        true_neg = np.mean(yhat[mask] == observed[mask])
-        true_pos = np.mean(yhat[~mask] == observed[~mask])
-        mean = (true_pos + true_neg) / 2
-        # This approximation has quite large bias for small samples
-        bls_acc_var = (true_pos * (1 - true_pos) + true_neg * (1 - true_neg)) / 4
-        std_error = bls_acc_var / n_obs**0.5
+    mean, std_error = array_stats.metrics(observed, predicted, kind=kind)
 
     return estimate(round_num(mean, round_to), round_num(std_error, round_to))

--- a/src/arviz_stats/utils.py
+++ b/src/arviz_stats/utils.py
@@ -272,6 +272,8 @@ def round_num(value, precision):
 
         if isinstance(precision, str) and precision.endswith("g"):
             sig_digits = int(precision[:-1])
+            if value == 0:
+                return 0
             return round(value, sig_digits - int(np.floor(np.log10(abs(value)))) - 1)
 
     return value

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,14 +1,14 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from .helpers import importorskip
 
 azb = importorskip("arviz_base")
 
 from arviz_stats.base import array_stats
-from arviz_stats.metrics import kl_divergence, r2_score, wasserstein
+from arviz_stats.metrics import kl_divergence, metrics, r2_score, wasserstein
 
 
 @pytest.fixture
@@ -28,6 +28,16 @@ def fake_post():
             },
         }
     )
+
+
+@pytest.fixture(name="centered_eight", scope="session")
+def fixture_centered_eight():
+    return azb.load_arviz_data("centered_eight")
+
+
+@pytest.fixture(name="anes", scope="session")
+def fixture_anes():
+    return azb.load_arviz_data("anes")
 
 
 def test_r2_score_summary(sample_data):
@@ -51,6 +61,38 @@ def test_r2_score_invalid_shapes():
     y_pred = np.array([[2.5, 0.0, 2]])
     with pytest.raises(ValueError):
         array_stats.r2_score(y_true, y_pred)
+
+
+@pytest.mark.parametrize(
+    "kind, round_to, expected_mean, expected_se",
+    [
+        ("mae", 2, 7.42, 2.14),
+        ("mse", "2g", 92.0, 51.0),
+        ("rmse", None, 9.5757, 2.6479),
+    ],
+)
+def test_metrics(centered_eight, kind, round_to, expected_mean, expected_se):
+    result = metrics(centered_eight, kind=kind, round_to=round_to)
+    assert_almost_equal(result.mean, expected_mean, decimal=4)
+    assert_almost_equal(result.se, expected_se, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "kind, round_to, expected_mean, expected_se",
+    [
+        ("acc", 2, 0.82, 0.02),
+        ("acc_balanced", "2g", 0.82, 0.0039),
+    ],
+)
+def test_metrics_acc(anes, kind, round_to, expected_mean, expected_se):
+    result = metrics(anes, kind=kind, round_to=round_to)
+    assert_almost_equal(result.mean, expected_mean, decimal=4)
+    assert_almost_equal(result.se, expected_se, decimal=4)
+
+
+def test_metrics_invalid_kind(centered_eight):
+    with pytest.raises(ValueError, match="kind must be one of"):
+        metrics(centered_eight, kind="invalid_kind")
 
 
 @pytest.mark.parametrize("joint", [True, False])


### PR DESCRIPTION
This adds a series of metrics mirroring those already available in `loo_metrics`. To ease comparison between predictive metrics and this one, they are defined in the same way. 

~I guess for a future PR we may want to move the computation to the array interface, similar to what we already have for r2_score~.

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview arviz-stats end -->