### PR TITLE
Fix function specific k-hat computation 

### DIFF
--- a/src/arviz_stats/loo/loo_expectations.py
+++ b/src/arviz_stats/loo/loo_expectations.py
@@ -256,25 +256,34 @@ def _get_function_khat(
     )
 
     # Get right tail khat
-    khat_r_da = r_theta_da.azstats.pareto_khat(dims="sample", tail="right", log_weights=False)
-    khat_r = khat_r_da.item()
+    try:
+        khat_r_da = r_theta_da.azstats.pareto_khat(dims="sample", tail="right", log_weights=False)
+        khat_r = khat_r_da.item()
+    except ValueError:
+        khat_r = np.nan
 
     # For quantile/median, only need khat_r
     if kind in ["quantile", "median"]:
         return khat_r
 
     h_theta_values = values.ravel() if kind == "mean" else values.ravel() ** 2
-    h_theta_finite = h_theta_values[np.isfinite(h_theta_values)]
+    unique_h = np.unique(h_theta_values[np.isfinite(h_theta_values)])
 
-    if h_theta_finite.size == 0 or len(np.unique(h_theta_finite)) <= 2:
+    if len(unique_h) <= 1:
+        return khat_r
+    if len(unique_h) == 2:
+        return khat_r
+    if np.any(~np.isfinite(h_theta_values)):
         return khat_r
 
-    # Compute khat for h(theta) * r(theta)
     hr_theta_da = xr.DataArray(h_theta_values * r_theta_da.values, dims=["sample"])
-    khat_hr_da = hr_theta_da.azstats.pareto_khat(dims="sample", tail="both", log_weights=False)
-    khat_hr = khat_hr_da.item()
 
-    if np.isnan(khat_hr) or np.isnan(khat_r):
-        return khat_r
+    try:
+        khat_hr_da = hr_theta_da.azstats.pareto_khat(dims="sample", tail="both", log_weights=False)
+        khat_hr = khat_hr_da.item()
+    except ValueError:
+        khat_hr = np.nan
 
-    return max(khat_hr, khat_r)
+    if np.isnan(khat_hr) and np.isnan(khat_r):
+        return np.nan
+    return np.nanmax([khat_hr, khat_r])


### PR DESCRIPTION
This PR fixes a bug where `loo_metrics` would fail with `ValueError: All tail values are the same` when computing function-specific k-hat values via `_get_function_khat`.

  Changes:
  - Added try-except handling in `_get_function_khat` to catch the error from `pareto_khat` when tail values are identical
  - Fall back to importance ratio's k-hat (`khat_r`) when function-specific k-hat (`khat_hr`) computation fails
  - Added validation for edge cases: constant, binary, or non-finite function values

I wanted to note that we also have a `try...except` block around `khat_r` because in `diagnostics.py` for `_pareto_khat`, when we catch the error that all tail values are the same, we do not assign `np.nan` to it. So, `_get_function_khat` could potentially fail here as well. It's worth noting that in the R implementation, it's not necessary to catch the error for `khat_r` and assign `NA` because it is already done [here](https://github.com/stan-dev/posterior/blob/f170d78695e8144b4789b03517f6a7ecd6f502c7/R/pareto_smooth.R#L515) in the Posterior package. We could also do something similar for `_pareto_khat` in `diagnostics.py` if we wanted to and avoid having the first `try...except` block around `khat_r`.

---
Resolves: [#164](https://github.com/arviz-devs/arviz-stats/issues/164)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--165.org.readthedocs.build/en/165/

<!-- readthedocs-preview arviz-stats end -->