### PR TITLE
Fix loo_moment_match to be more modular

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -135,7 +135,7 @@ indent-string='    '
 max-line-length=100
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=1500
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -936,8 +936,8 @@ def _update_quantities_i(
     lwi_new, ki_new_tuple = log_ratio_i.azstats.psislw(r_eff=reff_i, dim=sample_dims)
     ki_new = ki_new_tuple[0].item() if isinstance(ki_new_tuple, tuple) else ki_new_tuple.item()
 
-    log_ratio_f = log_prob_new - orig_log_prob
-    lwfi_new, kfi_new_tuple = log_ratio_f.azstats.psislw(r_eff=reff_i, dim=sample_dims)
+    log_ratio_full = log_prob_new - orig_log_prob
+    lwfi_new, kfi_new_tuple = log_ratio_full.azstats.psislw(r_eff=reff_i, dim=sample_dims)
     kfi_new = kfi_new_tuple[0].item() if isinstance(kfi_new_tuple, tuple) else kfi_new_tuple.item()
 
     return UpdateQuantities(

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -16,7 +16,7 @@ from arviz_stats.loo.helper_loo import (
     _shift,
     _shift_and_cov,
     _shift_and_scale,
-    _update_loo_data_i,
+    _warn_pareto_k,
 )
 from arviz_stats.sampling_diagnostics import ess
 from arviz_stats.utils import ELPDData
@@ -934,6 +934,49 @@ def _loo_moment_match_i(
     )
 
 
+def _update_loo_data_i(
+    loo_data,
+    i,
+    new_elpd_i,
+    new_pareto_k,
+    log_liki,
+    sample_dims,
+    obs_dims,
+    n_samples,
+    original_log_liki=None,
+    suppress_warnings=False,
+):
+    """Update the ELPDData object for a single observation."""
+    if loo_data.elpd_i is None or loo_data.pareto_k is None:
+        raise ValueError("loo_data must contain pointwise elpd_i and pareto_k values.")
+
+    lpd_i_log_lik = original_log_liki if original_log_liki is not None else log_liki
+    lpd_i = logsumexp(lpd_i_log_lik, dims=sample_dims, b=1 / n_samples).item()
+    p_loo_i = lpd_i - new_elpd_i
+
+    if len(obs_dims) == 1:
+        idx_dict = {obs_dims[0]: i}
+    else:
+        coords = np.unravel_index(i, tuple(loo_data.elpd_i.sizes[d] for d in obs_dims))
+        idx_dict = dict(zip(obs_dims, coords))
+
+    loo_data.elpd_i[idx_dict] = new_elpd_i
+    loo_data.pareto_k[idx_dict] = new_pareto_k
+
+    if not hasattr(loo_data, "p_loo_i") or loo_data.p_loo_i is None:
+        loo_data.p_loo_i = xr.full_like(loo_data.elpd_i, np.nan)
+
+    loo_data.p_loo_i[idx_dict] = p_loo_i
+    loo_data.elpd = np.nansum(loo_data.elpd_i.values)
+    loo_data.se = np.sqrt(loo_data.n_data_points * np.nanvar(loo_data.elpd_i.values))
+
+    loo_data.warning, loo_data.good_k = _warn_pareto_k(
+        loo_data.pareto_k.values[~np.isnan(loo_data.pareto_k.values)],
+        loo_data.n_samples,
+        suppress=suppress_warnings,
+    )
+
+
 def _update_quantities_i(
     upars,
     i,
@@ -943,7 +986,7 @@ def _update_quantities_i(
     reff_i,
     sample_dims,
 ):
-    """Update the importance weights, Pareto diagnostic and log-likelihood for observation i."""
+    """Update the moment matching quantities for a single observation."""
     log_prob_new = log_prob_upars_fn(upars)
     log_liki_new = log_lik_i_upars_fn(upars, i)
 

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -4,6 +4,7 @@ import warnings
 from collections import namedtuple
 from copy import deepcopy
 
+import arviz_base as azb
 import numpy as np
 import xarray as xr
 from arviz_base import dataset_to_dataarray, rcParams
@@ -297,13 +298,10 @@ def loo_moment_match(
 
     if upars is None:
         if hasattr(data, "unconstrained_posterior"):
-            upars_ds = data.unconstrained_posterior.ds
+            upars_ds = azb.get_unconstrained_samples(data, return_dataset=True)
             upars = dataset_to_dataarray(
                 upars_ds, sample_dims=sample_dims, new_dim="unconstrained_parameter"
             )
-
-            if "chain" in upars.dims and "draw" in upars.dims:
-                upars = upars.transpose("chain", "draw", "unconstrained_parameter", ...)
         else:
             raise ValueError(
                 "upars must be provided or data must contain an 'unconstrained_posterior' group."

--- a/tests/test_helper_loo.py
+++ b/tests/test_helper_loo.py
@@ -22,7 +22,6 @@ from arviz_stats.loo.helper_loo import (
     _prepare_loo_inputs,
     _prepare_subsample,
     _prepare_update_subsample,
-    _recalculate_weights_k,
     _select_obs_by_coords,
     _select_obs_by_indices,
     _shift,
@@ -645,54 +644,6 @@ def test_split_moment_match_errors():
             log_prob_upars_fn=lambda x: x,
             log_lik_i_upars_fn=lambda x, _i: x,
         )
-
-
-def test_recalculate_weights_k(centered_eight):
-    posterior = centered_eight.posterior
-    chain_size = posterior.chain.size
-    draw_size = posterior.draw.size
-    dims = ["chain", "draw"]
-    coords = {"chain": posterior.chain, "draw": posterior.draw}
-
-    log_liki_new = xr.DataArray(
-        np.random.randn(chain_size, draw_size),
-        dims=dims,
-        coords=coords,
-    )
-
-    log_prob_new = xr.DataArray(
-        np.random.randn(chain_size, draw_size),
-        dims=dims,
-        coords=coords,
-    )
-
-    orig_log_prob = xr.DataArray(
-        np.random.randn(chain_size, draw_size),
-        dims=dims,
-        coords=coords,
-    )
-
-    reff = 0.8
-    sample_dims = ["chain", "draw"]
-
-    result = _recalculate_weights_k(log_liki_new, log_prob_new, orig_log_prob, reff, sample_dims)
-
-    assert hasattr(result, "lwi")
-    assert hasattr(result, "lwfi")
-    assert hasattr(result, "ki")
-    assert hasattr(result, "kfi")
-    assert hasattr(result, "log_liki")
-
-    assert isinstance(result.lwi, xr.DataArray)
-    assert isinstance(result.lwfi, xr.DataArray)
-    assert isinstance(result.ki, float)
-    assert isinstance(result.kfi, float)
-    assert isinstance(result.log_liki, xr.DataArray)
-
-    assert result.lwi.dims == ("chain", "draw")
-    assert result.lwfi.dims == ("chain", "draw")
-    assert result.ki >= 0
-    assert result.kfi >= 0
 
 
 def test_get_log_weights_i():

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -632,8 +632,7 @@ def test_loo_moment_match_optional_upars(datatree, loo_orig, moment_match_data):
     assert isinstance(loo_mm_explicit, ELPDData)
 
     datatree_with_unconstrained = datatree.copy()
-    unconstrained_group = xr.DataTree(name="unconstrained_posterior")
-    unconstrained_group.ds = upars_ds
+    unconstrained_group = xr.DataTree(dataset=upars_ds, name="unconstrained_posterior")
     datatree_with_unconstrained["unconstrained_posterior"] = unconstrained_group
 
     loo_mm_implicit = loo_moment_match(

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -568,8 +568,10 @@ def moment_match_data(datatree):
     param_list_for_ds["b_main"] = b_param
     param_list_for_ds["log_sigma"] = log_sigma_param
 
-    temp_ds = xr.Dataset(param_list_for_ds)
-    upars_da_generated = temp_ds.to_array(dim="unconstrained_parameter", name="upars_values")
+    upars_ds = xr.Dataset(param_list_for_ds)
+    upars_da_generated = azb.dataset_to_dataarray(
+        upars_ds, sample_dims=["chain", "draw"], new_dim="unconstrained_parameter"
+    )
     upars_da_final = upars_da_generated.transpose("chain", "draw", "unconstrained_parameter")
 
     def log_prob_upars_fn(upars_arg):
@@ -581,11 +583,11 @@ def moment_match_data(datatree):
         perturbation = upars_arg.sum("unconstrained_parameter") * 0.0001
         return original_log_lik_for_i + perturbation
 
-    return upars_da_final, log_prob_upars_fn, log_lik_i_upars_fn
+    return upars_da_final, log_prob_upars_fn, log_lik_i_upars_fn, upars_ds
 
 
 def test_loo_moment_match(datatree, loo_orig, moment_match_data):
-    upars_da, log_prob_fn, log_lik_i_fn = moment_match_data
+    upars_da, log_prob_fn, log_lik_i_fn, _ = moment_match_data
     max_k = np.nanmax(loo_orig.pareto_k.values)
     k_threshold = np.nanpercentile(loo_orig.pareto_k.values, 90)
     assert k_threshold < max_k
@@ -615,8 +617,52 @@ def test_loo_moment_match(datatree, loo_orig, moment_match_data):
     assert hasattr(loo_mm, "p_loo_i"), "loo_mm object should have p_loo_i attribute"
 
 
+def test_loo_moment_match_optional_upars(datatree, loo_orig, moment_match_data):
+    upars_da, log_prob_fn, log_lik_i_fn, upars_ds = moment_match_data
+
+    loo_mm_explicit = loo_moment_match(
+        datatree,
+        loo_orig,
+        upars=upars_da,
+        log_prob_upars_fn=log_prob_fn,
+        log_lik_i_upars_fn=log_lik_i_fn,
+        var_name="y",
+        max_iters=2,
+    )
+    assert isinstance(loo_mm_explicit, ELPDData)
+
+    datatree_with_unconstrained = datatree.copy()
+    unconstrained_group = xr.DataTree(name="unconstrained_posterior")
+    unconstrained_group.ds = upars_ds
+    datatree_with_unconstrained["unconstrained_posterior"] = unconstrained_group
+
+    loo_mm_implicit = loo_moment_match(
+        datatree_with_unconstrained,
+        loo_orig,
+        upars=None,
+        log_prob_upars_fn=log_prob_fn,
+        log_lik_i_upars_fn=log_lik_i_fn,
+        var_name="y",
+        max_iters=2,
+    )
+    assert isinstance(loo_mm_implicit, ELPDData)
+
+    with pytest.raises(
+        ValueError,
+        match="upars must be provided or data must contain an 'unconstrained_posterior' group",
+    ):
+        loo_moment_match(
+            datatree,
+            loo_orig,
+            upars=None,
+            log_prob_upars_fn=log_prob_fn,
+            log_lik_i_upars_fn=log_lik_i_fn,
+            var_name="y",
+        )
+
+
 def test_loo_moment_match_no_problematic_k(datatree, loo_orig, moment_match_data):
-    upars_da, log_prob_fn, log_lik_i_fn = moment_match_data
+    upars_da, log_prob_fn, log_lik_i_fn, _ = moment_match_data
     k_threshold = np.nanmax(loo_orig.pareto_k.values) + 0.1
 
     loo_mm = loo_moment_match(
@@ -634,7 +680,7 @@ def test_loo_moment_match_no_problematic_k(datatree, loo_orig, moment_match_data
 
 
 def test_loo_moment_match_errors(datatree, moment_match_data):
-    upars_da, log_prob_fn, log_lik_i_fn = moment_match_data
+    upars_da, log_prob_fn, log_lik_i_fn, _ = moment_match_data
 
     loo_non_pointwise = loo(datatree, pointwise=False, var_name="y")
     with pytest.raises(
@@ -746,8 +792,10 @@ def test_log_weights_input_formats(centered_eight):
     metrics_da = loo_metrics(centered_eight, kind="rmse", log_weights=log_weights_da)
     metrics_elpddata = loo_metrics(centered_eight, kind="rmse", log_weights=loo_result)
     assert metrics_da.mean == metrics_elpddata.mean
-    assert metrics_da.se == metrics_elpddata.se
 
+
+def test_log_weights_input_formats_subsample(centered_eight):
+    loo_result = loo(centered_eight, pointwise=True)
     loo_sub_elpddata = loo_subsample(
         centered_eight,
         observations=4,


### PR DESCRIPTION
This PR refactors the `loo_moment_match` function to improve modularity, maintainability, and usability.

Changes

- The `upars` parameter is now optional and will attempt to use the `unconstrained_posterior` group from the input data if not provided
- Extracted the core moment matching logic into separate helper functions:
  - `_loo_moment_match_i`: Handles moment matching for a single observation now
  - `_update_quantities_i`: Recalculates importance weights and Pareto k after transformations
  - `_update_loo_data_i`: Moved this from `helper_loo.py` into the main `loo_moment_match.py` file. I think it makes sense to have all of the update data functions here for clarity. 

Had to increase the max line length for a module from 1000 to 1500 with the addition of `_update_loo_data_i` to the main file. I can revert this if needed and just move `_update_loo_data_i` and `update_quantities_i` into `helper_loo.py`. Just thought it made sense to have all the relevant update functions in one place to understand how things are getting updated in `loo_moment_match`.

---
Resolves: [#153](https://github.com/arviz-devs/arviz-stats/issues/153)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview arviz-stats end -->