### PR TITLE
Add loo_kfold for exact K-fold cross validation 

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -61,6 +61,7 @@ you should jump to {ref}`array_stats_api` and read forward.
    arviz_stats.compare
    arviz_stats.loo
    arviz_stats.loo_approximate_posterior
+   arviz_stats.loo_kfold
    arviz_stats.loo_moment_match
    arviz_stats.loo_subsample
    arviz_stats.reloo

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -16,6 +16,7 @@ try:
         reloo,
         compare,
         SamplingWrapper,
+        loo_kfold,
     )
     from arviz_stats.psense import psense, psense_summary
     from arviz_stats.metrics import kl_divergence, metrics, r2_score, wasserstein

--- a/src/arviz_stats/loo/__init__.py
+++ b/src/arviz_stats/loo/__init__.py
@@ -1,4 +1,4 @@
-"""Pareto-smoothed importance sampling LOO (PSIS-LOO-CV) functions."""
+"""Pareto-smoothed importance sampling LOO (PSIS-LOO-CV) and K-fold cross-validation functions."""
 
 from arviz_stats.loo.loo import loo
 from arviz_stats.loo.loo_approximate_posterior import loo_approximate_posterior
@@ -9,6 +9,7 @@ from arviz_stats.loo.loo_moment_match import loo_moment_match
 from arviz_stats.loo.reloo import reloo
 from arviz_stats.loo.wrapper import SamplingWrapper
 from arviz_stats.loo.compare import compare, _calculate_ics
+from arviz_stats.loo.loo_kfold import loo_kfold
 
 __all__ = [
     "loo",
@@ -22,4 +23,5 @@ __all__ = [
     "reloo",
     "SamplingWrapper",
     "compare",
+    "loo_kfold",
 ]

--- a/src/arviz_stats/loo/helper_loo_kfold.py
+++ b/src/arviz_stats/loo/helper_loo_kfold.py
@@ -1,0 +1,381 @@
+"""Helper functions for K-fold cross-validation."""
+
+from collections import namedtuple
+
+import numpy as np
+from arviz_base import convert_to_datatree
+from xarray_einstats.stats import logsumexp
+
+from arviz_stats.loo.wrapper import SamplingWrapper
+from arviz_stats.utils import get_log_likelihood
+
+__all__ = [
+    "_prepare_kfold_inputs",
+    "_compute_kfold_results",
+    "_kfold_split_random",
+    "_kfold_split_stratified",
+    "_kfold_split_grouped",
+    "_extract_fold_data",
+    "_get_fold_indices",
+    "_combine_fold_elpds",
+    "_validate_k_value",
+    "_validate_array_length",
+    "_validate_fold_parameters",
+]
+
+FoldData = namedtuple("FoldData", ["train_indices", "test_indices", "fold_id"])
+
+KfoldResults = namedtuple("KfoldResults", ["elpds", "ps", "fold_fits"])
+
+KfoldInputs = namedtuple(
+    "KfoldInputs",
+    [
+        "log_likelihood",
+        "var_name",
+        "sample_dims",
+        "obs_dims",
+        "n_data_points",
+        "n_samples",
+        "folds",
+        "K",
+    ],
+)
+
+
+def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_by):
+    """Prepare inputs for kfold."""
+    data = convert_to_datatree(data)
+
+    if not isinstance(wrapper, SamplingWrapper):
+        raise TypeError("wrapper must be an instance of SamplingWrapper")
+
+    required_methods = ["sel_observations", "sample", "get_inference_data", "log_likelihood__i"]
+    not_implemented = wrapper.check_implemented_methods(required_methods)
+
+    if not_implemented:
+        raise ValueError(
+            f"The following methods must be implemented in the SamplingWrapper: {not_implemented}"
+        )
+
+    log_likelihood = get_log_likelihood(data, var_name)
+    var_name = log_likelihood.name if var_name is None else var_name
+    sample_dims = ["chain", "draw"]
+
+    obs_dims = [dim for dim in log_likelihood.dims if dim not in sample_dims]
+    n_data_points = int(np.prod([log_likelihood.sizes[dim] for dim in obs_dims]))
+    n_samples = int(np.prod([log_likelihood.sizes[dim] for dim in sample_dims]))
+
+    _validate_fold_parameters(folds, stratify_by, group_by)
+
+    if folds is not None:
+        folds = _validate_array_length(folds, n_data_points, "folds")
+        k = len(np.unique(folds))
+    elif stratify_by is not None:
+        stratify_by = _validate_array_length(stratify_by, n_data_points, "stratify_by")
+        folds = _kfold_split_stratified(k=k, x=stratify_by)
+    elif group_by is not None:
+        group_by = _validate_array_length(group_by, n_data_points, "group_by")
+        folds = _kfold_split_grouped(k=k, x=group_by)
+    else:
+        folds = _kfold_split_random(k=k, n=n_data_points)
+
+    return KfoldInputs(
+        log_likelihood=log_likelihood,
+        var_name=var_name,
+        sample_dims=sample_dims,
+        obs_dims=obs_dims,
+        n_data_points=n_data_points,
+        n_samples=n_samples,
+        folds=folds,
+        K=k,
+    )
+
+
+def _compute_kfold_results(kfold_inputs, wrapper, save_fits):
+    """Compute k-fold cross-validation results."""
+    ll_full = kfold_inputs.log_likelihood
+    lpds_full = logsumexp(ll_full, dims=kfold_inputs.sample_dims, b=1 / kfold_inputs.n_samples)
+
+    fold_indices = _get_fold_indices(kfold_inputs.folds, kfold_inputs.K)
+
+    elpd_unordered = []
+    fold_results = {} if save_fits else None
+
+    for fold_num in range(1, kfold_inputs.K + 1):
+        test_idx = fold_indices[fold_num]["test_indices"]
+        train_data, test_data = wrapper.sel_observations(test_idx)
+        fitted_model = wrapper.sample(train_data)
+        idata_k = wrapper.get_inference_data(fitted_model)
+        log_lik_k = wrapper.log_likelihood__i(test_data, idata_k)
+
+        if "chain" in log_lik_k.dims and "draw" in log_lik_k.dims:
+            sample_dims_k = ["chain", "draw"]
+        else:
+            sample_dims_k = [dim for dim in log_lik_k.dims if dim not in kfold_inputs.obs_dims]
+
+        n_samples_k = int(np.prod([log_lik_k.sizes[dim] for dim in sample_dims_k]))
+        elpd_k = logsumexp(log_lik_k, dims=sample_dims_k, b=1 / n_samples_k)
+        elpd_values = elpd_k.values if hasattr(elpd_k, "values") else elpd_k
+
+        if np.isscalar(elpd_values):
+            elpd_unordered.append((test_idx[0], float(elpd_values)))
+        else:
+            for i, idx in enumerate(test_idx):
+                elpd_unordered.append((idx, float(elpd_values[i])))
+
+        if save_fits:
+            fold_results[fold_num] = {"fit": idata_k, "test_indices": test_idx}
+
+    elpd_unordered.sort(key=lambda x: x[0])
+    elpds = np.array([x[1] for x in elpd_unordered])
+
+    lpds_ordered = lpds_full.values.flatten()
+    ps = lpds_ordered - elpds
+
+    return KfoldResults(elpds=elpds, ps=ps, fold_fits=fold_results)
+
+
+def _kfold_split_random(k=10, n=None):
+    """Split the data into K groups of equal size (or roughly equal size).
+
+    Parameters
+    ----------
+    k : int, default=10
+        The number of folds to use.
+    n : int
+        The number of observations in the data.
+
+    Returns
+    -------
+    ndarray
+        An integer vector of length n where each element is an index in 1:k.
+    """
+    if n is None:
+        raise ValueError("n must be provided")
+    if not isinstance(n, int | np.integer) or np.isnan(n):
+        raise ValueError("n must be an integer")
+    n = int(n)
+    k = _validate_k_value(k, n)
+
+    fold_size = n // k
+    remainder = n % k
+
+    folds = np.zeros(n, dtype=int)
+    start = 0
+    for i in range(k):
+        end = start + fold_size + (1 if i < remainder else 0)
+        folds[start:end] = i + 1
+        start = end
+
+    rng = np.random.default_rng()
+    perm = rng.permutation(n)
+    return folds[perm]
+
+
+def _kfold_split_stratified(k=10, x=None):
+    """Split observations into k groups ensuring relative category frequencies are preserved.
+
+    Parameters
+    ----------
+    k : int, default=10
+        The number of folds to use.
+    x : array-like
+        A discrete variable of length n with at least k levels (unique values).
+        Will be coerced to integer categories.
+
+    Returns
+    -------
+    ndarray
+        An integer vector of length n where each element is an index in 1:k.
+    """
+    if x is None:
+        raise ValueError("x must be provided")
+    x = np.asarray(x)
+    k = _validate_k_value(k, len(x))
+
+    unique_vals = np.unique(x)
+    x_int = np.zeros(len(x), dtype=int)
+    for i, val in enumerate(unique_vals):
+        x_int[x == val] = i
+
+    n_lev = len(unique_vals)
+    n = len(x)
+    xids = []
+
+    rng = np.random.default_rng()
+    for level in range(n_lev):
+        idx = np.where(x_int == level)[0]
+        if len(idx) > 1:
+            xids.extend(rng.permutation(idx))
+        else:
+            xids.extend(idx)
+
+    xids = np.array(xids)
+    bins = np.zeros(n, dtype=int)
+    bins[xids] = np.tile(np.arange(1, k + 1), int(np.ceil(n / k)))[:n]
+
+    return bins
+
+
+def _kfold_split_grouped(k=10, x=None):
+    """Split observations ensuring all observations from the same group stay together.
+
+    Parameters
+    ----------
+    k : int, default=10
+        The number of folds to use.
+    x : array-like
+        A grouping variable of length n. Will be coerced to integer categories.
+
+    Returns
+    -------
+    ndarray
+        An integer vector of length n where each element is an index in 1:k.
+    """
+    if x is None:
+        raise ValueError("x must be provided")
+    x = np.asarray(x)
+    k = _validate_k_value(k, len(x))
+
+    unique_vals = np.unique(x)
+    x_int = np.zeros(len(x), dtype=int)
+    for i, val in enumerate(unique_vals):
+        x_int[x == val] = i + 1
+
+    n_levels = len(unique_vals)
+
+    if n_levels < k:
+        raise ValueError("k must not be bigger than the number of levels/groups in x")
+
+    if n_levels == k:
+        return x_int
+
+    s1 = int(np.ceil(n_levels / k))
+    n_s2 = s1 * k - n_levels
+    n_s1 = k - n_s2
+
+    rng = np.random.default_rng()
+    perm = rng.permutation(n_levels) + 1
+
+    breaks = []
+    if n_s1 > 0:
+        breaks.extend(np.arange(s1 + 0.5, s1 * n_s1 + 0.5, s1))
+    if n_s2 > 0:
+        start = breaks[-1] if breaks else 0.5
+        breaks.extend(np.arange(start + s1 - 1, start + (s1 - 1) * n_s2, s1 - 1))
+
+    breaks = np.array(breaks)
+    groups = np.searchsorted(breaks, perm, side="right") + 1
+
+    bins = np.zeros(len(x), dtype=int)
+    for j in range(1, n_levels + 1):
+        bins[x_int == j] = groups[j - 1]
+
+    return bins
+
+
+def _extract_fold_data(data, fold_indices, train=True):
+    """Extract data for a specific fold.
+
+    Parameters
+    ----------
+    data : DataArray
+        The data array to extract from
+    fold_indices : array-like
+        Boolean mask or integer indices for the fold
+    train : bool, default=True
+        If True, extract training data (complement of fold_indices)
+        If False, extract test data (fold_indices)
+
+    Returns
+    -------
+    DataArray
+        The extracted data
+    """
+    if train:
+        mask = np.ones(data.shape[-1], dtype=bool)
+        mask[fold_indices] = False
+        return data.isel({data.dims[-1]: mask})
+    return data.isel({data.dims[-1]: fold_indices})
+
+
+def _get_fold_indices(fold_assignments, k):
+    """Get test indices for each fold.
+
+    Parameters
+    ----------
+    fold_assignments : ndarray
+        Fold assignments for each observation (1 to k)
+    k : int
+        Number of folds
+
+    Returns
+    -------
+    dict
+        Dictionary mapping fold number to test indices and test count
+    """
+    results = {}
+
+    for i in range(1, k + 1):
+        test_indices = np.where(fold_assignments == i)[0]
+        results[i] = {"test_indices": test_indices, "n_test": len(test_indices)}
+
+    return results
+
+
+def _combine_fold_elpds(fold_elpds, n_data_points):
+    """Combine ELPD values from all folds into final estimates.
+
+    Parameters
+    ----------
+    fold_elpds : list
+        List of ELPD values from each fold
+    n_data_points : int
+        Total number of data points
+
+    Returns
+    -------
+    dict
+        Combined results with estimates and standard errors
+    """
+    elpds = np.concatenate(fold_elpds)
+    elpd_kfold = np.sum(elpds)
+    se_elpd_kfold = np.sqrt(n_data_points * np.var(elpds))
+
+    return {"elpd_kfold": elpd_kfold, "se_elpd_kfold": se_elpd_kfold, "pointwise": elpds}
+
+
+def _validate_k_value(k, n, param_name="k"):
+    """Validate k parameter for k-fold splitting."""
+    if not isinstance(k, int | np.integer) or np.isnan(k):
+        raise ValueError(f"{param_name} must be an integer")
+    k = int(k)
+    if k <= 1:
+        raise ValueError(f"{param_name} must be greater than 1")
+    if k > n:
+        raise ValueError(f"{param_name} must not be greater than n ({n})")
+    return k
+
+
+def _validate_array_length(array, expected_length, param_name):
+    """Validate array length matches expected number of observations."""
+    if array is None:
+        raise ValueError(f"{param_name} must be provided")
+    array = np.asarray(array)
+    if len(array) != expected_length:
+        raise ValueError(
+            f"Length of {param_name} ({len(array)}) must match number of "
+            f"observations ({expected_length})"
+        )
+    return array
+
+
+def _validate_fold_parameters(folds, stratify_by, group_by):
+    """Validate fold parameter combinations."""
+    if folds is not None:
+        if stratify_by is not None or group_by is not None:
+            raise ValueError(
+                "Cannot use stratify_by or group_by when folds are explicitly provided"
+            )
+    elif stratify_by is not None and group_by is not None:
+        raise ValueError("Cannot use both stratify_by and group_by")

--- a/src/arviz_stats/loo/helper_loo_kfold.py
+++ b/src/arviz_stats/loo/helper_loo_kfold.py
@@ -26,7 +26,7 @@ __all__ = [
 
 FoldData = namedtuple("FoldData", ["train_indices", "test_indices", "fold_id"])
 
-KfoldResults = namedtuple("KfoldResults", ["elpds", "ps", "fold_fits"])
+KfoldResults = namedtuple("KfoldResults", ["elpds", "ps", "fold_fits", "elpd_i", "p_kfold_i"])
 
 KfoldInputs = namedtuple(
     "KfoldInputs",
@@ -133,7 +133,23 @@ def _compute_kfold_results(kfold_inputs, wrapper, save_fits):
     lpds_ordered = lpds_full.values.flatten()
     ps = lpds_ordered - elpds
 
-    return KfoldResults(elpds=elpds, ps=ps, fold_fits=fold_results)
+    obs_dim = kfold_inputs.obs_dims[-1] if kfold_inputs.obs_dims else "obs"
+
+    elpd_i = xr.DataArray(
+        elpds,
+        dims=[obs_dim],
+        coords={obs_dim: kfold_inputs.log_likelihood.coords[obs_dim]},
+    )
+
+    p_kfold_i = xr.DataArray(
+        ps,
+        dims=[obs_dim],
+        coords={obs_dim: kfold_inputs.log_likelihood.coords[obs_dim]},
+    )
+
+    return KfoldResults(
+        elpds=elpds, ps=ps, fold_fits=fold_results, elpd_i=elpd_i, p_kfold_i=p_kfold_i
+    )
 
 
 def _kfold_split_random(k=10, n=None):

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -1,4 +1,4 @@
-"""K-fold cross-validation for model assessment."""
+"""K-fold cross-validation."""
 
 import numpy as np
 from arviz_base import rcParams

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -14,9 +14,9 @@ from arviz_stats.utils import ELPDData
 
 def loo_kfold(
     data,
+    wrapper,
     pointwise=None,
     var_name=None,
-    wrapper=None,
     k=10,
     folds=None,
     stratify_by=None,
@@ -38,15 +38,15 @@ def loo_kfold(
     ----------
     data : DataTree or InferenceData
         Input data containing the posterior and log_likelihood groups from the full model fit.
+    wrapper : SamplingWrapper
+        An instance of SamplingWrapper class handling model refitting. The wrapper must
+        implement the following methods: sel_observations, sample, get_inference_data,
+        and log_likelihood__i.
     pointwise : bool, optional
         If True, return pointwise estimates. Defaults to ``rcParams["stats.ic_pointwise"]``.
     var_name : str, optional
         The name of the variable in log_likelihood group storing the pointwise log
         likelihood data to use for computation.
-    wrapper : SamplingWrapper
-        An instance of SamplingWrapper class handling model refitting. The wrapper must
-        implement the following methods: sel_observations, sample, get_inference_data,
-        and log_likelihood__i.
     k : int, default=10
         The number of folds for cross-validation. The data will be partitioned into k subsets
         of equal (or approximately equal) size.
@@ -96,7 +96,7 @@ def loo_kfold(
     -----
     When K equals the number of observations, this becomes exact leave-one-out
     cross-validation. Note that :func:`arviz_stats.loo` provides a much more efficient
-    approximation for that case and is recommended for large datasets.
+    approximation for that case and is recommended.
 
     See Also
     --------

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -92,6 +92,107 @@ def loo_kfold(
         - **fold_fits**: Dictionary containing fitted models for each fold
         - **fold_indices**: Dictionary containing test indices for each fold
 
+    Examples
+    --------
+    Unlike PSIS-LOO (which approximates LOO-CV), k-fold cross-validation refits
+    the model k times. So we need to tell ``loo_kfold`` how to refit the model.
+
+    This is done by creating an instance of the ``SamplingWrapper`` class that
+    implements four key methods: ``sel_observations``, ``sample``, ``get_inference_data``,
+    and ``log_likelihood__i``.
+
+    .. ipython::
+
+        In [1]: import numpy as np
+           ...: import xarray as xr
+           ...: from scipy import stats
+           ...: from arviz_base import load_arviz_data, from_dict
+           ...: from arviz_stats import loo_kfold
+           ...: from arviz_stats.loo import SamplingWrapper
+           ...:
+           ...: class CenteredEightWrapper(SamplingWrapper):
+           ...:     def __init__(self, idata):
+           ...:         super().__init__(model=None, idata_orig=idata)
+           ...:         self.y_obs = idata.observed_data["obs"].values
+           ...:         self.sigma = np.array([15, 10, 16, 11, 9, 11, 10, 18])
+           ...:
+           ...:     def sel_observations(self, idx):
+           ...:         all_idx = np.arange(len(self.y_obs))
+           ...:         train_idx = np.setdiff1d(all_idx, idx)
+           ...:
+           ...:         train_data = {
+           ...:             "y": self.y_obs[train_idx],
+           ...:             "sigma": self.sigma[train_idx],
+           ...:             "indices": train_idx
+           ...:         }
+           ...:         test_data = {
+           ...:             "y": self.y_obs[idx],
+           ...:             "sigma": self.sigma[idx],
+           ...:             "indices": idx
+           ...:         }
+           ...:         return train_data, test_data
+           ...:
+           ...:     def sample(self, modified_observed_data):
+           ...:         # (Simplified version where we normally would use the actual sampler)
+           ...:         train_y = modified_observed_data["y"]
+           ...:         n = 1000
+           ...:         mu = np.random.normal(train_y.mean(), 5, n)
+           ...:         tau = np.abs(np.random.normal(10, 2, n))
+           ...:         return {"mu": mu, "tau": tau}
+           ...:
+           ...:     def get_inference_data(self, fitted_model):
+           ...:         posterior = {
+           ...:             "mu": fitted_model["mu"].reshape(1, -1),
+           ...:             "tau": fitted_model["tau"].reshape(1, -1)
+           ...:         }
+           ...:         return from_dict({"posterior": posterior})
+           ...:
+           ...:     def log_likelihood__i(self, excluded_obs, idata__i):
+           ...:         test_y = excluded_obs["y"]
+           ...:         test_sigma = excluded_obs["sigma"]
+           ...:         mu = idata__i.posterior["mu"].values.flatten()
+           ...:         tau = idata__i.posterior["tau"].values.flatten()
+           ...:
+           ...:         var_total = tau[:, np.newaxis] ** 2 + test_sigma**2
+           ...:         log_lik = stats.norm.logpdf(
+           ...:             test_y, loc=mu[:, np.newaxis], scale=np.sqrt(var_total)
+           ...:         )
+           ...:
+           ...:         dims = ["chain", "school", "draw"]
+           ...:         coords = {"school": excluded_obs["indices"]}
+           ...:         return xr.DataArray(
+           ...:             log_lik.T[np.newaxis, :, :], dims=dims, coords=coords
+           ...:         )
+
+    Now let's run k-fold cross-validation. With k=4, we'll refit the model 4 times,
+    each time leaving out 2 schools for testing:
+
+    .. ipython::
+
+        In [2]: data = load_arviz_data("centered_eight")
+           ...: wrapper = CenteredEightWrapper(data)
+           ...: kfold_results = loo_kfold(data, wrapper, k=4, pointwise=True)
+           ...: kfold_results
+
+    Sometimes we want more control over how the data is split. For instance,
+    if you have imbalanced groups, stratified k-fold ensures each fold has
+    a similar distribution:
+
+    .. ipython::
+
+        In [3]: strata = (data.observed_data["obs"] > 5).astype(int)
+           ...: kfold_strat = loo_kfold(data, wrapper, k=4, stratify_by=strata)
+           ...: kfold_strat
+
+    Moreover, sometimes we want to group observations together. For instance,
+    if we have repeated measurements from the same subject, we can group by subject:
+
+    .. ipython::
+
+        In [4]: groups = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims="school")
+           ...: kfold_group = loo_kfold(data, wrapper, k=4, group_by=groups)
+           ...: kfold_group
+
     Notes
     -----
     When K equals the number of observations, this becomes exact leave-one-out

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -1,0 +1,149 @@
+"""K-fold cross-validation for model assessment."""
+
+import numpy as np
+import xarray as xr
+from arviz_base import rcParams
+
+from arviz_stats.loo.helper_loo_kfold import (
+    _combine_fold_elpds,
+    _compute_kfold_results,
+    _prepare_kfold_inputs,
+)
+from arviz_stats.utils import ELPDData
+
+
+def loo_kfold(
+    data,
+    pointwise=None,
+    var_name=None,
+    wrapper=None,
+    k=10,
+    folds=None,
+    stratify_by=None,
+    group_by=None,
+    save_fits=False,
+):
+    """Perform exact K-fold cross-validation.
+
+    K-fold cross-validation evaluates model predictive accuracy by partitioning the data
+    into K complementary subsets (folds), then iteratively refitting the model K times,
+    each time holding out one fold as a test set and training on the remaining K-1 folds.
+
+    This method provides an unbiased estimate of model performance by ensuring each
+    observation is used exactly once for testing. Unlike PSIS-LOO-CV (Pareto-smoothed
+    importance sampling leave-one-out cross-validation), which approximates cross-validation
+    efficiently, K-fold requires actual model refitting but yields exact results.
+
+    When K equals the number of observations, this becomes exact leave-one-out
+    cross-validation, though :func:`arviz_stats.loo` provides a much more efficient
+    approximation for that case.
+
+    Parameters
+    ----------
+    data : DataTree or InferenceData
+        Input data containing the posterior and log_likelihood groups from the full model fit.
+    pointwise : bool, optional
+        If True, return pointwise estimates. Defaults to ``rcParams["stats.ic_pointwise"]``.
+    var_name : str, optional
+        The name of the variable in log_likelihood group storing the pointwise log
+        likelihood data to use for computation.
+    wrapper : SamplingWrapper
+        An instance of SamplingWrapper class handling model refitting. The wrapper must
+        implement the following methods: sel_observations, sample, get_inference_data,
+        and log_likelihood__i.
+    k : int, default=10
+        The number of folds for cross-validation. The data will be partitioned into k subsets
+        of equal (or approximately equal) size.
+    folds : array-like, optional
+        An optional integer array with one element per observation in the data. Each element
+        should be an integer in 1:k indicating which fold the observation belongs to.
+        If not provided, data will be randomly partitioned into k folds.
+    stratify_by : array-like, optional
+        A categorical variable to use for stratified K-fold splitting. When provided,
+        the folds will be created to preserve the relative frequencies of the categories.
+        Cannot be used together with `folds` or `group_by`.
+    group_by : array-like, optional
+        A grouping variable to use for grouped K-fold splitting. When provided,
+        all observations from the same group will be kept together in the same fold.
+        Cannot be used together with `folds` or `stratify_by`.
+    save_fits : bool, default=False
+        If True, store the fitted models and fold indices in the returned object.
+
+    Returns
+    -------
+    ELPDData
+        Object with the following attributes:
+
+        - **elpd**: expected log pointwise predictive density
+        - **se**: standard error of the elpd
+        - **p**: effective number of parameters
+        - **n_samples**: number of samples per fold
+        - **n_data_points**: number of data points
+        - **warning**: True if any issues occurred during fitting
+        - **elpd_i**: pointwise predictive accuracy (if ``pointwise=True``)
+        - **pareto_k**: None (not applicable for k-fold)
+        - **scale**: "log"
+
+        Additional attributes when ``save_fits=True``:
+
+        - **fold_fits**: Dictionary containing fitted models for each fold
+        - **fold_indices**: Dictionary containing test indices for each fold
+
+    See Also
+    --------
+    loo : Pareto-smoothed importance sampling LOO-CV
+    SamplingWrapper : Base class for implementing sampling wrappers
+
+    References
+    ----------
+
+    .. [1] Vehtari et al. *Practical Bayesian model evaluation using leave-one-out cross-validation
+        and WAIC*. Statistics and Computing. 27(5) (2017) https://doi.org/10.1007/s11222-016-9696-4
+        arXiv preprint https://arxiv.org/abs/1507.04544.
+
+    .. [2] Vehtari et al. *Pareto Smoothed Importance Sampling*.
+        Journal of Machine Learning Research, 25(72) (2024) https://jmlr.org/papers/v25/19-556.html
+        arXiv preprint https://arxiv.org/abs/1507.02646
+    """
+    pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
+
+    kfold_inputs = _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_by)
+    kfold_results = _compute_kfold_results(kfold_inputs, wrapper, save_fits)
+
+    if pointwise:
+        pointwise_data = np.column_stack([kfold_results.elpds, kfold_results.ps])
+        obs_dim = kfold_inputs.obs_dims[-1] if kfold_inputs.obs_dims else "observation"
+
+        pointwise_df = xr.DataArray(
+            pointwise_data,
+            dims=[obs_dim, "metric"],
+            coords={
+                obs_dim: kfold_inputs.log_likelihood.coords[obs_dim],
+                "metric": ["elpd_loo_kfold", "p_loo_kfold"],
+            },
+        )
+    else:
+        pointwise_df = None
+
+    combined_results = _combine_fold_elpds([kfold_results.elpds], kfold_inputs.n_data_points)
+    elpd_sum = combined_results["elpd_kfold"]
+    se_elpd = combined_results["se_elpd_kfold"]
+    p_sum = np.sum(kfold_results.ps)
+
+    elpd_data = ELPDData(
+        kind="loo_kfold",
+        elpd=elpd_sum,
+        se=se_elpd,
+        p=p_sum,
+        n_samples=kfold_inputs.n_samples,
+        n_data_points=kfold_inputs.n_data_points,
+        scale="log",
+        warning=False,
+        good_k=None,
+        elpd_i=pointwise_df if pointwise else None,
+        pareto_k=None,
+    )
+
+    if save_fits:
+        elpd_data.fold_fits = kfold_results.fold_fits
+    return elpd_data

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -34,10 +34,6 @@ def loo_kfold(
     importance sampling leave-one-out cross-validation), which approximates cross-validation
     efficiently, K-fold requires actual model refitting but yields exact results.
 
-    When K equals the number of observations, this becomes exact leave-one-out
-    cross-validation, though :func:`arviz_stats.loo` provides a much more efficient
-    approximation for that case.
-
     Parameters
     ----------
     data : DataTree or InferenceData
@@ -88,6 +84,12 @@ def loo_kfold(
 
         - **fold_fits**: Dictionary containing fitted models for each fold
         - **fold_indices**: Dictionary containing test indices for each fold
+
+    Notes
+    -----
+    When K equals the number of observations, this becomes exact leave-one-out
+    cross-validation. Note that :func:`arviz_stats.loo` provides a much more efficient
+    approximation for that case and is recommended for large datasets.
 
     See Also
     --------

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -50,18 +50,25 @@ def loo_kfold(
     k : int, default=10
         The number of folds for cross-validation. The data will be partitioned into k subsets
         of equal (or approximately equal) size.
-    folds : array-like, optional
-        An optional integer array with one element per observation in the data. Each element
-        should be an integer in 1:k indicating which fold the observation belongs to.
-        If not provided, data will be randomly partitioned into k folds.
-    stratify_by : array-like, optional
-        A categorical variable to use for stratified K-fold splitting. When provided,
-        the folds will be created to preserve the relative frequencies of the categories.
-        Cannot be used together with `folds` or `group_by`.
-    group_by : array-like, optional
-        A grouping variable to use for grouped K-fold splitting. When provided,
-        all observations from the same group will be kept together in the same fold.
-        Cannot be used together with `folds` or `stratify_by`.
+    folds : array or DataArray, optional
+        An optional integer array or DataArray with one element per observation in the data.
+        Each element should be an integer from 1 to k indicating which fold the observation
+        belongs to. For example, with k=4 and 8 observations, one possible assignment is
+        [1,1,2,2,3,3,4,4] to put the first two observations in fold 1, next two in fold 2, etc.
+        If not provided, data will be randomly partitioned into k folds of approximately
+        equal size. DataArray inputs will be automatically flattened to 1D.
+    stratify_by : array or DataArray, optional
+        A categorical variable to use for stratified K-fold splitting. For example, with
+        8 observations where [0,0,1,1,0,0,1,1] indicates two categories (0 and 1), the
+        algorithm ensures each fold contains approximately the same 50/50 split of 0s and 1s
+        as the full dataset. Cannot be used together with `folds` or `group_by`. DataArray
+        inputs will be automatically flattened to 1D.
+    group_by : array or DataArray, optional
+        A grouping variable to use for grouped K-fold splitting. For example, with
+        [1,1,2,2,3,3,4,4] representing 4 subjects with 2 observations each, all observations
+        from subject 1 will be placed in the same fold, all from subject 2 in the same fold,
+        etc. This ensures related observations stay together. Cannot be used together with
+        `folds` or `stratify_by`. DataArray inputs will be automatically flattened to 1D.
     save_fits : bool, default=False
         If True, store the fitted models and fold indices in the returned object.
 

--- a/tests/test_helper_loo_kfold.py
+++ b/tests/test_helper_loo_kfold.py
@@ -1,0 +1,373 @@
+# pylint: disable=redefined-outer-name, unused-import
+# ruff: noqa: F811
+"""Test helper functions for k-fold cross-validation."""
+
+import numpy as np
+import pytest
+
+from .helpers import datatree, importorskip  # noqa: F401
+
+azb = importorskip("arviz_base")
+xr = importorskip("xarray")
+
+from arviz_stats.loo import SamplingWrapper
+from arviz_stats.loo.helper_loo_kfold import (
+    _combine_fold_elpds,
+    _extract_fold_data,
+    _get_fold_indices,
+    _kfold_split_grouped,
+    _kfold_split_random,
+    _kfold_split_stratified,
+    _prepare_kfold_inputs,
+    _validate_array_length,
+    _validate_fold_parameters,
+    _validate_k_value,
+)
+
+
+@pytest.fixture(name="simple_data", scope="session")
+def fixture_simple_data():
+    return azb.load_arviz_data("centered_eight")
+
+
+@pytest.fixture
+def simple_wrapper():
+    class SimpleWrapper(SamplingWrapper):
+        def __init__(self):
+            super().__init__(model=None, idata_orig=None)
+
+        def sel_observations(self, idx):
+            return {"train": idx}, {"test": idx}
+
+        def sample(self, modified_observed_data):
+            return {"data": modified_observed_data}
+
+        def get_inference_data(self, fitted_model):
+            return fitted_model
+
+        def log_likelihood__i(self, excluded_obs, idata__i):
+            return np.random.randn(10)
+
+    return SimpleWrapper()
+
+
+@pytest.fixture
+def sample_array():
+    return np.array([1, 2, 3, 4, 5])
+
+
+@pytest.fixture
+def sample_dataarray():
+    return xr.DataArray([1, 2, 3, 4, 5], dims=["obs"])
+
+
+@pytest.fixture
+def fold_assignments():
+    return np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+
+@pytest.fixture
+def stratified_data():
+    return np.array([0, 0, 0, 0, 1, 1, 1, 1])
+
+
+@pytest.fixture
+def grouped_data():
+    return np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+
+@pytest.mark.parametrize(
+    "k,n,expected",
+    [
+        (5, 10, 5),
+        (2, 100, 2),
+        (10, 10, 10),
+    ],
+)
+def test_validate_k_value_valid(k, n, expected):
+    assert _validate_k_value(k, n) == expected
+
+
+@pytest.mark.parametrize(
+    "k,n,error_msg",
+    [
+        ("not_int", 10, "k must be an integer"),
+        (2.5, 10, "k must be an integer"),
+        (1, 10, "k must be greater than 1"),
+        (11, 10, "k must not be greater than n"),
+    ],
+)
+def test_validate_k_value_invalid(k, n, error_msg):
+    with pytest.raises(ValueError, match=error_msg):
+        _validate_k_value(k, n)
+
+
+def test_validate_array_length_numpy(sample_array):
+    result = _validate_array_length(sample_array, 5, "test_array")
+    np.testing.assert_array_equal(result, sample_array)
+
+
+def test_validate_array_length_xarray(sample_dataarray):
+    result = _validate_array_length(sample_dataarray, 5, "test_da")
+    np.testing.assert_array_equal(result, sample_dataarray.values)
+
+
+@pytest.mark.parametrize(
+    "array,length,param_name,error_pattern",
+    [
+        (None, 5, "test_array", "test_array must be provided"),
+        ([1, 2, 3], 5, "test_array", "Length of test_array"),
+    ],
+)
+def test_validate_array_length_errors(array, length, param_name, error_pattern):
+    with pytest.raises(ValueError, match=error_pattern):
+        _validate_array_length(array, length, param_name)
+
+
+@pytest.mark.parametrize(
+    "folds,stratify_by,group_by",
+    [
+        (None, None, None),
+        ([1, 2, 3], None, None),
+        (None, [1, 2], None),
+        (None, None, [1, 2]),
+    ],
+)
+def test_validate_fold_parameters_valid(folds, stratify_by, group_by):
+    _validate_fold_parameters(folds, stratify_by, group_by)
+
+
+@pytest.mark.parametrize(
+    "folds,stratify_by,group_by,error_msg",
+    [
+        (
+            [1, 2],
+            [1, 2],
+            None,
+            "Cannot use stratify_by or group_by when folds are explicitly provided",
+        ),
+        (
+            [1, 2],
+            None,
+            [1, 2],
+            "Cannot use stratify_by or group_by when folds are explicitly provided",
+        ),
+        (None, [1, 2], [1, 2], "Cannot use both stratify_by and group_by"),
+    ],
+)
+def test_validate_fold_parameters_invalid(folds, stratify_by, group_by, error_msg):
+    with pytest.raises(ValueError, match=error_msg):
+        _validate_fold_parameters(folds, stratify_by, group_by)
+
+
+@pytest.mark.parametrize(
+    "n,k",
+    [
+        (20, 4),
+        (10, 5),
+        (8, 2),
+    ],
+)
+def test_kfold_split_random(n, k):
+    folds = _kfold_split_random(k=k, n=n)
+
+    assert len(folds) == n
+    assert set(folds) == set(range(1, k + 1))
+
+    fold_sizes = [np.sum(folds == i) for i in range(1, k + 1)]
+    assert all(n // k <= size <= n // k + 1 for size in fold_sizes)
+
+
+def test_kfold_split_random_errors():
+    with pytest.raises(ValueError, match="n must be provided"):
+        _kfold_split_random(k=5)
+
+    with pytest.raises(ValueError, match="n must be an integer"):
+        _kfold_split_random(k=5, n="not_int")
+
+    with pytest.raises(ValueError, match="k must not be greater than n"):
+        _kfold_split_random(k=10, n=5)
+
+
+@pytest.mark.parametrize("k", [2, 4])
+def test_kfold_split_stratified(stratified_data, k):
+    folds = _kfold_split_stratified(k=k, x=stratified_data)
+
+    assert len(folds) == len(stratified_data)
+    assert set(folds) == set(range(1, k + 1))
+
+    for fold in range(1, k + 1):
+        fold_mask = folds == fold
+        assert np.sum(stratified_data[fold_mask] == 0) >= 1
+        assert np.sum(stratified_data[fold_mask] == 1) >= 1
+
+
+def test_kfold_split_stratified_errors():
+    with pytest.raises(ValueError, match="x must be provided"):
+        _kfold_split_stratified(k=5)
+
+
+def test_kfold_split_grouped(grouped_data):
+    k = 2
+    folds = _kfold_split_grouped(k=k, x=grouped_data)
+
+    assert len(folds) == len(grouped_data)
+    assert set(folds) == {1, 2}
+
+    for group in [1, 2, 3, 4]:
+        group_mask = grouped_data == group
+        group_folds = folds[group_mask]
+        assert len(set(group_folds)) == 1
+
+
+def test_kfold_split_grouped_many_groups():
+    x_many_groups = np.repeat(np.arange(10), 3)
+    k = 3
+    folds = _kfold_split_grouped(k=k, x=x_many_groups)
+    assert len(set(folds)) <= k
+    assert len(set(folds)) >= 1
+    assert min(folds) >= 1
+    assert max(folds) <= k
+
+    for group_id in np.unique(x_many_groups):
+        group_mask = x_many_groups == group_id
+        group_folds = folds[group_mask]
+        assert len(set(group_folds)) == 1
+
+
+def test_kfold_split_grouped_errors():
+    with pytest.raises(ValueError, match="x must be provided"):
+        _kfold_split_grouped(k=5)
+
+    with pytest.raises(ValueError, match="k must not be bigger than the number of levels"):
+        _kfold_split_grouped(k=3, x=np.array([1, 1, 2, 2]))
+
+
+@pytest.mark.parametrize("train", [True, False])
+def test_extract_fold_data(sample_dataarray, train):
+    fold_indices = np.array([2, 3, 4])
+
+    result = _extract_fold_data(sample_dataarray, fold_indices, train=train)
+
+    if train:
+        assert result.shape == (2,)
+        np.testing.assert_array_equal(result.values, [1, 2])
+    else:
+        assert result.shape == (3,)
+        np.testing.assert_array_equal(result.values, [3, 4, 5])
+
+
+def test_get_fold_indices(fold_assignments):
+    k = 4
+    fold_indices = _get_fold_indices(fold_assignments, k)
+
+    assert len(fold_indices) == k
+
+    expected_indices = {
+        1: [0, 1],
+        2: [2, 3],
+        3: [4, 5],
+        4: [6, 7],
+    }
+
+    for i in range(1, k + 1):
+        assert fold_indices[i]["test_indices"].tolist() == expected_indices[i]
+        assert fold_indices[i]["n_test"] == 2
+
+
+def test_combine_fold_elpds():
+    fold_elpds = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+    n_data_points = 4
+
+    result = _combine_fold_elpds(fold_elpds, n_data_points)
+
+    assert result["elpd_kfold"] == 10.0
+    np.testing.assert_array_equal(result["pointwise"], [1.0, 2.0, 3.0, 4.0])
+
+    expected_se = np.sqrt(4 * np.var([1.0, 2.0, 3.0, 4.0]))
+    assert np.isclose(result["se_elpd_kfold"], expected_se)
+
+
+def test_prepare_kfold_inputs(simple_data, simple_wrapper):
+    result = _prepare_kfold_inputs(
+        data=simple_data,
+        var_name=None,
+        wrapper=simple_wrapper,
+        k=4,
+        folds=None,
+        stratify_by=None,
+        group_by=None,
+    )
+
+    assert result.log_likelihood is not None
+    assert result.n_data_points == 8
+    assert result.k == 4
+    assert len(result.folds) == 8
+    assert set(result.folds) == {1, 2, 3, 4}
+
+
+def test_prepare_kfold_inputs_invalid_wrapper(simple_data):
+    with pytest.raises(TypeError, match="wrapper must be an instance of SamplingWrapper"):
+        _prepare_kfold_inputs(
+            data=simple_data,
+            var_name=None,
+            wrapper="not_a_wrapper",
+            k=4,
+            folds=None,
+            stratify_by=None,
+            group_by=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "custom_folds",
+    [
+        np.array([1, 1, 2, 2, 3, 3, 4, 4]),
+        np.array([1, 2, 1, 2, 1, 2, 1, 2]),
+    ],
+)
+def test_prepare_kfold_inputs_with_custom_folds(simple_data, simple_wrapper, custom_folds):
+    result = _prepare_kfold_inputs(
+        data=simple_data,
+        var_name=None,
+        wrapper=simple_wrapper,
+        k=None,
+        folds=custom_folds,
+        stratify_by=None,
+        group_by=None,
+    )
+
+    assert result.k == len(np.unique(custom_folds))
+    np.testing.assert_array_equal(result.folds, custom_folds)
+
+
+def test_prepare_kfold_inputs_with_stratify(simple_data, simple_wrapper):
+    strata = np.array([0, 0, 1, 1, 0, 0, 1, 1])
+    result = _prepare_kfold_inputs(
+        data=simple_data,
+        var_name=None,
+        wrapper=simple_wrapper,
+        k=4,
+        folds=None,
+        stratify_by=strata,
+        group_by=None,
+    )
+
+    assert result.k == 4
+    assert len(result.folds) == 8
+
+
+def test_prepare_kfold_inputs_with_groups(simple_data, simple_wrapper):
+    groups = np.array([1, 1, 2, 2, 3, 3, 4, 4])
+    result = _prepare_kfold_inputs(
+        data=simple_data,
+        var_name=None,
+        wrapper=simple_wrapper,
+        k=2,
+        folds=None,
+        stratify_by=None,
+        group_by=groups,
+    )
+
+    assert result.k == 2
+    assert len(result.folds) == 8

--- a/tests/test_loo_kfold.py
+++ b/tests/test_loo_kfold.py
@@ -148,6 +148,42 @@ def test_loo_kfold_save_fits(centered_eight, mock_wrapper):
         assert "test_indices" in kfold_data.fold_fits[k]
 
 
+def test_loo_kfold_dataarray_inputs(centered_eight, mock_wrapper):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    folds_da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=["school"])
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=True, wrapper=mock_wrapper, folds=folds_da
+    )
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 4
+
+    mock_wrapper.fit_count = 0
+    strata_da = xr.DataArray([0, 0, 1, 1, 0, 0, 1, 1], dims=["school"])
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, stratify_by=strata_da
+    )
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 4
+
+    mock_wrapper.fit_count = 0
+    groups_da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=["school"])
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=2, group_by=groups_da
+    )
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 2
+
+    mock_wrapper.fit_count = 0
+    folds_2d = xr.DataArray([[1, 2], [1, 2], [3, 4], [3, 4]], dims=["school", "county"])
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, folds=folds_2d
+    )
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 4
+
+
 def test_loo_kfold_errors(centered_eight, mock_wrapper):
     with pytest.raises(TypeError, match="wrapper must be an instance of SamplingWrapper"):
         loo_kfold(data=centered_eight, wrapper="not_a_wrapper")

--- a/tests/test_loo_kfold.py
+++ b/tests/test_loo_kfold.py
@@ -1,0 +1,177 @@
+# pylint: disable=redefined-outer-name, unused-import
+# ruff: noqa: F811
+"""Test k-fold cross-validation."""
+
+import numpy as np
+import pytest
+
+from .helpers import datatree, importorskip  # noqa: F401
+
+azb = importorskip("arviz_base")
+xr = importorskip("xarray")
+
+from arviz_stats import loo_kfold
+from arviz_stats.loo import SamplingWrapper
+from arviz_stats.utils import ELPDData
+
+
+@pytest.fixture(name="centered_eight", scope="session")
+def fixture_centered_eight():
+    return azb.load_arviz_data("centered_eight")
+
+
+@pytest.fixture
+def mock_wrapper(centered_eight):
+    class MockSamplingWrapper(SamplingWrapper):
+        def __init__(self, idata):
+            super().__init__(model=None, idata_orig=idata)
+            self.fit_count = 0
+            self.test_indices_history = []
+
+        def sel_observations(self, idx):
+            train_data = {"n": len(idx)}
+            test_data = {"indices": idx}
+            self.test_indices_history.append(idx)
+            return train_data, test_data
+
+        def sample(self, modified_observed_data):
+            self.fit_count += 1
+            return {"model_id": self.fit_count, "data": modified_observed_data}
+
+        def get_inference_data(self, fitted_model):
+            return self.idata_orig
+
+        def log_likelihood__i(self, excluded_obs, idata__i):
+            log_lik = idata__i.log_likelihood["obs"]
+            test_idx = excluded_obs["indices"]
+            return log_lik.isel(school=test_idx)
+
+    return MockSamplingWrapper(centered_eight)
+
+
+@pytest.mark.parametrize("pointwise", [True, False])
+def test_loo_kfold(centered_eight, mock_wrapper, pointwise):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    kfold_data = loo_kfold(data=centered_eight, pointwise=pointwise, wrapper=mock_wrapper, k=4)
+
+    assert isinstance(kfold_data, ELPDData)
+    assert kfold_data.kind == "loo_kfold"
+    assert kfold_data.n_data_points == 8
+    assert kfold_data.n_samples == 2000
+    assert kfold_data.scale == "log"
+    assert kfold_data.warning is False
+    assert kfold_data.good_k is None
+    assert kfold_data.pareto_k is None
+
+    assert mock_wrapper.fit_count == 4
+
+    if pointwise:
+        assert kfold_data.elpd_i is not None
+        assert kfold_data.elpd_i.shape == (8, 2)
+        assert list(kfold_data.elpd_i.coords["metric"].values) == [
+            "elpd_loo_kfold",
+            "p_loo_kfold",
+        ]
+    else:
+        assert kfold_data.elpd_i is None
+
+
+@pytest.mark.parametrize("k", [2, 5, 8])
+def test_loo_kfold_different_k(centered_eight, mock_wrapper, k):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    kfold_data = loo_kfold(data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=k)
+
+    assert mock_wrapper.fit_count == k
+    assert isinstance(kfold_data.elpd, float)
+    assert isinstance(kfold_data.se, float)
+    assert isinstance(kfold_data.p, float)
+
+
+def test_loo_kfold_custom_folds(centered_eight, mock_wrapper):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    folds = np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+    kfold_data = loo_kfold(data=centered_eight, pointwise=True, wrapper=mock_wrapper, folds=folds)
+
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 4
+
+
+def test_loo_kfold_stratified(centered_eight, mock_wrapper):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    strata = np.array([0, 0, 1, 1, 0, 0, 1, 1])
+
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, stratify_by=strata
+    )
+
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 4
+
+
+def test_loo_kfold_grouped(centered_eight, mock_wrapper):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    groups = np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=2, group_by=groups
+    )
+
+    assert kfold_data.kind == "loo_kfold"
+    assert mock_wrapper.fit_count == 2
+
+
+def test_loo_kfold_save_fits(centered_eight, mock_wrapper):
+    mock_wrapper.fit_count = 0
+    mock_wrapper.test_indices_history = []
+
+    kfold_data = loo_kfold(
+        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, save_fits=True
+    )
+
+    assert hasattr(kfold_data, "fold_fits")
+    assert len(kfold_data.fold_fits) == 4
+
+    for k in range(1, 5):
+        assert k in kfold_data.fold_fits
+        assert "fit" in kfold_data.fold_fits[k]
+        assert "test_indices" in kfold_data.fold_fits[k]
+
+
+def test_loo_kfold_errors(centered_eight, mock_wrapper):
+    with pytest.raises(TypeError, match="wrapper must be an instance of SamplingWrapper"):
+        loo_kfold(data=centered_eight, wrapper="not_a_wrapper")
+
+    match_msg = "Cannot use stratify_by or group_by when folds are explicitly provided"
+    with pytest.raises(ValueError, match=match_msg):
+        loo_kfold(
+            data=centered_eight,
+            wrapper=mock_wrapper,
+            folds=[1, 2, 1, 2, 1, 2, 1, 2],
+            stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
+        )
+
+    with pytest.raises(ValueError, match="Cannot use both stratify_by and group_by"):
+        loo_kfold(
+            data=centered_eight,
+            wrapper=mock_wrapper,
+            stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
+            group_by=[1, 1, 2, 2, 3, 3, 4, 4],
+        )
+
+    with pytest.raises(ValueError, match="Length of stratify_by"):
+        loo_kfold(
+            data=centered_eight,
+            wrapper=mock_wrapper,
+            stratify_by=[0, 1, 0],
+        )

--- a/tests/test_loo_kfold.py
+++ b/tests/test_loo_kfold.py
@@ -173,13 +173,13 @@ def test_loo_kfold(centered_eight, fresh_wrapper, pointwise):
 
     if pointwise:
         assert kfold_data.elpd_i is not None
-        assert kfold_data.elpd_i.shape == (8, 2)
-        assert list(kfold_data.elpd_i.coords["metric"].values) == [
-            "elpd_loo_kfold",
-            "p_loo_kfold",
-        ]
+        assert kfold_data.elpd_i.shape == (8,)
+        assert hasattr(kfold_data, "p_kfold_i")
+        assert kfold_data.p_kfold_i is not None
+        assert kfold_data.p_kfold_i.shape == (8,)
     else:
         assert kfold_data.elpd_i is None
+        assert not hasattr(kfold_data, "p_kfold_i")
 
 
 @pytest.mark.parametrize("k", [2, 5, 8])

--- a/tests/test_loo_kfold.py
+++ b/tests/test_loo_kfold.py
@@ -21,6 +21,21 @@ def fixture_centered_eight():
 
 
 @pytest.fixture
+def custom_folds():
+    return np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+
+@pytest.fixture
+def strata():
+    return np.array([0, 0, 1, 1, 0, 0, 1, 1])
+
+
+@pytest.fixture
+def groups():
+    return np.array([1, 1, 2, 2, 3, 3, 4, 4])
+
+
+@pytest.fixture
 def mock_wrapper(centered_eight):
     class CenteredEightWrapper(SamplingWrapper):
         def __init__(self, idata):
@@ -135,12 +150,16 @@ def mock_wrapper(centered_eight):
     return CenteredEightWrapper(centered_eight)
 
 
-@pytest.mark.parametrize("pointwise", [True, False])
-def test_loo_kfold(centered_eight, mock_wrapper, pointwise):
+@pytest.fixture
+def fresh_wrapper(mock_wrapper):
     mock_wrapper.fit_count = 0
     mock_wrapper.test_indices_history = []
+    return mock_wrapper
 
-    kfold_data = loo_kfold(data=centered_eight, pointwise=pointwise, wrapper=mock_wrapper, k=4)
+
+@pytest.mark.parametrize("pointwise", [True, False])
+def test_loo_kfold(centered_eight, fresh_wrapper, pointwise):
+    kfold_data = loo_kfold(data=centered_eight, pointwise=pointwise, wrapper=fresh_wrapper, k=4)
 
     assert isinstance(kfold_data, ELPDData)
     assert kfold_data.kind == "loo_kfold"
@@ -150,8 +169,7 @@ def test_loo_kfold(centered_eight, mock_wrapper, pointwise):
     assert kfold_data.warning is False
     assert kfold_data.good_k is None
     assert kfold_data.pareto_k is None
-
-    assert mock_wrapper.fit_count == 4
+    assert fresh_wrapper.fit_count == 4
 
     if pointwise:
         assert kfold_data.elpd_i is not None
@@ -165,135 +183,149 @@ def test_loo_kfold(centered_eight, mock_wrapper, pointwise):
 
 
 @pytest.mark.parametrize("k", [2, 5, 8])
-def test_loo_kfold_different_k(centered_eight, mock_wrapper, k):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
+def test_loo_kfold_different_k(centered_eight, fresh_wrapper, k):
+    kfold_data = loo_kfold(data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=k)
 
-    kfold_data = loo_kfold(data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=k)
-
-    assert mock_wrapper.fit_count == k
+    assert fresh_wrapper.fit_count == k
     assert isinstance(kfold_data.elpd, float)
     assert isinstance(kfold_data.se, float)
     assert isinstance(kfold_data.p, float)
 
 
-def test_loo_kfold_custom_folds(centered_eight, mock_wrapper):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
-
-    folds = np.array([1, 1, 2, 2, 3, 3, 4, 4])
-
-    kfold_data = loo_kfold(data=centered_eight, pointwise=True, wrapper=mock_wrapper, folds=folds)
-
-    assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 4
-
-
-def test_loo_kfold_stratified(centered_eight, mock_wrapper):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
-
-    strata = np.array([0, 0, 1, 1, 0, 0, 1, 1])
-
+@pytest.mark.parametrize("pointwise", [True, False])
+def test_loo_kfold_custom_folds(centered_eight, fresh_wrapper, custom_folds, pointwise):
     kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, stratify_by=strata
+        data=centered_eight, pointwise=pointwise, wrapper=fresh_wrapper, folds=custom_folds
     )
 
     assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 4
+    assert fresh_wrapper.fit_count == 4
 
 
-def test_loo_kfold_grouped(centered_eight, mock_wrapper):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
-
-    groups = np.array([1, 1, 2, 2, 3, 3, 4, 4])
-
+@pytest.mark.parametrize("k,pointwise", [(4, False), (2, True)])
+def test_loo_kfold_stratified(centered_eight, fresh_wrapper, strata, k, pointwise):
     kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=2, group_by=groups
+        data=centered_eight, pointwise=pointwise, wrapper=fresh_wrapper, k=k, stratify_by=strata
     )
 
     assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 2
+    assert fresh_wrapper.fit_count == k
 
 
-def test_loo_kfold_save_fits(centered_eight, mock_wrapper):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
-
+def test_loo_kfold_grouped(centered_eight, fresh_wrapper, groups):
     kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, save_fits=True
+        data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=2, group_by=groups
     )
 
-    assert hasattr(kfold_data, "fold_fits")
-    assert len(kfold_data.fold_fits) == 4
-
-    for k in range(1, 5):
-        assert k in kfold_data.fold_fits
-        assert "fit" in kfold_data.fold_fits[k]
-        assert "test_indices" in kfold_data.fold_fits[k]
-
-
-def test_loo_kfold_dataarray_inputs(centered_eight, mock_wrapper):
-    mock_wrapper.fit_count = 0
-    mock_wrapper.test_indices_history = []
-
-    folds_da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=["school"])
-    kfold_data = loo_kfold(
-        data=centered_eight, pointwise=True, wrapper=mock_wrapper, folds=folds_da
-    )
     assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 4
+    assert fresh_wrapper.fit_count == 2
 
-    mock_wrapper.fit_count = 0
-    strata_da = xr.DataArray([0, 0, 1, 1, 0, 0, 1, 1], dims=["school"])
+
+@pytest.mark.parametrize("save_fits", [True, False])
+def test_loo_kfold_save_fits(centered_eight, fresh_wrapper, save_fits):
     kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, stratify_by=strata_da
+        data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=4, save_fits=save_fits
     )
-    assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 4
 
-    mock_wrapper.fit_count = 0
-    groups_da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=["school"])
-    kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=2, group_by=groups_da
-    )
-    assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 2
+    if save_fits:
+        assert hasattr(kfold_data, "fold_fits")
+        assert len(kfold_data.fold_fits) == 4
 
-    mock_wrapper.fit_count = 0
-    folds_2d = xr.DataArray([[1, 2], [1, 2], [3, 4], [3, 4]], dims=["school", "county"])
-    kfold_data = loo_kfold(
-        data=centered_eight, pointwise=False, wrapper=mock_wrapper, k=4, group_by=folds_2d
-    )
-    assert kfold_data.kind == "loo_kfold"
-    assert mock_wrapper.fit_count == 4
+        for k in range(1, 5):
+            assert k in kfold_data.fold_fits
+            assert "fit" in kfold_data.fold_fits[k]
+            assert "test_indices" in kfold_data.fold_fits[k]
+    else:
+        assert not hasattr(kfold_data, "fold_fits") or kfold_data.fold_fits is None
 
 
-def test_loo_kfold_errors(centered_eight, mock_wrapper):
-    with pytest.raises(TypeError, match="wrapper must be an instance of SamplingWrapper"):
-        loo_kfold(data=centered_eight, wrapper="not_a_wrapper")
-
-    match_msg = "Cannot use stratify_by or group_by when folds are explicitly provided"
-    with pytest.raises(ValueError, match=match_msg):
-        loo_kfold(
-            data=centered_eight,
-            wrapper=mock_wrapper,
-            folds=[1, 2, 1, 2, 1, 2, 1, 2],
-            stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
+@pytest.mark.parametrize(
+    "input_type,dims",
+    [
+        ("folds", ["school"]),
+        ("stratify_by", ["school"]),
+        ("group_by", ["school"]),
+        ("group_by_2d", ["school", "county"]),
+    ],
+)
+def test_loo_kfold_dataarray_inputs(centered_eight, fresh_wrapper, input_type, dims):
+    if input_type == "folds":
+        da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=dims)
+        kfold_data = loo_kfold(data=centered_eight, pointwise=True, wrapper=fresh_wrapper, folds=da)
+        expected_fits = 4
+    elif input_type == "stratify_by":
+        da = xr.DataArray([0, 0, 1, 1, 0, 0, 1, 1], dims=dims)
+        kfold_data = loo_kfold(
+            data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=4, stratify_by=da
         )
-
-    with pytest.raises(ValueError, match="Cannot use both stratify_by and group_by"):
-        loo_kfold(
-            data=centered_eight,
-            wrapper=mock_wrapper,
-            stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
-            group_by=[1, 1, 2, 2, 3, 3, 4, 4],
+        expected_fits = 4
+    elif input_type == "group_by":
+        da = xr.DataArray([1, 1, 2, 2, 3, 3, 4, 4], dims=dims)
+        kfold_data = loo_kfold(
+            data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=2, group_by=da
         )
-
-    with pytest.raises(ValueError, match="Length of stratify_by"):
-        loo_kfold(
-            data=centered_eight,
-            wrapper=mock_wrapper,
-            stratify_by=[0, 1, 0],
+        expected_fits = 2
+    else:
+        da = xr.DataArray([[1, 2], [1, 2], [3, 4], [3, 4]], dims=dims)
+        kfold_data = loo_kfold(
+            data=centered_eight, pointwise=False, wrapper=fresh_wrapper, k=4, group_by=da
         )
+        expected_fits = 4
+
+    assert kfold_data.kind == "loo_kfold"
+    assert fresh_wrapper.fit_count == expected_fits
+
+
+@pytest.mark.parametrize(
+    "error_case,expected_error,expected_msg",
+    [
+        ("invalid_wrapper", TypeError, "wrapper must be an instance of SamplingWrapper"),
+        (
+            "stratify_with_folds",
+            ValueError,
+            "Cannot use stratify_by or group_by when folds are explicitly provided",
+        ),
+        (
+            "group_with_folds",
+            ValueError,
+            "Cannot use stratify_by or group_by when folds are explicitly provided",
+        ),
+        ("both_stratify_group", ValueError, "Cannot use both stratify_by and group_by"),
+        ("short_stratify", ValueError, "Length of stratify_by"),
+    ],
+)
+def test_loo_kfold_errors(centered_eight, mock_wrapper, error_case, expected_error, expected_msg):
+    if error_case == "invalid_wrapper":
+        with pytest.raises(expected_error, match=expected_msg):
+            loo_kfold(data=centered_eight, wrapper="not_a_wrapper")
+    elif error_case == "stratify_with_folds":
+        with pytest.raises(expected_error, match=expected_msg):
+            loo_kfold(
+                data=centered_eight,
+                wrapper=mock_wrapper,
+                folds=[1, 2, 1, 2, 1, 2, 1, 2],
+                stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
+            )
+    elif error_case == "group_with_folds":
+        with pytest.raises(expected_error, match=expected_msg):
+            loo_kfold(
+                data=centered_eight,
+                wrapper=mock_wrapper,
+                folds=[1, 2, 1, 2, 1, 2, 1, 2],
+                group_by=[1, 1, 2, 2, 3, 3, 4, 4],
+            )
+    elif error_case == "both_stratify_group":
+        with pytest.raises(expected_error, match=expected_msg):
+            loo_kfold(
+                data=centered_eight,
+                wrapper=mock_wrapper,
+                stratify_by=[0, 0, 1, 1, 0, 0, 1, 1],
+                group_by=[1, 1, 2, 2, 3, 3, 4, 4],
+            )
+    elif error_case == "short_stratify":
+        with pytest.raises(expected_error, match=expected_msg):
+            loo_kfold(
+                data=centered_eight,
+                wrapper=mock_wrapper,
+                stratify_by=[0, 1, 0],
+            )


### PR DESCRIPTION
This PR adds `loo_kfold` functionality for k-fold cross validation with helpers in `helper_loo_kfold.py` and a test suite for the main function and helpers. Made some slight changes to the `SamplingWrapper` to better accomodate k-fold CV and tracking refits.

We follow the R module [loo-kfold](https://github.com/stan-dev/rstanarm/blob/2ec70ba7d2280749bef4fba2b7c5a7334dd9bba7/R/loo-kfold.R) closely and use [kfold-helpers](https://github.com/stan-dev/loo/blob/master/R/kfold-helpers.R) as inspiration for helper functions.

---
Resolves [#150](https://github.com/arviz-devs/arviz-stats/issues/150)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--158.org.readthedocs.build/en/158/

<!-- readthedocs-preview arviz-stats end -->