### PR TITLE
Dim fix

### DIFF
--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -483,9 +483,16 @@ def loo_pit(
             )
 
             pit_upper = pit_lower + pit_sup_addition[var].values
+
+            if pit_lower.ndim > 1:
+                pit_lower = np.diag(pit_lower)
+                pit_upper = np.diag(pit_upper)
+
             random_value = rng.uniform(pit_lower, pit_upper)
             loo_pit_values[var] = observed_data[var].copy(data=random_value)
         else:
+            if pit_lower.ndim > 1:
+                pit_lower = np.diag(pit_lower)
             loo_pit_values[var] = observed_data[var].copy(data=pit_lower)
 
     return loo_pit_values


### PR DESCRIPTION
Fixes the dimension error from `test_loo_pit_different_names`. I think the issue is that when we use `data_pairs` to map between different variable names, the resulting PIT values form a matrix where each element $p_{ij}$ represents $P(pred_{j} \leq y_i | y_{-i})$. For LOO-PIT, I think we only need the diagonal elements.