### PR TITLE
Add loo_moment_match

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -135,7 +135,7 @@ indent-string='    '
 max-line-length=100
 
 # Maximum number of lines in a module
-max-module-lines=2000
+max-module-lines=2500
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -62,6 +62,7 @@ you should jump to {ref}`array_stats_api` and read forward.
    arviz_stats.loo_approximate_posterior
    arviz_stats.loo_subsample
    arviz_stats.update_subsample
+   arviz_stats.loo_moment_match
 ```
 
 ### Other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ doc = [
     "jupyter-sphinx",
     "h5netcdf",
     "sphinx_autosummary_accessors",
+    "pymc",
 ]
 numba = [
   "numba",

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -12,6 +12,7 @@ try:
         loo_approximate_posterior,
         loo_subsample,
         update_subsample,
+        loo_moment_match,
         compare,
     )
     from arviz_stats.psense import psense, psense_summary

--- a/src/arviz_stats/helper_loo.py
+++ b/src/arviz_stats/helper_loo.py
@@ -12,11 +12,12 @@ from xarray_einstats.stats import logsumexp
 from arviz_stats.utils import get_log_likelihood
 
 __all__ = [
-    "_get_r_eff",
+    "_split_moment_match",
     "_plpd_approx",
     "_diff_srs_estimator",
     "_srs_estimator",
     "_generate_subsample_indices",
+    "_get_r_eff",
     "_prepare_loo_inputs",
     "_extract_loo_data",
     "_check_log_density",
@@ -27,13 +28,19 @@ __all__ = [
     "_select_obs_by_indices",
     "_select_obs_by_coords",
     "_prepare_full_arrays",
+    "_shift",
+    "_shift_and_scale",
+    "_shift_and_cov",
+    "_recalculate_weights_k",
+    "_update_loo_data_i",
+    "_get_log_likelihood_i",
 ]
-
 
 LooInputs = namedtuple(
     "LooInputs",
     ["log_likelihood", "var_name", "sample_dims", "obs_dims", "n_samples", "n_data_points"],
 )
+
 SubsampleData = namedtuple(
     "SubsampleData",
     ["log_likelihood_sample", "lpd_approx_sample", "lpd_approx_all", "indices", "subsample_size"],
@@ -52,19 +59,462 @@ UpdateSubsampleData = namedtuple(
     ],
 )
 
+SplitMomentMatch = namedtuple("SplitMomentMatch", ["lwi", "lwfi", "log_liki", "reff"])
+ShiftResult = namedtuple("ShiftResult", ["upars", "shift"])
+ShiftAndScaleResult = namedtuple("ShiftAndScaleResult", ["upars", "shift", "scaling"])
+ShiftAndCovResult = namedtuple("ShiftAndCovResult", ["upars", "shift", "mapping"])
+RecalculateWeightsResult = namedtuple(
+    "RecalculateWeightsResult", ["lwi", "lwfi", "ki", "kfi", "log_liki"]
+)
 
-def _get_r_eff(data, n_samples):
-    if not hasattr(data, "posterior"):
-        raise TypeError("Must be able to extract a posterior group from data.")
-    posterior = data.posterior
-    n_chains = len(posterior.chain)
-    if n_chains == 1:
-        reff = 1.0
+
+def _split_moment_match(
+    upars,
+    cov,
+    total_shift,
+    total_scaling,
+    total_mapping,
+    i,
+    reff,
+    log_prob_upars_fn,
+    log_lik_i_upars_fn,
+):
+    r"""Split moment matching importance sampling for PSIS-LOO-CV.
+
+    Applies affine transformations based on the total moment matching transformation
+    to half of the posterior draws, leaving the other half unchanged. These approximations
+    to the leave-one-out posterior are then combined using multiple importance sampling.
+
+    Based on the implicit adaptive importance sampling algorithm of [1]_ and the
+    PSIS-LOO-CV method of [2]_ and [3]_.
+
+    Parameters
+    ----------
+    upars : DataArray
+        A DataArray representing the posterior draws of the model parameters in the
+        unconstrained space. Must contain the dimensions `chain` and `draw` and a final
+        dimension representing the different unconstrained parameters.
+    cov : bool
+        Whether to match the full covariance matrix of the samples (True) or just the
+        marginal variances (False). Using the full covariance is more computationally
+        expensive.
+    total_shift : ndarray
+        Vector containing the total shift (translation) applied to the parameters. Shape should
+        match the parameter dimension of ``upars``.
+    total_scaling : ndarray
+        Vector containing the total scaling factors for the marginal variances. Shape should
+        match the parameter dimension of ``upars``.
+    total_mapping : ndarray
+        Square matrix representing the linear transformation applied to the covariance matrix.
+        Shape should be (d, d) where d is the parameter dimension.
+    i : int
+        Index of the specific observation to be left out for computing leave-one-out
+        likelihood.
+    reff : float
+        Relative MCMC efficiency, ``ess / n`` i.e. number of effective samples divided by the number
+        of actual samples.
+    log_prob_upars_fn : Callable[[DataArray], DataArray]
+        A function that computes the log probability density of the *full posterior*
+        distribution evaluated at given unconstrained parameter values (as a DataArray).
+        Input and Output must have dimensions `chain` and `draw`.
+    log_lik_i_upars_fn : Callable[[DataArray, int], DataArray]
+        A function that computes the log-likelihood of the *left-out observation* `i`
+        evaluated at given unconstrained parameter values (as a DataArray).
+        Input and Output must have dimensions `chain` and `draw`.
+
+    Returns
+    -------
+    SplitMomentMatch
+        A namedtuple containing:
+
+        - lwi: Updated log importance weights for each sample
+        - lwfi: Updated log importance weights for full distribution
+        - log_liki: Updated log likelihood values for the specific observation
+        - reff: Relative MCMC efficiency
+
+    References
+    ----------
+
+    .. [1] Paananen, T., Piironen, J., Buerkner, P.-C., Vehtari, A. (2021). *Implicitly Adaptive
+        Importance Sampling*. Statistics and Computing. 31(2) (2021)
+        https://doi.org/10.1007/s11222-020-09982-2
+        arXiv preprint https://arxiv.org/abs/1906.08850.
+    .. [2] Vehtari et al. *Practical Bayesian model evaluation using leave-one-out cross-validation
+        and WAIC*. Statistics and Computing. 27(5) (2017) https://doi.org/10.1007/s11222-016-9696-4
+        arXiv preprint https://arxiv.org/abs/1507.04544.
+    .. [3] Vehtari et al. *Pareto Smoothed Importance Sampling*.
+        Journal of Machine Learning Research, 25(72) (2024) https://jmlr.org/papers/v25/19-556.html
+        arXiv preprint https://arxiv.org/abs/1507.02646
+    """
+    if not isinstance(upars, xr.DataArray):
+        raise TypeError("upars must be a DataArray.")
+
+    sample_dims = ["chain", "draw"]
+    param_dim_list = [dim for dim in upars.dims if dim not in sample_dims]
+
+    if len(param_dim_list) != 1:
+        raise ValueError("upars must have exactly one dimension besides chain and draw.")
+    param_dim = param_dim_list[0]
+
+    if not all(dim in upars.dims for dim in sample_dims):
+        raise ValueError(
+            f"Required sample dimensions {sample_dims} not found in upars dimensions {upars.dims}"
+        )
+
+    dim = upars.sizes[param_dim]
+    n_samples = upars.sizes["chain"] * upars.sizes["draw"]
+    n_samples_half = n_samples // 2
+
+    upars_stacked = upars.stack(__sample__=sample_dims).transpose("__sample__", param_dim)
+    mean_original = upars_stacked.mean(dim="__sample__")
+
+    if total_shift is None or total_shift.size == 0:
+        total_shift = np.zeros(dim)
+    if total_scaling is None or total_scaling.size == 0:
+        total_scaling = np.ones(dim)
+    if total_mapping is None or total_mapping.size == 0:
+        total_mapping = np.eye(dim)
+
+    # Forward transformation
+    upars_trans = upars_stacked - mean_original
+    upars_trans = upars_trans * xr.DataArray(total_scaling, dims=param_dim)
+    if cov and dim > 0:
+        upars_trans = xr.DataArray(
+            np.einsum("sp,pq->sq", upars_trans.data, total_mapping),
+            coords=upars_trans.coords,
+            dims=upars_trans.dims,
+        )
+    upars_trans = upars_trans + (xr.DataArray(total_shift, dims=param_dim) + mean_original)
+
+    # Inverse transformation
+    upars_trans_inv = upars_stacked - mean_original
+
+    if cov and dim > 0:
+        try:
+            inv_mapping = np.linalg.inv(total_mapping)
+            upars_trans_inv = xr.DataArray(
+                np.einsum("sp,pq->sq", upars_trans_inv.data, inv_mapping),
+                coords=upars_trans_inv.coords,
+                dims=upars_trans_inv.dims,
+            )
+        except np.linalg.LinAlgError:
+            warnings.warn("Could not invert mapping matrix. Using identity.", UserWarning)
+
+    upars_trans_inv = upars_trans_inv / xr.DataArray(total_scaling, dims=param_dim)
+    upars_trans_inv = upars_trans_inv + (mean_original - xr.DataArray(total_shift, dims=param_dim))
+
+    upars_trans_half = upars_stacked.copy(deep=True).unstack("__sample__")
+    upars_trans_half = upars_trans_half.transpose(*sample_dims, param_dim)
+    upars_trans_half.values.reshape(-1, dim)[:n_samples_half] = upars_trans.values.reshape(-1, dim)[
+        :n_samples_half
+    ]
+
+    upars_trans_half_inv = upars_stacked.copy(deep=True).unstack("__sample__")
+    upars_trans_half_inv = upars_trans_half_inv.transpose(*sample_dims, param_dim)
+    upars_trans_half_inv.values.reshape(-1, dim)[n_samples_half:] = upars_trans_inv.values.reshape(
+        -1, dim
+    )[n_samples_half:]
+
+    try:
+        log_prob_half_trans = log_prob_upars_fn(upars_trans_half)
+        log_prob_half_trans_inv = log_prob_upars_fn(upars_trans_half_inv)
+    except Exception as e:
+        raise ValueError(
+            f"Could not compute log probabilities for transformed parameters: {e}"
+        ) from e
+
+    try:
+        log_liki_half = log_lik_i_upars_fn(upars_trans_half, i)
+        if not all(dim in log_liki_half.dims for dim in sample_dims) or len(
+            log_liki_half.dims
+        ) != len(sample_dims):
+            raise ValueError(
+                f"log_lik_i_upars_fn must return a DataArray with dimensions {sample_dims}"
+            )
+        if (
+            log_liki_half.sizes["chain"] != upars.sizes["chain"]
+            or log_liki_half.sizes["draw"] != upars.sizes["draw"]
+        ):
+            raise ValueError(
+                "log_lik_i_upars_fn output shape does not match input sample dimensions"
+            )
+    except Exception as e:
+        raise ValueError(f"Could not compute log likelihood for observation {i}: {e}") from e
+
+    # Jacobian adjustment
+    log_jacobian_det = 0.0
+    if dim > 0:
+        log_jacobian_det = -np.sum(np.log(total_scaling))
+        if cov:
+            try:
+                sign, logdet = np.linalg.slogdet(total_mapping)
+                if sign <= 0:
+                    log_jacobian_det -= np.inf
+                else:
+                    log_jacobian_det -= logdet
+            except np.linalg.LinAlgError:
+                log_jacobian_det -= np.inf
+
+    log_prob_half_trans_inv_adj = log_prob_half_trans_inv + log_jacobian_det
+
+    # Multiple importance sampling
+    use_forward_log_prob = log_prob_half_trans > log_prob_half_trans_inv_adj
+    raw_log_weights_half = -log_liki_half + log_prob_half_trans
+
+    log_sum_terms = xr.where(
+        use_forward_log_prob,
+        log_prob_half_trans
+        + xr.ufuncs.log1p(xr.ufuncs.exp(log_prob_half_trans_inv_adj - log_prob_half_trans)),
+        log_prob_half_trans_inv_adj
+        + xr.ufuncs.log1p(xr.ufuncs.exp(log_prob_half_trans - log_prob_half_trans_inv_adj)),
+    )
+
+    raw_log_weights_half -= log_sum_terms
+    raw_log_weights_half = xr.where(np.isnan(raw_log_weights_half), -np.inf, raw_log_weights_half)
+    raw_log_weights_half = xr.where(
+        np.isposinf(raw_log_weights_half), -np.inf, raw_log_weights_half
+    )
+
+    # PSIS smoothing for half posterior
+    lwi_psis_da, _ = raw_log_weights_half.azstats.psislw(r_eff=reff, dims=sample_dims)
+
+    lr_full = lwi_psis_da + log_liki_half
+    lr_full = xr.where(np.isnan(lr_full) | (np.isinf(lr_full) & (lr_full > 0)), -np.inf, lr_full)
+
+    # PSIS smoothing for full posterior
+    lwfi_psis_da, _ = lr_full.azstats.psislw(r_eff=reff, dims=sample_dims)
+
+    return SplitMomentMatch(
+        lwi=lwi_psis_da,
+        lwfi=lwfi_psis_da,
+        log_liki=log_liki_half,
+        reff=reff,
+    )
+
+
+def _shift(upars, lwi):
+    """Shift a DataArray of parameters to their weighted mean."""
+    sample_dims = ["chain", "draw"]
+    param_dim = [dim for dim in upars.dims if dim not in sample_dims][0]
+    upars_stacked = upars.stack(__sample__=sample_dims)
+    lwi_stacked = lwi.stack(__sample__=sample_dims)
+
+    upars_values = upars_stacked.transpose("__sample__", param_dim).data
+    lwi_values = lwi_stacked.transpose("__sample__").data
+
+    mean_original = np.mean(upars_values, axis=0)
+    weights = np.exp(
+        lwi_values - logsumexp(lwi_stacked.transpose("__sample__"), dims="__sample__").data
+    )
+    mean_weighted = np.sum(weights[:, None] * upars_values, axis=0)
+    shift_vec = mean_weighted - mean_original
+    upars_new_values = upars_values + shift_vec[None, :]
+
+    upars_new_stacked = xr.DataArray(
+        upars_new_values,
+        dims=["__sample__", param_dim],
+        coords={
+            "__sample__": upars_stacked["__sample__"],
+            param_dim: upars_stacked[param_dim],
+        },
+    )
+    upars_new_da = upars_new_stacked.unstack("__sample__")
+    return ShiftResult(upars=upars_new_da, shift=shift_vec)
+
+
+def _shift_and_scale(upars, lwi):
+    """Shift parameters to weighted mean and scale marginal variances."""
+    sample_dims = ["chain", "draw"]
+    param_dim = [dim for dim in upars.dims if dim not in sample_dims][0]
+    upars_stacked = upars.stack(__sample__=sample_dims)
+    lwi_stacked = lwi.stack(__sample__=sample_dims)
+
+    upars_values = upars_stacked.transpose("__sample__", param_dim).data
+    lwi_values = lwi_stacked.transpose("__sample__").data
+
+    mean_original = np.mean(upars_values, axis=0)
+    weights = np.exp(
+        lwi_values - logsumexp(lwi_stacked.transpose("__sample__"), dims="__sample__").data
+    )
+    mean_weighted = np.sum(weights[:, None] * upars_values, axis=0)
+    shift_vec = mean_weighted - mean_original
+
+    var_weighted = np.sum(weights[:, None] * (upars_values - mean_weighted[None, :]) ** 2, axis=0)
+    ess_approx = 1.0 / np.sum(weights**2)
+
+    if ess_approx > 1:
+        var_weighted *= ess_approx / (ess_approx - 1)
     else:
-        ess_p = posterior.azstats.ess(method="mean")
-        # this mean is over all data variables
-        reff = np.hstack([ess_p[v].values.flatten() for v in ess_p.data_vars]).mean() / n_samples
-    return reff
+        var_weighted = np.var(upars_values, axis=0)
+
+    var_original = np.var(upars_values, axis=0, ddof=1)
+
+    scaling_vec = np.ones_like(mean_original)
+    valid_mask = (var_original > 1e-9) & (var_weighted > 1e-9)
+    scaling_vec[valid_mask] = np.sqrt(var_weighted[valid_mask] / var_original[valid_mask])
+
+    upars_new_values = upars_values - mean_original[None, :]
+    upars_new_values = upars_new_values * scaling_vec[None, :]
+    upars_new_values = upars_new_values + mean_weighted[None, :]
+
+    upars_new_stacked = xr.DataArray(
+        upars_new_values,
+        dims=["__sample__", param_dim],
+        coords={
+            "__sample__": upars_stacked["__sample__"],
+            param_dim: upars_stacked[param_dim],
+        },
+    )
+    upars_new_da = upars_new_stacked.unstack("__sample__")
+    return ShiftAndScaleResult(upars=upars_new_da, shift=shift_vec, scaling=scaling_vec)
+
+
+def _shift_and_cov(upars, lwi):
+    """Shift parameters and scale covariance to match weighted covariance."""
+    sample_dims = ["chain", "draw"]
+    param_dim = [dim for dim in upars.dims if dim not in sample_dims][0]
+    upars_stacked = upars.stack(__sample__=sample_dims)
+    lwi_stacked = lwi.stack(__sample__=sample_dims)
+
+    upars_values = upars_stacked.transpose("__sample__", param_dim).data
+    lwi_values = lwi_stacked.transpose("__sample__").data
+
+    mean_original = np.mean(upars_values, axis=0)
+    weights = np.exp(
+        lwi_values - logsumexp(lwi_stacked.transpose("__sample__"), dims="__sample__").data
+    )
+    mean_weighted = np.sum(weights[:, None] * upars_values, axis=0)
+    shift_vec = mean_weighted - mean_original
+
+    cov_original = np.cov(upars_values, rowvar=False, ddof=1)
+    cov_weighted = np.cov(upars_values, rowvar=False, aweights=weights, ddof=0)
+
+    mapping_mat = np.eye(upars_values.shape[1])
+    try:
+        min_eig_orig = np.min(np.linalg.eigvalsh(cov_original))
+        min_eig_weighted = np.min(np.linalg.eigvalsh(cov_weighted))
+        jitter = 1e-6
+
+        if min_eig_orig <= 0:
+            cov_original += np.eye(cov_original.shape[0]) * (jitter - min_eig_orig)
+        if min_eig_weighted <= 0:
+            cov_weighted += np.eye(cov_weighted.shape[0]) * (jitter - min_eig_weighted)
+
+        chol_weighted = np.linalg.cholesky(cov_weighted)
+        chol_original = np.linalg.cholesky(cov_original)
+        mapping_mat = chol_weighted @ np.linalg.inv(chol_original)
+
+    except np.linalg.LinAlgError as e:
+        warnings.warn(
+            f"Cholesky decomposition failed: {e}. Using mean-shift only with identity mapping. "
+            "Check Pareto k diagnostics and model specification for highly "
+            "influential observations.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    upars_new_values = upars_values - mean_original[None, :]
+    upars_new_values = upars_new_values @ mapping_mat.T
+    upars_new_values = upars_new_values + mean_weighted[None, :]
+
+    upars_new_stacked = xr.DataArray(
+        upars_new_values,
+        dims=["__sample__", param_dim],
+        coords={
+            "__sample__": upars_stacked["__sample__"],
+            param_dim: upars_stacked[param_dim],
+        },
+    )
+    upars_new_da = upars_new_stacked.unstack("__sample__")
+    return ShiftAndCovResult(upars=upars_new_da, shift=shift_vec, mapping=mapping_mat)
+
+
+def _get_log_likelihood_i(log_likelihood, i, obs_dims):
+    """Extract the log likelihood for a specific observation index `i`."""
+    if not obs_dims:
+        raise ValueError("log_likelihood must have observation dimensions.")
+
+    if len(obs_dims) == 1:
+        obs_dim = obs_dims[0]
+        if i < 0 or i >= log_likelihood.sizes[obs_dim]:
+            raise IndexError(f"Index {i} is out of bounds for dimension '{obs_dim}'.")
+        log_lik_i = log_likelihood.isel({obs_dim: i})
+    else:
+        stacked_obs_dim = "__obs__"
+        log_lik_stacked = log_likelihood.stack({stacked_obs_dim: obs_dims})
+        if i < 0 or i >= log_lik_stacked.sizes[stacked_obs_dim]:
+            raise IndexError(
+                f"Index {i} is out of bounds for stacked dimension '{stacked_obs_dim}'."
+            )
+        log_lik_i = log_lik_stacked.isel({stacked_obs_dim: i})
+    return log_lik_i
+
+
+def _recalculate_weights_k(
+    log_liki_new,
+    log_prob_new,
+    orig_log_prob,
+    reff,
+    sample_dims,
+):
+    """Recalculate importance weights and Pareto k after parameter transformation."""
+    log_ratio_i = -log_liki_new + log_prob_new - orig_log_prob
+    log_ratio_i = xr.where(np.isnan(log_ratio_i), -np.inf, log_ratio_i)
+
+    lwi_new, ki_new = log_ratio_i.azstats.psislw(r_eff=reff, dims=sample_dims)
+    ki_new = ki_new[0].item() if isinstance(ki_new, tuple) else ki_new.item()
+
+    log_ratio_full = log_prob_new - orig_log_prob
+    log_ratio_full = xr.where(np.isnan(log_ratio_full), -np.inf, log_ratio_full)
+
+    lwfi_new, kfi_new = log_ratio_full.azstats.psislw(r_eff=reff, dims=sample_dims)
+    kfi_new = kfi_new[0].item() if isinstance(kfi_new, tuple) else kfi_new.item()
+
+    return RecalculateWeightsResult(
+        lwi=lwi_new, lwfi=lwfi_new, ki=ki_new, kfi=kfi_new, log_liki=log_liki_new
+    )
+
+
+def _update_loo_data_i(
+    loo_data,
+    i,
+    new_elpd_i,
+    new_pareto_k,
+    log_liki,
+    sample_dims,
+    obs_dims,
+    n_samples,
+    original_log_liki=None,
+):
+    """Update the ELPDData object for a single observation."""
+    if loo_data.elpd_i is None or loo_data.pareto_k is None:
+        raise ValueError("loo_data must contain pointwise elpd_i and pareto_k values.")
+
+    lpd_i_log_lik = original_log_liki if original_log_liki is not None else log_liki
+    lpd_i = logsumexp(lpd_i_log_lik, dims=sample_dims, b=1 / n_samples).item()
+    p_loo_i = lpd_i - new_elpd_i
+
+    if len(obs_dims) == 1:
+        idx_dict = {obs_dims[0]: i}
+    else:
+        coords = np.unravel_index(i, tuple(loo_data.elpd_i.sizes[d] for d in obs_dims))
+        idx_dict = dict(zip(obs_dims, coords))
+
+    loo_data.elpd_i[idx_dict] = new_elpd_i
+    loo_data.pareto_k[idx_dict] = new_pareto_k
+
+    if not hasattr(loo_data, "p_loo_i") or loo_data.p_loo_i is None:
+        loo_data.p_loo_i = xr.full_like(loo_data.elpd_i, np.nan)
+
+    loo_data.p_loo_i[idx_dict] = p_loo_i
+
+    loo_data.elpd = float(np.nansum(loo_data.elpd_i.values))
+    loo_data.p = float(np.nansum(loo_data.p_loo_i.values))
+    loo_data.se = float(np.sqrt(loo_data.n_data_points * np.nanvar(loo_data.elpd_i.values)))
+
+    loo_data.warning, loo_data.good_k = _warn_pareto_k(
+        loo_data.pareto_k.values[~np.isnan(loo_data.pareto_k.values)], loo_data.n_samples
+    )
 
 
 def _plpd_approx(
@@ -295,6 +745,20 @@ def _generate_subsample_indices(n_data_points, observations, seed):
     else:
         raise TypeError("observations must be an integer or a numpy array of integers.")
     return indices, subsample_size
+
+
+def _get_r_eff(data, n_samples):
+    if not hasattr(data, "posterior"):
+        raise TypeError("Must be able to extract a posterior group from data.")
+    posterior = data.posterior
+    n_chains = len(posterior.chain)
+    if n_chains == 1:
+        reff = 1.0
+    else:
+        ess_p = posterior.azstats.ess(method="mean")
+        # this mean is over all data variables
+        reff = np.hstack([ess_p[v].values.flatten() for v in ess_p.data_vars]).mean() / n_samples
+    return reff
 
 
 def _prepare_loo_inputs(data, var_name, thin_factor=None):

--- a/src/arviz_stats/helper_loo.py
+++ b/src/arviz_stats/helper_loo.py
@@ -507,10 +507,8 @@ def _update_loo_data_i(
         loo_data.p_loo_i = xr.full_like(loo_data.elpd_i, np.nan)
 
     loo_data.p_loo_i[idx_dict] = p_loo_i
-
-    loo_data.elpd = float(np.nansum(loo_data.elpd_i.values))
-    loo_data.p = float(np.nansum(loo_data.p_loo_i.values))
-    loo_data.se = float(np.sqrt(loo_data.n_data_points * np.nanvar(loo_data.elpd_i.values)))
+    loo_data.elpd = np.nansum(loo_data.elpd_i.values)
+    loo_data.se = np.sqrt(loo_data.n_data_points * np.nanvar(loo_data.elpd_i.values))
 
     loo_data.warning, loo_data.good_k = _warn_pareto_k(
         loo_data.pareto_k.values[~np.isnan(loo_data.pareto_k.values)], loo_data.n_samples

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -1135,14 +1135,11 @@ def loo_moment_match(
     data : DataTree or InferenceData
         Input data. It should contain the posterior and the log_likelihood groups.
     loo_orig : ELPDData
-        An existing ELPDData object from a previous `loo` result. It must contain
+        An existing ELPDData object from a previous `loo` result. Must contain
         pointwise Pareto k values (`pointwise=True` must have been used).
     upars : DataArray
-        Posterior draws transformed to the unconstrained parameter space. It must have
-        "chain" and "draw" dimensions. If it has a third dimension, this dimension
-        represents the different unconstrained parameters. If it only has "chain" and
-        "draw" dimensions, it is assumed to represent a single unconstrained parameter and
-        will be expanded internally.
+        Posterior draws transformed to the unconstrained parameter space. Must have
+        `chain` and `draw` dimensions.
     log_prob_upars_fn : Callable[[DataArray], DataArray]
         A function that takes the unconstrained parameter draws and returns a
         :class:`~xarray.DataArray` containing the log probability density of the full posterior

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -1,6 +1,7 @@
 """Pareto-smoothed importance sampling LOO (PSIS-LOO-CV) related functions."""
 
 import itertools
+import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -14,17 +15,25 @@ from xarray_einstats.stats import logsumexp
 from arviz_stats.helper_loo import (
     _check_log_density,
     _diff_srs_estimator,
+    _get_log_likelihood_i,
     _get_r_eff,
     _prepare_full_arrays,
     _prepare_loo_inputs,
     _prepare_subsample,
     _prepare_update_subsample,
+    _recalculate_weights_k,
     _select_obs_by_coords,
+    _shift,
+    _shift_and_cov,
+    _shift_and_scale,
+    _split_moment_match,
     _srs_estimator,
+    _update_loo_data_i,
     _warn_pareto_k,
     _warn_pointwise_loo,
 )
 from arviz_stats.metrics import _metrics
+from arviz_stats.sampling_diagnostics import ess
 from arviz_stats.utils import ELPDData, get_log_likelihood_dataset
 
 
@@ -1094,6 +1103,588 @@ def update_subsample(
         log_q,
         thin,
     )
+
+
+def loo_moment_match(
+    data,
+    loo_orig,
+    upars,
+    log_prob_upars_fn,
+    log_lik_i_upars_fn,
+    max_iters=30,
+    k_threshold=None,
+    split=True,
+    cov=False,
+    pointwise=None,
+    var_name=None,
+    reff=None,
+):
+    r"""Compute moment matching for problematic observations in PSIS-LOO-CV.
+
+    Adjusts the results of a previously computed Pareto smoothed importance sampling leave-one-out
+    cross-validation (PSIS-LOO-CV) object by applying a moment matching algorithm to
+    observations with high Pareto k diagnostic values. The moment matching algorithm iteratively
+    adjusts the posterior draws in the unconstrained parameter space to better approximate the
+    leave-one-out posterior.
+
+    The moment matching algorithm is described in [1]_ and the PSIS-LOO-CV method is described in
+    [2]_ and [3]_.
+
+    Parameters
+    ----------
+    data : DataTree or InferenceData
+        Input data. It should contain the posterior and the log_likelihood groups.
+    loo_orig : ELPDData
+        An existing ELPDData object from a previous `loo` result. It must contain
+        pointwise Pareto k values (`pointwise=True` must have been used).
+    upars : DataArray
+        Posterior draws transformed to the unconstrained parameter space. It must have
+        "chain" and "draw" dimensions. If it has a third dimension, this dimension
+        represents the different unconstrained parameters. If it only has "chain" and
+        "draw" dimensions, it is assumed to represent a single unconstrained parameter and
+        will be expanded internally.
+    log_prob_upars_fn : Callable[[DataArray], DataArray]
+        A function that takes the unconstrained parameter draws and returns a
+        :class:`~xarray.DataArray` containing the log probability density of the full posterior
+        distribution evaluated at each unconstrained parameter draw. The returned DataArray must
+        have dimensions `chain`, `draw`.
+    log_lik_i_upars_fn : Callable[[DataArray, int], DataArray]
+        A function that takes the unconstrained parameter draws and the integer index `i`
+        of the left-out observation. It should return a :class:`~xarray.DataArray` containing the
+        log-likelihood of the left-out observation `i` evaluated at each unconstrained parameter
+        draw. The returned DataArray must have dimensions `chain`, `draw`.
+    max_iters : int, default 30
+        Maximum number of moment matching iterations for each problematic observation.
+    k_threshold : float, optional
+        Threshold value for Pareto k values above which moment matching is applied.
+        Defaults to :math:`\min(1 - 1/\log_{10}(S), 0.7)`, where S is the number of samples.
+    split : bool, default True
+        If True, only transform half of the draws and use multiple importance sampling to combine
+        them with untransformed draws.
+    cov : bool, default False
+        If True, match the covariance structure during the transformation, in addition
+        to the mean and marginal variances. Ignored if ``split=False``.
+    pointwise: bool, optional
+        If True, the pointwise predictive accuracy will be returned. Defaults to
+        ``rcParams["stats.ic_pointwise"]``. Moment matching always requires
+        pointwise data from `loo_orig`. This argument controls whether the returned
+        object includes pointwise data.
+    var_name : str, optional
+        The name of the variable in log_likelihood groups storing the pointwise log
+        likelihood data to use for loo computation.
+    reff: float, optional
+        Relative MCMC efficiency, ``ess / n`` i.e. number of effective samples divided by the number
+        of actual samples. Computed from trace by default.
+
+    Returns
+    -------
+    ELPDData
+        Object with the following attributes:
+
+        - **elpd**: expected log pointwise predictive density
+        - **se**: standard error of the elpd
+        - **p**: effective number of parameters
+        - **n_samples**: number of samples
+        - **n_data_points**: number of data points
+        - **warning**: True if the estimated shape parameter of Pareto distribution is greater
+          than ``good_k``.
+        - **elp_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
+          ``pointwise=True``
+        - **pareto_k**: array of Pareto shape values, only if ``pointwise=True``
+        - **good_k**: For a sample size S, the threshold is computed as
+          ``min(1 - 1/log10(S), 0.7)``
+        - **approx_posterior**: True if approximate posterior was used.
+
+    Examples
+    --------
+    We will use the radon dataset and artificially inflate some Pareto k values to demonstrate
+    moment matching.
+
+    .. ipython::
+
+        In [1]: import arviz_base as az
+           ...: from arviz_stats import loo, loo_moment_match
+           ...: import numpy as np
+           ...: import xarray as xr
+           ...: import pymc as pm
+           ...: import pytensor.tensor as pt
+           ...: idata = az.load_arviz_data("radon")
+
+    Compute initial LOO:
+
+    .. ipython::
+
+        In [2]: loo_orig = loo(idata, pointwise=True, var_name="y")
+           ...: loo_orig
+
+    Artificially inflate some Pareto k values to demonstrate moment matching:
+
+    .. ipython::
+
+        In [3]: rng = np.random.default_rng(214)
+           ...: modified_loo = loo_orig
+           ...: n_obs = len(loo_orig.pareto_k.values.flatten())
+           ...: problematic_indices = rng.choice(n_obs, size=8, replace=False)
+           ...:
+           ...: k_values = modified_loo.pareto_k.values.copy()
+           ...: k_flat = k_values.flatten()
+           ...: k_flat[problematic_indices] = rng.uniform(0.75, 1.2, size=8)
+           ...:
+           ...: modified_loo.pareto_k.values = k_flat.reshape(k_values.shape)
+           ...: modified_loo
+
+    Reconstruct the model:
+
+    .. ipython::
+
+        In [4]: n_counties = 85
+           ...: county_idx = idata.constant_data.county_idx.values
+           ...: floor_idx = idata.constant_data.floor_idx.values
+           ...: uranium = idata.constant_data.uranium.values
+           ...: y_obs = idata.observed_data.y.values
+           ...:
+           ...: with pm.Model() as radon_model:
+           ...:     sigma_a = pm.Exponential("sigma_a", 1.0)
+           ...:     za_county = pm.Normal("za_county", 0.0, 1.0, shape=n_counties)
+           ...:     a = pm.Deterministic("a", za_county[county_idx] * sigma_a)
+           ...:     b = pm.Normal("b", 0.0, 1.0)
+           ...:     g = pm.Normal("g", 0.0, 10.0, shape=2)
+           ...:     theta = a + g[0] * floor_idx + g[1] * uranium[county_idx]
+           ...:     sigma = pm.Exponential("sigma", 1.0)
+           ...:     y = pm.Normal("y", theta, sigma, observed=y_obs)
+           ...:
+           ...:     idata_with_transforms = pm.sample(
+           ...:         draws=100, tune=100, chains=2,
+           ...:         idata_kwargs={"include_transformed": True},
+           ...:         random_seed=42
+           ...:     )
+
+    Extract unconstrained parameters:
+
+    .. ipython::
+
+        In [5]: import numpy as np
+           ...:
+           ...: upars_dict = {
+           ...:     'sigma_a_log__': idata_with_transforms.posterior['sigma_a_log__'],
+           ...:     'za_county': idata_with_transforms.posterior['za_county'],
+           ...:     'b': idata_with_transforms.posterior['b'],
+           ...:     'g': idata_with_transforms.posterior['g'],
+           ...:     'sigma_log__': idata_with_transforms.posterior['sigma_log__']
+           ...: }
+           ...:
+           ...: upars_list = [
+           ...:     upars_dict['sigma_a_log__'].values.reshape(2, 100, 1),
+           ...:     upars_dict['za_county'].values.reshape(2, 100, -1),
+           ...:     upars_dict['b'].values.reshape(2, 100, 1),
+           ...:     upars_dict['g'].values.reshape(2, 100, -1),
+           ...:     upars_dict['sigma_log__'].values.reshape(2, 100, 1)
+           ...: ]
+           ...: upars_np = np.concatenate(upars_list, axis=-1)
+           ...: upars_da = xr.DataArray(upars_np, dims=['chain', 'draw', 'param'],
+           ...:                         coords={'chain': idata_with_transforms.posterior.chain,
+           ...:                                 'draw': idata_with_transforms.posterior.draw,
+           ...:                                 'param': np.arange(upars_np.shape[-1])})
+
+    Create log probability function:
+
+    .. ipython::
+
+        In [6]: compiled_logp = radon_model.compile_logp()
+           ...: def log_prob_upars(upars_da):
+           ...:     n_chains, n_draws = upars_da.shape[:2]
+           ...:     logp_values = np.empty((n_chains, n_draws))
+           ...:     for chain_idx, draw_idx in np.ndindex(n_chains, n_draws):
+           ...:         point_dict = {
+           ...:             name: upars_dict[name].isel(chain=chain_idx, draw=draw_idx).values
+           ...:             for name in upars_dict
+           ...:         }
+           ...:         logp_values[chain_idx, draw_idx] = compiled_logp(point_dict)
+           ...:     return xr.DataArray(
+           ...:         logp_values,
+           ...:         dims=["chain", "draw"],
+           ...:         coords={"chain": upars_da.chain, "draw": upars_da.draw}
+           ...:     )
+
+    Create pointwise log likelihood function:
+
+    .. ipython::
+
+        In [7]: def log_lik_i_upars(upars_da, i):
+           ...:     y_i = y_obs[i]
+           ...:     c_idx, f_idx, u_val = county_idx[i], floor_idx[i], uranium[county_idx[i]]
+           ...:
+           ...:     sigma_a_vals = np.exp(upars_dict['sigma_a_log__'].values)
+           ...:     sigma_vals = np.exp(upars_dict['sigma_log__'].values)
+           ...:     za_county_vals = upars_dict['za_county'].values
+           ...:     g_vals = upars_dict['g'].values
+           ...:
+           ...:     a_vals = za_county_vals[:, :, c_idx] * sigma_a_vals
+           ...:     theta_vals = a_vals + g_vals[:, :, 0] * f_idx + g_vals[:, :, 1] * u_val
+           ...:
+           ...:     loglik_values = pm.logp(pm.Normal.dist(theta_vals, sigma_vals), y_i).eval()
+           ...:
+           ...:     return xr.DataArray(
+           ...:         loglik_values,
+           ...:         dims=["chain", "draw"],
+           ...:         coords={"chain": upars_da.chain, "draw": upars_da.draw}
+           ...:     )
+
+    Apply moment matching with covariance matching and split transformation:
+
+    .. ipython::
+        :okwarning:
+
+        In [8]: loo_mm = loo_moment_match(
+           ...:     idata,
+           ...:     modified_loo,
+           ...:     upars=upars_da,
+           ...:     log_prob_upars_fn=log_prob_upars,
+           ...:     log_lik_i_upars_fn=log_lik_i_upars,
+           ...:     var_name="y",
+           ...:     split=True,
+           ...:     cov=True,
+           ...: )
+           ...: loo_mm
+
+    Notes
+    -----
+    The moment matching algorithm considers three affine transformations of the posterior draws.
+    For a specific draw :math:`\theta^{(s)}`, a generic affine transformation includes a square
+    matrix :math:`\mathbf{A}` representing a linear map and a vector :math:`\mathbf{b}`
+    representing a translation such that
+
+    .. math::
+        T : \theta^{(s)} \mapsto \mathbf{A}\theta^{(s)} + \mathbf{b}
+        =: \theta^{*{(s)}}.
+
+    The first transformation :math:`T_1` is a translation that matches the mean of the sample
+    to its importance weighted mean given by
+
+    .. math::
+        \mathbf{\theta^{*{(s)}}} = T_1(\mathbf{\theta^{(s)}}) =
+        \mathbf{\theta^{(s)}} - \bar{\theta} + \bar{\theta}_w,
+
+    where :math:`\bar{\theta}` is the mean of the sample and :math:`\bar{\theta}_w` is the
+    importance weighted mean of the sample. The second transformation :math:`T_2` is a scaling that
+    matches the marginal variances in addition to the means given by
+
+    .. math::
+        \mathbf{\theta^{*{(s)}}} = T_2(\mathbf{\theta^{(s)}}) =
+        \mathbf{v}^{1/2}_w \circ \mathbf{v}^{-1/2} \circ (\mathbf{\theta^{(s)}} - \bar{\theta}) +
+        \bar{\theta}_w,
+
+    where :math:`\mathbf{v}` and :math:`\mathbf{v}_w` are the sample and weighted variances.
+    The third transformation :math:`T_3` is a covariance transformation that matches the covariance
+    matrix of the sample to its importance weighted covariance matrix given by
+
+    .. math::
+        \mathbf{\theta^{*{(s)}}} = T_3(\mathbf{\theta^{(s)}}) =
+        \mathbf{L}_w \mathbf{L}^{-1} (\mathbf{\theta^{(s)}} - \bar{\theta}) + \bar{\theta}_w,
+
+    where :math:`\mathbf{L}` and :math:`\mathbf{L}_w` are the Cholesky decompositions of the
+    covariance matrix and the weighted covariance matrix, respectively, e.g.,
+
+    .. math::
+        \mathbf{LL}^T = \mathbf{\Sigma} = \frac{1}{S} \sum_{s=1}^S (\mathbf{\theta^{(s)}} -
+        \bar{\theta}) (\mathbf{\theta^{(s)}} - \bar{\theta})^T
+
+    and
+
+    .. math::
+        \mathbf{L}_w \mathbf{L}_w^T = \mathbf{\Sigma}_w = \frac{\frac{1}{S} \sum_{s=1}^S
+        w^{(s)} (\mathbf{\theta^{(s)}} - \bar{\theta}_w) (\mathbf{\theta^{(s)}} -
+        \bar{\theta}_w)^T}{\sum_{s=1}^S w^{(s)}}.
+
+    We iterate on :math:`T_1` repeatedly and move onto :math:`T_2` and :math:`T_3` only
+    if :math:`T_1` fails to yield a Pareto-k statistic below the threshold.
+
+    See Also
+    --------
+    loo : Standard PSIS-LOO-CV.
+    loo_approximate_posterior : Approximate posterior PSIS-LOO-CV.
+    loo_subsample : Sub-sampled PSIS-LOO-CV.
+
+    References
+    ----------
+
+    .. [1] Paananen, T., Piironen, J., Buerkner, P.-C., Vehtari, A. (2021). Implicitly Adaptive
+        Importance Sampling. Statistics and Computing. 31(2) (2021)
+        https://doi.org/10.1007/s11222-020-09982-2
+        arXiv preprint https://arxiv.org/abs/1906.08850.
+    .. [2] Vehtari et al. *Practical Bayesian model evaluation using leave-one-out cross-validation
+        and WAIC*. Statistics and Computing. 27(5) (2017) https://doi.org/10.1007/s11222-016-9696-4
+        arXiv preprint https://arxiv.org/abs/1507.04544.
+    .. [3] Vehtari et al. *Pareto Smoothed Importance Sampling*.
+        Journal of Machine Learning Research, 25(72) (2024) https://jmlr.org/papers/v25/19-556.html
+        arXiv preprint https://arxiv.org/abs/1507.02646
+    """
+    if not isinstance(loo_orig, ELPDData):
+        raise TypeError("loo_orig must be an ELPDData object.")
+    if loo_orig.pareto_k is None or loo_orig.elpd_i is None:
+        raise ValueError(
+            "Moment matching requires pointwise LOO results with Pareto k values. "
+            "Please compute the initial LOO with pointwise=True."
+        )
+
+    sample_dims = ["chain", "draw"]
+
+    if not isinstance(upars, xr.DataArray):
+        raise TypeError("upars must be a DataArray.")
+    if not all(dim_name in upars.dims for dim_name in sample_dims):
+        raise ValueError(f"upars must have dimensions {sample_dims}.")
+
+    param_dim_list = [dim for dim in upars.dims if dim not in sample_dims]
+
+    if len(param_dim_list) == 0:
+        param_dim_name = "_upars_dim_"
+        upars.expand_dims(dim={param_dim_name: 1})
+    elif len(param_dim_list) == 1:
+        param_dim_name = param_dim_list[0]
+    else:
+        raise ValueError("upars must have at most one dimension besides 'chain' and 'draw'.")
+
+    loo_data = deepcopy(loo_orig)
+    loo_data.method = "loo_moment_match"
+    pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
+
+    loo_inputs = _prepare_loo_inputs(data, var_name)
+    log_likelihood = loo_inputs.log_likelihood
+    obs_dims = loo_inputs.obs_dims
+    n_samples = loo_inputs.n_samples
+    var_name = loo_inputs.var_name
+    n_params = upars.sizes[param_dim_name]
+
+    if reff is None:
+        reff = _get_r_eff(data, n_samples)
+
+    try:
+        orig_log_prob = log_prob_upars_fn(upars)
+        if not isinstance(orig_log_prob, xr.DataArray):
+            raise TypeError("log_prob_upars_fn must return a DataArray.")
+        if not all(dim in orig_log_prob.dims for dim in sample_dims):
+            raise ValueError(f"Original log probability must have dimensions {sample_dims}.")
+        if len(orig_log_prob.dims) != len(sample_dims):
+            raise ValueError(
+                f"Original log probability should only have dimensions {sample_dims}, "
+                f"found {orig_log_prob.dims}"
+            )
+    except Exception as e:
+        raise ValueError(f"Error executing log_prob_upars_fn: {e}") from e
+
+    if k_threshold is None:
+        k_threshold = min(1 - 1 / np.log10(n_samples), 0.7) if n_samples > 1 else 0.7
+
+    ks = loo_data.pareto_k.stack(__obs__=obs_dims).transpose("__obs__").values
+    bad_obs_indices = np.where(ks > k_threshold)[0]
+
+    if len(bad_obs_indices) == 0:
+        warnings.warn("No Pareto k values exceed the threshold. Returning original LOO data.")
+        if not pointwise:
+            loo_data.elpd_i = None
+            loo_data.pareto_k = None
+            if hasattr(loo_data, "p_loo_i"):
+                loo_data.p_loo_i = None
+        return loo_data
+
+    # Moment matching algorithm
+    for i in bad_obs_indices:
+        log_liki = _get_log_likelihood_i(log_likelihood, i, obs_dims)
+        log_ratio_i_init = -log_liki
+        lwi, ki_tuple = log_ratio_i_init.azstats.psislw(r_eff=reff, dims=sample_dims)
+
+        ki = ki_tuple[0].item() if isinstance(ki_tuple, tuple) else ki_tuple.item()
+        ess_val = ess(log_liki.values.reshape(-1, 1), method="mean").item()
+        reff_i = ess_val / n_samples if n_samples > 0 else 1.0
+
+        upars_i = upars.copy(deep=True)
+        total_shift = np.zeros(upars_i.sizes[param_dim_name])
+        total_scaling = np.ones(upars_i.sizes[param_dim_name])
+        total_mapping = np.eye(upars_i.sizes[param_dim_name])
+
+        iterind = 1
+        transformations_applied = False
+
+        while ki > k_threshold:
+            if iterind > max_iters:
+                warnings.warn(
+                    f"Maximum number of moment matching iterations ({max_iters}) reached "
+                    f"for observation {i}. Final Pareto k is {ki:.2f}.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
+
+            # Try Mean Shift
+            try:
+                shift_res = _shift(upars_i, lwi)
+                log_prob_shifted = log_prob_upars_fn(shift_res.upars)
+                log_liki_shifted = log_lik_i_upars_fn(shift_res.upars, i)
+                weights_k_res = _recalculate_weights_k(
+                    log_liki_shifted, log_prob_shifted, orig_log_prob, reff_i, sample_dims
+                )
+                if weights_k_res.ki < ki:
+                    ki = weights_k_res.ki
+                    lwi = weights_k_res.lwi
+                    log_liki = weights_k_res.log_liki
+                    upars_i = shift_res.upars
+                    total_shift += shift_res.shift
+                    transformations_applied = True
+                    iterind += 1
+                    continue  # Restart, try mean shift again
+
+            except RuntimeError as e:
+                warnings.warn(
+                    f"Error during mean shift calculation for observation {i}: {e}. "
+                    "Stopping moment matching for this observation.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
+
+            # Try Scale Shift (only if mean shift didn't improve)
+            try:
+                scale_res = _shift_and_scale(upars_i, lwi)
+                log_prob_scaled = log_prob_upars_fn(scale_res.upars)
+                log_liki_scaled = log_lik_i_upars_fn(scale_res.upars, i)
+                weights_k_res_scale = _recalculate_weights_k(
+                    log_liki_scaled, log_prob_scaled, orig_log_prob, reff_i, sample_dims
+                )
+                if weights_k_res_scale.ki < ki:
+                    ki = weights_k_res_scale.ki
+                    lwi = weights_k_res_scale.lwi
+                    log_liki = weights_k_res_scale.log_liki
+                    upars_i = scale_res.upars
+                    total_shift = scale_res.shift + total_shift * scale_res.scaling
+                    total_scaling *= scale_res.scaling
+                    transformations_applied = True
+                    iterind += 1
+                    continue  # Restart, try mean shift again
+
+            except RuntimeError as e:
+                warnings.warn(
+                    f"Error during scale shift calculation for observation {i}: {e}. "
+                    "Stopping moment matching for this observation.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
+
+            # Try Covariance Shift (only if mean and scale shift didn't improve, cov=True,
+            # and S >= 10 * npars)
+            if cov and n_samples >= 10 * n_params:
+                try:
+                    cov_res = _shift_and_cov(upars_i, lwi)
+                    log_prob_cov = log_prob_upars_fn(cov_res.upars)
+                    log_liki_cov = log_lik_i_upars_fn(cov_res.upars, i)
+                    weights_k_res_cov = _recalculate_weights_k(
+                        log_liki_cov, log_prob_cov, orig_log_prob, reff_i, sample_dims
+                    )
+                    if weights_k_res_cov.ki < ki:
+                        ki = weights_k_res_cov.ki
+                        lwi = weights_k_res_cov.lwi
+                        log_liki = weights_k_res_cov.log_liki
+                        upars_i = cov_res.upars
+                        total_shift = cov_res.shift + total_shift @ cov_res.mapping.T
+                        total_mapping = cov_res.mapping @ total_mapping
+                        transformations_applied = True
+                        iterind += 1
+                        continue  # Restart, try mean shift again
+
+                except RuntimeError as e:
+                    warnings.warn(
+                        f"Error during covariance shift calculation for observation {i}: {e}. "
+                        "Stopping moment matching for this observation.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                    break
+
+            # If none of the transformations in this pass improved ki, break.
+            break
+
+        # MODIFIED SECTION: Split transformation logic
+        if split and transformations_applied:
+            try:
+                split_res = _split_moment_match(
+                    upars=upars,
+                    cov=cov,
+                    total_shift=total_shift,
+                    total_scaling=total_scaling,
+                    total_mapping=total_mapping,
+                    i=i,
+                    reff=reff_i,
+                    log_prob_upars_fn=log_prob_upars_fn,
+                    log_lik_i_upars_fn=log_lik_i_upars_fn,
+                )
+
+                final_log_liki = split_res.log_liki
+                final_lwi = split_res.lwi
+                _, ki_split_tuple = split_res.lwi.azstats.psislw(
+                    r_eff=split_res.reff, dims=sample_dims
+                )
+                ki_split = (
+                    ki_split_tuple[0].item()
+                    if isinstance(ki_split_tuple, tuple)
+                    else ki_split_tuple.item()
+                )
+                final_ki = ki_split
+
+                if ki_split > ki and ki <= k_threshold:
+                    warnings.warn(
+                        f"Split transformation increased Pareto k for observation {i} "
+                        f"({ki:.2f} -> {ki_split:.2f}). This may indicate numerical issues.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
+            except RuntimeError as e:
+                warnings.warn(
+                    f"Error during split moment matching for observation {i}: {e}. "
+                    "Using non-split transformation result.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                # On error, keep the non-split results
+                final_log_liki = log_liki
+                final_lwi = lwi
+                final_ki = ki
+        else:
+            # No split transformation
+            final_log_liki = log_liki
+            final_lwi = lwi
+            final_ki = ki
+
+        new_elpd_i = logsumexp(final_log_liki + final_lwi, dims=sample_dims).item()
+        original_log_liki = _get_log_likelihood_i(log_likelihood, i, obs_dims)
+
+        _update_loo_data_i(
+            loo_data,
+            i,
+            new_elpd_i,
+            final_ki,
+            final_log_liki,
+            sample_dims,
+            obs_dims,
+            n_samples,
+            original_log_liki=original_log_liki,
+        )
+
+    final_ks = loo_data.pareto_k.stack(__obs__=obs_dims).transpose("__obs__").values
+    if np.any(final_ks[bad_obs_indices] > k_threshold):
+        warnings.warn(
+            f"After Moment Matching, {np.sum(final_ks > k_threshold)} observations still have "
+            f"Pareto k > {k_threshold:.2f}.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    if not pointwise:
+        loo_data.elpd_i = None
+        loo_data.pareto_k = None
+        if hasattr(loo_data, "p_loo_i"):
+            loo_data.p_loo_i = None
+    return loo_data
 
 
 def compare(

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -1603,7 +1603,6 @@ def loo_moment_match(
             # If none of the transformations in this pass improved ki, break.
             break
 
-        # MODIFIED SECTION: Split transformation logic
         if split and transformations_applied:
             try:
                 split_res = _split_moment_match(

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -1215,7 +1215,7 @@ def loo_moment_match(
         In [2]: loo_orig = loo(idata, pointwise=True, var_name="y")
            ...: loo_orig
 
-    Artificially inflate some Pareto k values since the original Pareto k values are
+    We need to inflate some Pareto k values since the original Pareto k values are
     all below the threshold:
 
     .. ipython::
@@ -1354,7 +1354,7 @@ def loo_moment_match(
            ...: )
            ...: loo_mm
 
-    All the Pareto k values are now below the threshold, and the LOO is improved.
+    All the Pareto k values are now below the threshold, and the PSIS-LOO-CV is improved.
 
     Notes
     -----

--- a/src/arviz_stats/loo.py
+++ b/src/arviz_stats/loo.py
@@ -1263,7 +1263,7 @@ def loo_moment_match(
            ...:     )
 
     We need to extract the unconstrained parameters from the posterior. Recall that moment matching
-    requires the parameters to be in the unconstrained space. Note that the paramters in this model
+    requires the parameters to be in the unconstrained space. The parameters in this model
     have different shapes, so we need to flatten into a single dimension before stacking them:
 
 
@@ -1315,8 +1315,7 @@ def loo_moment_match(
 
     Next, we need to create the pointwise log likelihood function that takes the unconstrained
     parameters and returns the pointwise log likelihood. We will use the compiled logp function
-    again to do this. Note that the log likelihood function takes the unconstrained parameters
-    and the index of the observation to return the log likelihood for that observation:
+    again to do this:
 
     .. ipython::
 


### PR DESCRIPTION
This PR adds `loo_moment_match`,  implementing the moment matching algorithm for PSIS-LOO-CV described in [Paananen et al. (2021)](https://arxiv.org/pdf/1906.08850). This implementation addresses the limitation of standard PSIS-LOO-CV when many Pareto k values are high (k > 0.7), avoiding exact model refitting. The moment matching approach iteratively adjusts posterior draws to better approximate the leave-one-out posterior distribution.

### Major Additions

- **`loo_moment_match()`**: Main function handling all the logic and main moment matching algorithm. 

- **Affine Transformations**: 
  - `_shift()`: Simple mean-matching transformation
  - `_shift_and_scale()`: Matches both mean and marginal variances
  - `_shift_and_cov()`: Full covariance matching (when `cov=True`)

- **Split transformation**: `_split_moment_match` gives the option to transform only half the draws and use multiple importance sampling for improved stability

- **Helper functions**: Support for recalculating importance weights, updating pointwise PSIS-LOO-CV data, etc.

### Notes

- Had to expand the line limit for invidual modules to 2500 since the `loo.py` module is getting quite big. Maybe we want to move things around?
- Included `pymc` as a dependency for building the documentation. I wanted to include a realistic example using a PPL for moment matching to give the user an idea of how to define and use the required user-provided functions, `log_prob_upars_fn` and `log_lik_i_upars_fn`. Happy to modify this. 
- In [63](https://github.com/arviz-devs/arviz-stats/issues/63), it's mentioned that we might need a function which maps the adjusted, unconstrained posterior draws back to the constrained space, e.g.., a constraining bijector. To my understanding, this is not a requirement in [loo_moment_matching.R](https://github.com/stan-dev/loo/blob/master/R/loo_moment_matching.R), which is the main source of inspiration for this PR. This functionality does exist in [iwmm](https://github.com/topipa/iwmm/tree/main), however. Happy to discuss adding this here as well.

---

Resolves [63](https://github.com/arviz-devs/arviz-stats/issues/63)