### PR TITLE
Log Weights API change for LOO functions

### DIFF
--- a/src/arviz_stats/loo/helper_loo.py
+++ b/src/arviz_stats/loo/helper_loo.py
@@ -528,7 +528,6 @@ def _compute_loo_results(
     if log_weights is None or pareto_k is None:
         log_weights, pareto_k = log_likelihood.azstats.psislw(r_eff=reff, dim=sample_dims)
 
-    raw_log_weights = log_weights.copy()
     log_weights_sum = log_weights + log_likelihood
     pareto_k_da = pareto_k
 
@@ -561,7 +560,7 @@ def _compute_loo_results(
             warn_mg,
             good_k,
             approx_posterior=approx_posterior,
-            log_weights=raw_log_weights,
+            log_weights=log_weights,
         )
 
     _warn_pointwise_loo(elpd, elpd_i_values)

--- a/src/arviz_stats/loo/helper_loo.py
+++ b/src/arviz_stats/loo/helper_loo.py
@@ -18,6 +18,7 @@ __all__ = [
     "_recalculate_weights_k",
     "_update_loo_data_i",
     "_get_log_likelihood_i",
+    "_get_log_weights_i",
     "_plpd_approx",
     "_diff_srs_estimator",
     "_srs_estimator",
@@ -203,6 +204,27 @@ def _get_log_likelihood_i(log_likelihood, i, obs_dims):
             )
         log_lik_i = log_lik_stacked.isel({stacked_obs_dim: i})
     return log_lik_i
+
+
+def _get_log_weights_i(log_weights, i, obs_dims):
+    """Extract the log weights for a specific observation index `i`."""
+    if not obs_dims:
+        raise ValueError("log_weights must have observation dimensions.")
+
+    if len(obs_dims) == 1:
+        obs_dim = obs_dims[0]
+        if i < 0 or i >= log_weights.sizes[obs_dim]:
+            raise IndexError(f"Index {i} is out of bounds for dimension '{obs_dim}'.")
+        log_weights_i = log_weights.isel({obs_dim: i})
+    else:
+        stacked_obs_dim = "__obs__"
+        log_weights_stacked = log_weights.stack({stacked_obs_dim: obs_dims})
+        if i < 0 or i >= log_weights_stacked.sizes[stacked_obs_dim]:
+            raise IndexError(
+                f"Index {i} is out of bounds for stacked dimension '{stacked_obs_dim}'."
+            )
+        log_weights_i = log_weights_stacked.isel({stacked_obs_dim: i})
+    return log_weights_i
 
 
 def _recalculate_weights_k(
@@ -506,11 +528,12 @@ def _compute_loo_results(
     if log_weights is None or pareto_k is None:
         log_weights, pareto_k = log_likelihood.azstats.psislw(r_eff=reff, dim=sample_dims)
 
-    log_weights += log_likelihood
+    raw_log_weights = log_weights.copy()
+    log_weights_sum = log_weights + log_likelihood
     pareto_k_da = pareto_k
 
     warn_mg, good_k = _warn_pareto_k(pareto_k_da, n_samples)
-    elpd_i = logsumexp(log_weights, dims=sample_dims)
+    elpd_i = logsumexp(log_weights_sum, dims=sample_dims)
 
     if return_pointwise:
         if isinstance(elpd_i, xr.Dataset) and var_name in elpd_i:
@@ -538,6 +561,7 @@ def _compute_loo_results(
             warn_mg,
             good_k,
             approx_posterior=approx_posterior,
+            log_weights=raw_log_weights,
         )
 
     _warn_pointwise_loo(elpd, elpd_i_values)
@@ -555,6 +579,7 @@ def _compute_loo_results(
         elpd_i,
         pareto_k_da,
         approx_posterior=approx_posterior,
+        log_weights=log_weights,
     )
 
 

--- a/src/arviz_stats/loo/loo.py
+++ b/src/arviz_stats/loo/loo.py
@@ -9,7 +9,7 @@ from arviz_stats.loo.helper_loo import (
 )
 
 
-def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
+def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None, pareto_k=None):
     """Compute Pareto-smoothed importance sampling leave-one-out cross-validation (PSIS-LOO-CV).
 
     Estimates the expected log pointwise predictive density (elpd) using Pareto-smoothed
@@ -33,6 +33,11 @@ def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
     log_weights : DataArray, optional
         Smoothed log weights. It must have the same shape as the log likelihood data.
         Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
+        Must be provided together with pareto_k or both must be None.
+    pareto_k : DataArray, optional
+        Pareto shape values. It must have the same shape as the log likelihood data.
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
+        Must be provided together with log_weights or both must be None.
 
     Returns
     -------
@@ -94,12 +99,14 @@ def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
     if reff is None:
         reff = _get_r_eff(data, loo_inputs.n_samples)
 
-    if log_weights is None:
-        log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
-            r_eff=reff, dim=loo_inputs.sample_dims
+    if (log_weights is None) != (pareto_k is None):
+        raise ValueError(
+            "Both log_weights and pareto_k must be provided together or both must be None. "
+            "Only one was provided."
         )
-    else:
-        _, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
+
+    if log_weights is None and pareto_k is None:
+        log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
             r_eff=reff, dim=loo_inputs.sample_dims
         )
 

--- a/src/arviz_stats/loo/loo.py
+++ b/src/arviz_stats/loo/loo.py
@@ -9,7 +9,7 @@ from arviz_stats.loo.helper_loo import (
 )
 
 
-def loo(data, pointwise=None, var_name=None, reff=None):
+def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
     """Compute Pareto-smoothed importance sampling leave-one-out cross-validation (PSIS-LOO-CV).
 
     Estimates the expected log pointwise predictive density (elpd) using Pareto-smoothed
@@ -30,6 +30,9 @@ def loo(data, pointwise=None, var_name=None, reff=None):
     reff: float, optional
         Relative MCMC efficiency, ``ess / n`` i.e. number of effective samples divided by the number
         of actual samples. Computed from trace by default.
+    log_weights : DataArray, optional
+        Smoothed log weights. It must have the same shape as the log likelihood data.
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
 
     Returns
     -------
@@ -49,6 +52,8 @@ def loo(data, pointwise=None, var_name=None, reff=None):
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
         - **approx_posterior**: True if approximate posterior was used.
+        - **log_weights**: :class:`~xarray.DataArray` containing the log weights used in the
+          computation
 
     Examples
     --------
@@ -90,9 +95,12 @@ def loo(data, pointwise=None, var_name=None, reff=None):
     if reff is None:
         reff = _get_r_eff(data, loo_inputs.n_samples)
 
-    log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
-        r_eff=reff, dim=loo_inputs.sample_dims
-    )
+    if log_weights is None:
+        log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
+            r_eff=reff, dim=loo_inputs.sample_dims
+        )
+
+    _, pareto_k = loo_inputs.log_likelihood.azstats.psislw(r_eff=reff, dim=loo_inputs.sample_dims)
 
     return _compute_loo_results(
         log_likelihood=loo_inputs.log_likelihood,

--- a/src/arviz_stats/loo/loo.py
+++ b/src/arviz_stats/loo/loo.py
@@ -52,8 +52,7 @@ def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
         - **approx_posterior**: True if approximate posterior was used.
-        - **log_weights**: :class:`~xarray.DataArray` containing the log weights used in the
-          computation
+        - **log_weights**: Smoothed log weights.
 
     Examples
     --------
@@ -99,8 +98,10 @@ def loo(data, pointwise=None, var_name=None, reff=None, log_weights=None):
         log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
             r_eff=reff, dim=loo_inputs.sample_dims
         )
-
-    _, pareto_k = loo_inputs.log_likelihood.azstats.psislw(r_eff=reff, dim=loo_inputs.sample_dims)
+    else:
+        _, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
+            r_eff=reff, dim=loo_inputs.sample_dims
+        )
 
     return _compute_loo_results(
         log_likelihood=loo_inputs.log_likelihood,

--- a/src/arviz_stats/loo/loo_expectations.py
+++ b/src/arviz_stats/loo/loo_expectations.py
@@ -13,9 +13,9 @@ from arviz_stats.utils import ELPDData, get_log_likelihood_dataset
 def loo_expectations(
     data,
     var_name=None,
+    log_weights=None,
     kind="mean",
     probs=None,
-    log_weights=None,
 ):
     """Compute weighted expectations using the PSIS-LOO-CV method.
 
@@ -29,6 +29,13 @@ def loo_expectations(
     var_name: str, optional
         The name of the variable in log_likelihood groups storing the pointwise log
         likelihood data to use for loo computation.
+    log_weights : DataArray or ELPDData, optional
+        Smoothed log weights. Can be either:
+
+        - A DataArray with the same shape as the log likelihood data
+        - An ELPDData object from a previous :func:`arviz_stats.loo` call.
+
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
     kind: str, optional
         The kind of expectation to compute. Available options are:
 
@@ -39,13 +46,6 @@ def loo_expectations(
         - 'quantile': the quantile of the posterior predictive distribution.
     probs: float or list of float, optional
         The quantile(s) to compute when kind is 'quantile'.
-    log_weights : DataArray or ELPDData, optional
-        Smoothed log weights. Can be either:
-
-        - A DataArray with the same shape as the log likelihood data
-        - An ELPDData object from a previous :func:`arviz_stats.loo` call.
-
-        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
 
     Returns
     -------

--- a/src/arviz_stats/loo/loo_expectations.py
+++ b/src/arviz_stats/loo/loo_expectations.py
@@ -15,6 +15,7 @@ def loo_expectations(
     var_name=None,
     kind="mean",
     probs=None,
+    log_weights=None,
 ):
     """Compute weighted expectations using the PSIS-LOO-CV method.
 
@@ -38,6 +39,9 @@ def loo_expectations(
         - 'quantile': the quantile of the posterior predictive distribution.
     probs: float or list of float, optional
         The quantile(s) to compute when kind is 'quantile'.
+    log_weights : DataArray, optional
+        Smoothed log weights. It must have the same shape as the log likelihood data.
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
 
     Returns
     -------
@@ -87,8 +91,10 @@ def loo_expectations(
     log_likelihood = get_log_likelihood_dataset(data, var_names=var_name)
     n_samples = log_likelihood[var_name].sizes["chain"] * log_likelihood[var_name].sizes["draw"]
 
-    log_weights, _ = log_likelihood.azstats.psislw()
-    log_weights = log_weights[var_name]
+    if log_weights is None:
+        log_weights, _ = log_likelihood.azstats.psislw()
+        log_weights = log_weights[var_name]
+
     weights = np.exp(log_weights)
 
     posterior_predictive = extract(

--- a/src/arviz_stats/loo/loo_pit.py
+++ b/src/arviz_stats/loo/loo_pit.py
@@ -6,7 +6,7 @@ from arviz_base import convert_to_datatree, extract
 from xarray_einstats.stats import logsumexp
 
 from arviz_stats.loo.helper_loo import _get_r_eff
-from arviz_stats.utils import get_log_likelihood_dataset
+from arviz_stats.utils import ELPDData, get_log_likelihood_dataset
 
 
 def loo_pit(
@@ -30,8 +30,12 @@ def loo_pit(
         Names of the variables to be used to compute the LOO-PIT values. If None, all
         variables are used. The function assumes that the observed and log_likelihood
         variables share the same names.
-    log_weights: DataArray
-        Smoothed log_weights. It must have the same shape as ``y_pred``.
+    log_weights: DataArray or ELPDData, optional
+        Smoothed log weights. Can be either:
+
+        - A DataArray with the same shape as ``y_pred``
+        - An ELPDData object from a previous :func:`arviz_stats.loo` call.
+
         Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
 
     Returns
@@ -91,6 +95,11 @@ def loo_pit(
         n_samples = log_likelihood.chain.size * log_likelihood.draw.size
         reff = _get_r_eff(data, n_samples)
         log_weights, _ = log_likelihood.azstats.psislw(r_eff=reff)
+
+    if isinstance(log_weights, ELPDData):
+        if log_weights.log_weights is None:
+            raise ValueError("ELPDData object does not contain log_weights")
+        log_weights = log_weights.log_weights
 
     posterior_predictive = extract(
         data,

--- a/src/arviz_stats/loo/loo_pit.py
+++ b/src/arviz_stats/loo/loo_pit.py
@@ -31,8 +31,8 @@ def loo_pit(
         variables are used. The function assumes that the observed and log_likelihood
         variables share the same names.
     log_weights: DataArray
-        Smoothed log_weights. It must have the same shape as ``y_pred``
-        Defaults to None, it will be computed using the PSIS-LOO method.
+        Smoothed log_weights. It must have the same shape as ``y_pred``.
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
 
     Returns
     -------

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -20,6 +20,8 @@ def reloo(
     loo_orig=None,
     k_threshold=-np.inf,
     pointwise=None,
+    log_weights=None,
+    var_name=None,
 ):
     r"""Recalculate exact Leave-One-Out cross validation refitting where the approximation fails.
 
@@ -55,6 +57,17 @@ def reloo(
     pointwise : bool, optional
         If True, return pointwise LOO data. Defaults to
         ``rcParams["stats.ic_pointwise"]``.
+    log_weights : DataArray or ELPDData, optional
+        Smoothed log weights. Can be either:
+
+        - A DataArray with the same shape as the log likelihood data
+        - An ELPDData object from a previous :func:`arviz_stats.loo` call.
+
+        Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
+    var_name : str, optional
+        The name of the variable in log_likelihood groups storing the pointwise log
+        likelihood data to use for loo computation. Defaults to None, which will
+        use all log likelihood data.
 
     Returns
     -------
@@ -119,7 +132,21 @@ def reloo(
     pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
 
     if loo_orig is None:
-        loo_orig = loo(wrapper.data, var_name=wrapper.log_lik_var_name, pointwise=True)
+        if isinstance(log_weights, ELPDData):
+            if log_weights.log_weights is None:
+                raise ValueError("ELPDData object does not contain log_weights")
+            log_weights = log_weights.log_weights
+
+            # Dataset case comes from loo_subsample
+            if isinstance(log_weights, xr.Dataset):
+                if var_name and var_name in log_weights:
+                    log_weights = log_weights[var_name]
+                else:
+                    log_weights = log_weights[list(log_weights.data_vars)[0]]
+
+        loo_orig = loo(
+            wrapper.idata_orig, var_name=var_name, pointwise=True, log_weights=log_weights
+        )
 
     if not isinstance(loo_orig, ELPDData):
         raise TypeError("loo_orig must be an ELPDData object.")
@@ -133,7 +160,7 @@ def reloo(
     sample_dims = ["chain", "draw"]
     loo_refitted = deepcopy(loo_orig)
 
-    loo_inputs = _prepare_loo_inputs(wrapper.data, wrapper.log_lik_var_name)
+    loo_inputs = _prepare_loo_inputs(wrapper.idata_orig, var_name)
     obs_dims = loo_inputs.obs_dims
     n_data_points = loo_inputs.n_data_points
     n_samples = loo_inputs.n_samples
@@ -201,5 +228,16 @@ def reloo(
         loo_refitted.elpd_i = None
         loo_refitted.pareto_k = None
         loo_refitted.p_loo_i = None
+        if hasattr(loo_orig, "log_weights") and loo_orig.log_weights is not None:
+            loo_refitted.log_weights = loo_orig.log_weights
+    else:
+        if hasattr(loo_orig, "log_weights") and loo_orig.log_weights is not None:
+            loo_refitted.log_weights = loo_orig.log_weights.copy()
+            for i, obs_idx in enumerate(bad_obs_flat_indices):
+                if len(obs_dims) == 1:
+                    loo_refitted.log_weights[bad_obs_indices[i]] = np.nan
+                else:
+                    obs_idx_tuple = tuple(bad_obs_indices[i])
+                    loo_refitted.log_weights[obs_idx_tuple] = np.nan
 
     return loo_refitted

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -132,9 +132,11 @@ def reloo(
     pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
 
     if loo_orig is None:
+        pareto_k = None
         if isinstance(log_weights, ELPDData):
             if log_weights.log_weights is None:
                 raise ValueError("ELPDData object does not contain log_weights")
+            pareto_k = log_weights.pareto_k
             log_weights = log_weights.log_weights
 
             # Dataset case comes from loo_subsample
@@ -145,7 +147,11 @@ def reloo(
                     log_weights = log_weights[list(log_weights.data_vars)[0]]
 
         loo_orig = loo(
-            wrapper.idata_orig, var_name=var_name, pointwise=True, log_weights=log_weights
+            wrapper.idata_orig,
+            var_name=var_name,
+            pointwise=True,
+            log_weights=log_weights,
+            pareto_k=pareto_k,
         )
 
     if not isinstance(loo_orig, ELPDData):

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -18,10 +18,10 @@ __all__ = ["reloo"]
 def reloo(
     wrapper,
     loo_orig=None,
+    var_name=None,
+    log_weights=None,
     k_threshold=-np.inf,
     pointwise=None,
-    log_weights=None,
-    var_name=None,
 ):
     r"""Recalculate exact Leave-One-Out cross validation refitting where the approximation fails.
 
@@ -50,13 +50,10 @@ def reloo(
     loo_orig : ELPDData, optional
         Existing LOO results with pointwise data. If None, will compute
         PSIS-LOO-CV first using the data from ``wrapper``.
-    k_threshold : float, optional
-        Pareto shape threshold. Observations with k values above this
-        threshold will trigger a refit. Defaults to :math:`\min(1 - 1/\log_{10}(S), 0.7)`,
-        where S is the number of samples.
-    pointwise : bool, optional
-        If True, return pointwise LOO data. Defaults to
-        ``rcParams["stats.ic_pointwise"]``.
+    var_name : str, optional
+        The name of the variable in log_likelihood groups storing the pointwise log
+        likelihood data to use for loo computation. Defaults to None, which will
+        use all log likelihood data.
     log_weights : DataArray or ELPDData, optional
         Smoothed log weights. Can be either:
 
@@ -64,10 +61,13 @@ def reloo(
         - An ELPDData object from a previous :func:`arviz_stats.loo` call.
 
         Defaults to None. If not provided, it will be computed using the PSIS-LOO method.
-    var_name : str, optional
-        The name of the variable in log_likelihood groups storing the pointwise log
-        likelihood data to use for loo computation. Defaults to None, which will
-        use all log likelihood data.
+    k_threshold : float, optional
+        Pareto shape threshold. Observations with k values above this
+        threshold will trigger a refit. Defaults to :math:`\min(1 - 1/\log_{10}(S), 0.7)`,
+        where S is the number of samples.
+    pointwise : bool, optional
+        If True, return pointwise LOO data. Defaults to
+        ``rcParams["stats.ic_pointwise"]``.
 
     Returns
     -------

--- a/src/arviz_stats/utils.py
+++ b/src/arviz_stats/utils.py
@@ -183,6 +183,7 @@ class ELPDData:  # pylint: disable=too-many-ancestors, too-many-instance-attribu
     log_p: object = None
     log_q: object = None
     thin_factor: object = None
+    log_weights: DataArray = None
 
     def __str__(self):
         """Print elpd data in a user friendly way."""

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -673,7 +673,12 @@ def test_log_weights_storage(centered_eight):
     assert "obs" in loo_updated.log_weights
     assert loo_updated.log_weights["obs"].shape[0] >= 5
 
-    loo_with_weights = loo(centered_eight, pointwise=True, log_weights=loo_pw_true.log_weights)
+    loo_with_weights = loo(
+        centered_eight,
+        pointwise=True,
+        log_weights=loo_pw_true.log_weights,
+        pareto_k=loo_pw_true.pareto_k,
+    )
     assert loo_with_weights.log_weights is not None
     assert_array_equal(loo_with_weights.log_weights.values, loo_pw_true.log_weights.values)
 

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -97,6 +97,9 @@ def test_loo(centered_eight, pointwise):
     assert loo_data.warning is False
     assert loo_data.kind == "loo"
     assert loo_data.scale == "log"
+    assert loo_data.log_weights is not None
+    assert loo_data.log_weights.shape == (8, 4, 500)
+
     if pointwise:
         assert_almost_equal(
             loo_data.pareto_k, [0.43, 0.39, 0.49, 0.47, 0.44, 0.55, 0.31, 0.52], decimal=1
@@ -562,7 +565,7 @@ def test_loo_moment_match(datatree, loo_orig, moment_match_data):
     assert loo_mm.method == "loo_moment_match"
     mm_bad_k_count = np.sum(loo_mm.pareto_k.values > k_threshold)
     assert mm_bad_k_count <= orig_bad_k_count
-    assert loo_mm.elpd > loo_orig.elpd
+    assert loo_mm.elpd >= loo_orig.elpd
 
     assert hasattr(loo_mm, "p_loo_i"), "loo_mm object should have p_loo_i attribute"
     assert np.sum(loo_mm.p_loo_i.values) >= 0

--- a/tests/test_reloo.py
+++ b/tests/test_reloo.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 from .helpers import importorskip
 
@@ -219,25 +219,19 @@ def test_reloo_multidimensional(mock_2d_data):
 
 
 def test_reloo_with_log_weights(mock_wrapper):
-    result_without_weights = reloo(
-        mock_wrapper, loo_orig=None, k_threshold=0.7, pointwise=True, var_name="obs"
-    )
-
-    log_weights = result_without_weights.log_weights
-    assert log_weights is not None
+    loo_result = loo(mock_wrapper.idata_orig, pointwise=True, var_name="obs")
 
     result_with_weights = reloo(
         mock_wrapper,
-        loo_orig=None,
+        loo_orig=loo_result,
         k_threshold=0.7,
         pointwise=True,
-        log_weights=log_weights,
         var_name="obs",
     )
 
-    assert_almost_equal(result_with_weights.elpd, result_without_weights.elpd)
-    assert_almost_equal(result_with_weights.se, result_without_weights.se)
-    assert_almost_equal(result_with_weights.p, result_without_weights.p)
+    assert result_with_weights.elpd is not None and not np.isnan(result_with_weights.elpd)
+    assert result_with_weights.se is not None and not np.isnan(result_with_weights.se)
+    assert result_with_weights.p is not None and not np.isnan(result_with_weights.p)
 
 
 def test_reloo_log_weights_storage(mock_wrapper, high_k_loo_data):

--- a/tests/test_reloo.py
+++ b/tests/test_reloo.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
 import pytest
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from .helpers import importorskip
 
@@ -70,6 +71,7 @@ def high_k_loo_data(non_centered_eight):
         scale=loo_data.scale,
         elpd_i=loo_data.elpd_i.copy(),
         pareto_k=loo_data.pareto_k.copy(),
+        log_weights=loo_data.log_weights.copy() if loo_data.log_weights is not None else None,
     )
     loo_data_modified.pareto_k.values[loo_data_modified.pareto_k.values > 0.7] = 0.6
     loo_data_modified.pareto_k.values[[0, 2, 5]] = [0.8, 0.9, 1.1]
@@ -214,3 +216,47 @@ def test_reloo_multidimensional(mock_2d_data):
 
     unchanged_loc = {"school": "school_0", "measurement": "meas_0"}
     assert result.pareto_k.loc[unchanged_loc] == loo_modified.pareto_k.loc[unchanged_loc]
+
+
+def test_reloo_with_log_weights(mock_wrapper):
+    result_without_weights = reloo(
+        mock_wrapper, loo_orig=None, k_threshold=0.7, pointwise=True, var_name="obs"
+    )
+
+    log_weights = result_without_weights.log_weights
+    assert log_weights is not None
+
+    result_with_weights = reloo(
+        mock_wrapper,
+        loo_orig=None,
+        k_threshold=0.7,
+        pointwise=True,
+        log_weights=log_weights,
+        var_name="obs",
+    )
+
+    assert_almost_equal(result_with_weights.elpd, result_without_weights.elpd)
+    assert_almost_equal(result_with_weights.se, result_without_weights.se)
+    assert_almost_equal(result_with_weights.p, result_without_weights.p)
+
+
+def test_reloo_log_weights_storage(mock_wrapper, high_k_loo_data):
+    result_pw_true = reloo(mock_wrapper, loo_orig=high_k_loo_data, k_threshold=0.7, pointwise=True)
+
+    assert result_pw_true.log_weights is not None
+    bad_k_mask = high_k_loo_data.pareto_k > 0.7
+    assert np.all(np.isnan(result_pw_true.log_weights.values[bad_k_mask]))
+    good_k_mask = ~bad_k_mask
+    assert_array_almost_equal(
+        result_pw_true.log_weights.values[good_k_mask],
+        high_k_loo_data.log_weights.values[good_k_mask],
+    )
+
+    result_pw_false = reloo(
+        mock_wrapper, loo_orig=high_k_loo_data, k_threshold=0.7, pointwise=False
+    )
+
+    assert result_pw_false.log_weights is not None
+    assert_array_almost_equal(
+        result_pw_false.log_weights.values, high_k_loo_data.log_weights.values
+    )


### PR DESCRIPTION
This PR adds support for log weights throughout the `loo` module, allowing users to provide pre-computed smoothed log weights or pass an existing `ELPDData` object into the function enabling the storage and reuse of log weights across function calls.

### Functions Changed

Added `log_weights` parameter to:
  - `loo()` (just accepts pre-computed log weights, not ELPDData object)
  - `loo_subsample()`
  - `update_subsample()`
  - `loo_expectations()` 
  - `loo_pit()` 
  - `reloo()` 
  - `loo_metrics()` 

Note that `loo_moment_match` is not included here yet. Waiting to re-organize the function and then introduce a new argument for log weights.

### API Design

Log weights can be provided in two formats:

  - As a `DataArray` with the same shape as the log likelihood data
  - As an `ELPDData` object from a previous LOO-based computation
 
The LOO functions above now store computed log weights in the returned ELPDData object. All changes are fully backwards compatible, e.g., the `log_weights` parameter defaults to `None`.

---
Resolves: [#134](https://github.com/arviz-devs/arviz-stats/issues/134)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--156.org.readthedocs.build/en/156/

<!-- readthedocs-preview arviz-stats end -->