### PR TITLE
Add method for multiple chains, remove optimization method

### DIFF
--- a/tests/test_ecdf_utils.py
+++ b/tests/test_ecdf_utils.py
@@ -1,0 +1,14 @@
+from numpy.testing import assert_array_almost_equal
+from scipy.special._ufuncs import _hypergeom_cdf
+
+from arviz_stats.ecdf_utils import hypergeometric_cdf
+
+
+def test_hypergeom_cdf():
+    suc = 8000
+    pop = 200
+    draws = 1000
+    for x_vals in [0, 1, [2, 3]]:
+        expected_cdf = _hypergeom_cdf(x_vals, pop, draws, suc)
+        calculated_cdf = hypergeometric_cdf(x_vals, draws, suc, pop)
+        assert_array_almost_equal(calculated_cdf, expected_cdf)

--- a/tests/test_ecdf_utils.py
+++ b/tests/test_ecdf_utils.py
@@ -1,6 +1,9 @@
 from numpy.testing import assert_array_almost_equal
 from scipy.special._ufuncs import _hypergeom_cdf
 
+from .helpers import importorskip
+
+azb = importorskip("arviz_base")
 from arviz_stats.ecdf_utils import hypergeometric_cdf
 
 


### PR DESCRIPTION
I am adding the method for the envelope that takes into account multiple chains. I am implementing the cdf of the hypergeometric using numba, as the one in scipy is too slow for this. I visually compared the results with the example in bayesplot, and there is no clear difference. Results are also visually equivalent when using the custom function or the one from scipy. I added a small test comparing the computation in scipy and the custom cdf. 

I am removing the optimization method as it is currently slower than the simulation method, and the simulation method seems to be fast enough so far. We can later revisit this.

One more thing, I need to check in detail, but I think the default in bayesplot for the ci_prob when computing the envelope is 0.99, maybe the 0.94  will lead to too many "rejections". Should we have this default too. Maybe a new RcParams? ()


<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--151.org.readthedocs.build/en/151/

<!-- readthedocs-preview arviz-stats end -->