### PR TITLE
add mode computation

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -52,6 +52,7 @@ you should jump to {ref}`array_stats_api` and read forward.
    arviz_stats.loo_expectations
    arviz_stats.loo_metrics
    arviz_stats.metrics
+   arviz_stats.mode
    arviz_stats.qds
    arviz_stats.r2_score
    arviz_stats.summary

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -21,7 +21,7 @@ try:
     from arviz_stats.psense import psense, psense_summary
     from arviz_stats.metrics import kl_divergence, metrics, r2_score, wasserstein
     from arviz_stats.sampling_diagnostics import ess, mcse, rhat, rhat_nested
-    from arviz_stats.summary import summary, ci_in_rope
+    from arviz_stats.summary import summary, ci_in_rope, mode
     from arviz_stats.manipulation import thin
     from arviz_stats.bayes_factor import bayes_factor
     from arviz_stats.visualization import ecdf, eti, hdi, histogram, kde, qds

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -174,6 +174,10 @@ class _BaseAccessor:
         """Compute autocorrelation for all variables in the dataset."""
         return self._apply("autocorr", dim=dim, **kwargs)
 
+    def mode(self, dim=None, **kwargs):
+        """Compute mode for all variables in the dataset."""
+        return self._apply("mode", dim=dim, **kwargs)
+
 
 @xr.register_dataarray_accessor("azstats")
 class AzStatsDaAccessor(_BaseAccessor):

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -586,5 +586,30 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         )
         return metrics_ufunc(observed, predicted)
 
+    def mode(self, ary, axis=None):
+        """Compute mode of values along the specified axis.
+
+        Parameters
+        ----------
+        values : array-like
+            Input array.
+        axis : int, sequence of int or None, default -1
+            Axis or axes along which to compute the mode.
+
+        Returns
+        -------
+        mode : array-like
+            Mode of the input values along the specified axis.
+        """
+        ary, axes = process_ary_axes(ary, axis)
+        mode_ufunc = make_ufunc(
+            self._mode,
+            n_output=1,
+            n_input=1,
+            n_dims=len(axes),
+            ravel=False,
+        )
+        return mode_ufunc(ary)
+
 
 array_stats = BaseArray()

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -419,3 +419,27 @@ class _CoreBase:
                 [hdi_intervals, np.full((max_modes - hdi_intervals.shape[0], 2), np.nan)]
             )
         return hdi_intervals
+
+    def _mode(self, ary):  # pylint: disable=no-self-use
+        ary = ary.flatten()
+
+        if ary.size == 0:
+            return np.nan
+        if ary.size == 1:
+            return ary.item()
+
+        ary = ary[~np.isnan(ary)]
+
+        if ary.dtype.kind == "f":
+            # For continuous data, we use the half-sample mode algorithm.
+            x = np.sort(ary)
+            while len(x) > 2:
+                n = (len(x) + 1) // 2
+                widths = x[n:] - x[:-n]
+                min_idx = np.argmin(widths)
+                x = x[min_idx : min_idx + n]
+
+            return (x[0] + x[1]) / 2
+        # For discrete data, we use the most frequent value.
+        vals, cnts = np.unique(ary, return_counts=True)
+        return vals[cnts.argmax()]

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -402,5 +402,19 @@ class BaseDataArray:
             output_core_dims=[dims],
         )
 
+    def mode(self, da, dim=None):
+        """Compute mode on DataArray input."""
+        if dim is None:
+            dims = list(da.dims)
+        else:
+            dims = dim if isinstance(dim, (list | tuple)) else [dim]
+
+        return apply_ufunc(
+            self.array_class.mode,
+            da,
+            input_core_dims=[dims],
+            kwargs={"axis": np.arange(-len(dims), 0, 1)},
+        )
+
 
 dataarray_stats = BaseDataArray(array_class=array_stats)

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -404,15 +404,13 @@ class BaseDataArray:
 
     def mode(self, da, dim=None):
         """Compute mode on DataArray input."""
-        if dim is None:
-            dims = list(da.dims)
-        else:
-            dims = dim if isinstance(dim, (list | tuple)) else [dim]
+        dims = validate_dims(dim)
 
         return apply_ufunc(
             self.array_class.mode,
             da,
             input_core_dims=[dims],
+            output_core_dims=[[]],
             kwargs={"axis": np.arange(-len(dims), 0, 1)},
         )
 

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -379,19 +379,19 @@ def mode(
           similar functions.
 
           It is recommended to first perform the conversion manually and then call
-          ``arviz_stats.kde``. This allows controlling the conversion step and inspecting
+          ``arviz_stats.mode``. This allows controlling the conversion step and inspecting
           its results.
     dim : sequence of hashable, optional
     group : hashable, default "posterior"
-        Group on which to compute the quantile dots
+        Group on which to compute the mode
     var_names : str or list of str, optional
-        Names of the variables for which the quantile dots should be computed.
+        Names of the variables for which the mode should be computed.
     filter_vars : {None, "like", "regex"}, default None
     coords : dict, optional
         Dictionary of dimension/index names to coordinate values defining a subset
         of the data for which to perform the computation.
     **kwargs : any, optional
-        Forwarded to the array or dataarray interface for quantile dots.
+        Forwarded to the array or dataarray interface for mode.
 
     Returns
     -------

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -382,6 +382,7 @@ def mode(
           ``arviz_stats.mode``. This allows controlling the conversion step and inspecting
           its results.
     dim : sequence of hashable, optional
+        Dimensions over which to compute the mode. Defaults to ``rcParams["data.sample_dims"]``.
     group : hashable, default "posterior"
         Group on which to compute the mode
     var_names : str or list of str, optional

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -5,6 +5,7 @@ import xarray as xr
 from arviz_base import dataset_to_dataframe, extract, rcParams, references_to_dataset
 from xarray_einstats import stats
 
+from arviz_stats.utils import _apply_multi_input_function
 from arviz_stats.validate import validate_dims
 
 __all__ = ["summary", "ci_in_rope"]
@@ -346,3 +347,103 @@ def ci_in_rope(
     proportion = (in_rope.sum(dim=sample_dims) / in_ci.sum(dim=sample_dims)) * 100
 
     return proportion
+
+
+def mode(
+    data,
+    dim=None,
+    group="posterior",
+    var_names=None,
+    filter_vars=None,
+    coords=None,
+    **kwargs,
+):
+    r"""Compute the mode.
+
+    The mode is the value that appears most frequently in a data set.
+    If the data is of type float, we assume it is continuous and use the half-sample method [1]_.
+    If the data is of type int, we assume it is discrete and use :func:`numpy.unique` to find the
+    most frequent value.
+
+
+    Parameters
+    ----------
+    data : array-like, DataArray, Dataset, DataTree, DataArrayGroupBy, DatasetGroupBy, or idata-like
+        Input data. It will have different pre-processing applied to it depending on its type:
+
+        - array-like: call array layer within ``arviz-stats``.
+        - xarray object: apply dimension aware function to all relevant subsets
+        - others: passed to :func:`arviz_base.convert_to_dataset` then treated as
+          :class:`xarray.Dataset`. This option is discouraged due to needing this conversion
+          which is completely automated and will be needed again in future executions or
+          similar functions.
+
+          It is recommended to first perform the conversion manually and then call
+          ``arviz_stats.kde``. This allows controlling the conversion step and inspecting
+          its results.
+    dim : sequence of hashable, optional
+    group : hashable, default "posterior"
+        Group on which to compute the quantile dots
+    var_names : str or list of str, optional
+        Names of the variables for which the quantile dots should be computed.
+    filter_vars : {None, "like", "regex"}, default None
+    coords : dict, optional
+        Dictionary of dimension/index names to coordinate values defining a subset
+        of the data for which to perform the computation.
+    **kwargs : any, optional
+        Forwarded to the array or dataarray interface for quantile dots.
+
+    Returns
+    -------
+    ndarray, DataArray, Dataset, DataTree
+        Requested mode of the provided input.
+
+    See Also
+    --------
+    :func:`xarray.DataArray.mean`, :func:`xarray.Dataset.mean`, :func:`xarray.DataArray.median`,
+    :func:`xarray.Dataset.median`
+
+
+    References
+    ----------
+    .. [1] Bickel DR, Fruehwirth R. *On a Fast, Robust Estimator of the Mode:
+       Comparisons to Other Robust Estimators with Applications.* Computational Statistics
+       & Data Analysis. 2006. https://doi.org/10.1016/j.csda.2005.07.011
+       arXiv preprint https://doi.org/10.48550/arXiv.math/0505419
+
+    Examples
+    --------
+    Calculate the mode of a Normal random variable:
+
+    .. ipython::
+
+        In [1]: import arviz_stats as azs
+           ...: import numpy as np
+           ...: data = np.random.default_rng().normal(size=2000)
+           ...: azs.mode(data)
+
+    Calculate the modes for specific variables:
+
+    .. ipython::
+
+        In [1]: import arviz_base as azb
+           ...: dt = azb.load_arviz_data("centered_eight")
+           ...: azs.mode(dt, var_names=["mu", "theta"])
+
+    Calculate the modes excluding the school dimension:
+
+    .. ipython::
+
+        In [1]: azs.mode(dt, dim=["chain", "draw"])
+    """
+    return _apply_multi_input_function(
+        "mode",
+        data,
+        dim,
+        "dim",
+        group=group,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        coords=coords,
+        **kwargs,
+    )

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -401,8 +401,7 @@ def mode(
 
     See Also
     --------
-    :func:`xarray.DataArray.mean`, :func:`xarray.Dataset.mean`, :func:`xarray.DataArray.median`,
-    :func:`xarray.Dataset.median`
+    :func:`xarray.Dataset.mean`, :func:`xarray.Dataset.median`
 
 
     References

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -10,7 +10,7 @@ from .helpers import datatree, fake_dt, importorskip  # noqa: F401
 
 azb = importorskip("arviz_base")
 
-from arviz_stats import ci_in_rope, eti, hdi, qds, summary
+from arviz_stats import ci_in_rope, eti, hdi, mode, qds, summary
 
 
 def test_summary_ndarray():
@@ -156,3 +156,16 @@ def test_qds(datatree):
     result = qds(datatree.posterior["mu"].values)
     assert result[0].shape == (4, 100)
     assert result[2].shape == (4,)
+
+
+def test_mode(datatree):
+    result = mode(datatree)
+    assert result["mu"].shape == ()
+    assert result["theta"].shape == (7,)
+    result = mode(datatree.posterior)
+    assert result["mu"].shape == ()
+    assert result["theta"].shape == (7,)
+    result = mode(datatree.posterior["mu"])
+    assert result.shape == ()
+    result = mode(datatree.posterior["mu"].values)
+    assert result.shape == ()


### PR DESCRIPTION
closes #9 

For the mode computation I use the half-sample method, instead of the max density from a kde. According to what I read and a few tests it seems to provide reasonable results (even for circular variable without doing any change). It only returns a single mode.

This PR assumes we want the mode computation to behave like xarray's mean (or similar functions). So

```python
dt = azb.load_arviz_data("centered_eight").posterior
dt.azstats.mode()
``` 

returns 3 values, one for mu, theta, and tau. 

And 

```python
dt.azstats.mode(dim=["chain", "draw"])
``` 

returns 10 values, one for mu and tau, and eight for theta

This currently fails 

```python
dt.azstats.mode(dim=["school"])
``` 

If we were computing the mean, the result would be 3 arrays of shape (4, 500), one per variable.



<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--174.org.readthedocs.build/en/174/

<!-- readthedocs-preview arviz-stats end -->