### PR TITLE
Add support for Jacobian adjustment to elpd_loo values

### DIFF
--- a/src/arviz_stats/loo/helper_loo.py
+++ b/src/arviz_stats/loo/helper_loo.py
@@ -499,12 +499,12 @@ def _compute_loo_results(
                 )
 
     if log_weights is None or pareto_k is None:
-        log_weights, pareto_k = log_likelihood_da.azstats.psislw(r_eff=reff, dim=list(sample_dims))
+        log_weights, pareto_k = log_likelihood_da.azstats.psislw(r_eff=reff, dim=sample_dims)
 
     warn_mg, good_k = _warn_pareto_k(pareto_k, n_samples)
 
     log_weights_sum = log_weights + log_likelihood_da
-    elpd_i = logsumexp(log_weights_sum, dims=list(sample_dims))
+    elpd_i = logsumexp(log_weights_sum, dims=sample_dims)
 
     jacobian_da = _check_log_jacobian(log_jacobian, obs_dims)
     if jacobian_da is not None:
@@ -512,7 +512,7 @@ def _compute_loo_results(
 
     elpd = elpd_i.sum().item()
 
-    lppd_da = logsumexp(log_likelihood_da, b=1 / n_samples, dims=list(sample_dims))
+    lppd_da = logsumexp(log_likelihood_da, b=1 / n_samples, dims=sample_dims)
     if jacobian_da is not None:
         lppd_da = lppd_da + jacobian_da
     lppd = lppd_da.sum().item()

--- a/src/arviz_stats/loo/helper_loo.py
+++ b/src/arviz_stats/loo/helper_loo.py
@@ -522,12 +522,11 @@ def _compute_loo_results(
     if return_pointwise:
         return elpd_i, pareto_k, approx_posterior
 
-    elpd_i_values = elpd_i.values.astype(np.float64)
-    elpd_se = (n_data_points * np.var(elpd_i_values)) ** 0.5
+    elpd_se = (n_data_points * np.var(elpd_i.values)) ** 0.5
 
     pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
     if pointwise:
-        _warn_pointwise_loo(elpd, elpd_i_values)
+        _warn_pointwise_loo(elpd, elpd_i.values)
 
     return ELPDData(
         "loo",

--- a/src/arviz_stats/loo/loo_approximate_posterior.py
+++ b/src/arviz_stats/loo/loo_approximate_posterior.py
@@ -9,8 +9,8 @@ from arviz_stats.loo.helper_loo import (  # pylint: disable=cyclic-import
 )
 
 
-def loo_approximate_posterior(data, log_p, log_q, pointwise=None, var_name=None):
-    """Compute PSIS-LOO-CV for approximate posteriors.
+def loo_approximate_posterior(data, log_p, log_q, pointwise=None, var_name=None, log_jacobian=None):
+    r"""Compute PSIS-LOO-CV for approximate posteriors.
 
     Estimates the expected log pointwise predictive density (elpd) using Pareto-smoothed
     importance sampling leave-one-out cross-validation (PSIS-LOO-CV) for approximate
@@ -40,6 +40,12 @@ def loo_approximate_posterior(data, log_p, log_q, pointwise=None, var_name=None)
     var_name : str, optional
         The name of the variable in log_likelihood groups storing the pointwise log
         likelihood data to use for loo computation.
+    log_jacobian : DataArray, optional
+        Log-Jacobian adjustment for variable transformations. Required when the model was fitted
+        on transformed response data :math:`z = T(y)` but you want to compute ELPD on the
+        original response scale :math:`y`. The value should be :math:`\log|\frac{dz}{dy}|`
+        (the log absolute value of the derivative of the transformation). Must be a DataArray
+        with dimensions matching the observation dimensions.
 
     Returns
     -------
@@ -167,4 +173,5 @@ def loo_approximate_posterior(data, log_p, log_q, pointwise=None, var_name=None)
         log_weights=log_weights,
         pareto_k=pareto_k,
         approx_posterior=True,
+        log_jacobian=log_jacobian,
     )


### PR DESCRIPTION
This adds support for log-Jacobian adjustments when computing PSIS-LOO-CV, enabling correct ELPD calculation for models fitted on transformed response variables.

Changes

- Adds optional `log_jacobian` parameter to `loo` and `loo_approximate_posterior`
- Validation and dimension checking for Jacobian input via `_check_log_jacobian` helper
- Adjusts both pointwise ELPD values and aggregate metrics when Jacobian is provided
- Added some validation for pre-computed `log_weights` and `pareto_k` since we're allowing those now

Since this is backward compatible, we can keep working on improvements for this. It might make sense to allow `np.array` log Jacobian inputs as well. Figured we could start with the standard `DataArray` input first. 

Adding the Jacobian adjustment to `loo_subsample` needs a bit more attention given that we only use a subsample of the observations for this. So we would need the adjustment to only apply to subsampled observations. I want to tackle this in v2 of this addition. 

Resolves [#169](https://github.com/arviz-devs/arviz-stats/issues/169)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--175.org.readthedocs.build/en/175/

<!-- readthedocs-preview arviz-stats end -->