### PR TITLE
Add more informative errors for model comparison in `compare()`

### DIFF
--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -221,7 +221,6 @@ def _ic_matrix(ics):
     rows = len(ics["elpd_i"].iloc[0])
     ic_i_val = np.zeros((rows, cols))
 
-    first_model = ics.index[0]
     mismatches = []
     for val in ics.index:
         ic_len = len(ics.loc[val]["elpd_i"])
@@ -229,11 +228,12 @@ def _ic_matrix(ics):
             mismatches.append((val, ic_len))
 
     if mismatches:
-        mismatch_details = ", ".join([f"'{name}' ({count})" for name, count in mismatches])
+        obs_counts = {name: len(ics.loc[name]["elpd_i"]) for name in ics.index}
+        sorted_counts = sorted(obs_counts.items(), key=lambda item: (item[1], item[0]))
+        mismatch_details = ", ".join([f"'{name}' ({count})" for name, count in sorted_counts])
         raise ValueError(
-            f"Models have inconsistent observation counts. "
-            f"Model '{first_model}' has {rows} observations, but these models differ: "
-            f"{mismatch_details}. All models must have the same number of observations."
+            "All models must have the same number of observations, but models have inconsistent "
+            f"observation counts: {mismatch_details}"
         )
 
     for idx, val in enumerate(ics.index):
@@ -273,7 +273,7 @@ def _calculate_ics(
             if elpd_data.elpd_i is None:
                 raise ValueError(
                     f"Model '{name}' is missing pointwise ELPD values. "
-                    f"Recalculate with loo(model, pointwise=True)."
+                    f"Recalculate with pointwise=True."
                 )
 
         methods_used = {}
@@ -299,7 +299,7 @@ def _calculate_ics(
                 raise ValueError(
                     f"Cannot compare models with incompatible cross-validation methods: "
                     f"{method_list}. Only comparisons between 'loo' and 'loo_kfold' methods "
-                    f"are supported."
+                    f"are supported currently."
                 )
 
     compare_dict = deepcopy(compare_dict)

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -123,8 +123,8 @@ def compare(
         raise ValueError(
             f"Invalid method '{method}'. "
             f"Available methods: {', '.join(available_methods)}. "
-            f"Use 'stacking' for robust model averaging as recommended in "
-            f"the original paper https://arxiv.org/abs/1704.02030."
+            f"Use 'stacking' for robust model averaging as recommended in the original paper "
+            f"https://arxiv.org/abs/1704.02030."
         )
 
     ics = pd.DataFrame.from_dict(ics_dict, orient="index")
@@ -268,7 +268,7 @@ def _calculate_ics(
             if elpd_data.elpd_i is None:
                 raise ValueError(
                     f"Model '{name}' is missing pointwise ELPD values. "
-                    f"Recalculate with: loo(model, pointwise=True)"
+                    f"Recalculate with loo(model, pointwise=True)."
                 )
             if elpd_data.kind != first_kind:
                 raise ValueError(

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -123,7 +123,8 @@ def compare(
         raise ValueError(
             f"Invalid method '{method}'. "
             f"Available methods: {', '.join(available_methods)}. "
-            f"Use 'stacking' (recommended) for robust model averaging."
+            f"Use 'stacking' for robust model averaging as recommended in "
+            f"the original paper https://arxiv.org/abs/1704.02030."
         )
 
     ics = pd.DataFrame.from_dict(ics_dict, orient="index")

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -125,7 +125,7 @@ def compare(
             f"Invalid method '{method}'. "
             f"Available methods: {', '.join(available_methods)}. "
             f"Use 'stacking' for robust model averaging as recommended in the original paper "
-            f"https://arxiv.org/abs/1704.02030."
+            f"https://doi.org/10.1214/17-BA1091."
         )
 
     ics = pd.DataFrame.from_dict(ics_dict, orient="index")

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -136,13 +136,6 @@ def test_compare_different(centered_eight, non_centered_eight, method):
     assert_allclose(np.sum(weight), 1.0)
 
 
-def test_compare_different_size(centered_eight):
-    centered_eight_subset = centered_eight.sel(school="Choate")
-    model_dict = {"centered": centered_eight, "centered__subset": centered_eight_subset}
-    with pytest.raises(ValueError, match="Models have inconsistent observation counts"):
-        compare(model_dict)
-
-
 def test_compare_multiple_different_sizes(centered_eight):
     centered_eight_subset1 = centered_eight.sel(school=["Choate"])
     centered_eight_subset2 = centered_eight.sel(school=["Choate", "Deerfield"])
@@ -155,9 +148,11 @@ def test_compare_multiple_different_sizes(centered_eight):
     with pytest.raises(ValueError) as exc_info:
         compare(model_dict)
     error_msg = str(exc_info.value)
-    assert "Models have inconsistent observation counts" in error_msg
-    assert "(8)" in error_msg and "(2)" in error_msg
-    assert "model_" in error_msg
+    expected_msg = (
+        "All models must have the same number of observations, but models have inconsistent "
+        "observation counts: 'model_b' (1), 'model_d' (2), 'model_a' (8), 'model_c' (8)"
+    )
+    assert error_msg == expected_msg
 
 
 def test_compare_multiple_obs(multivariable_log_likelihood, centered_eight, non_centered_eight):

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -191,25 +191,6 @@ def test_calculate_ics_pointwise_error(centered_eight, non_centered_eight):
         _calculate_ics(in_dict)
 
 
-def test_calculate_ics_mixed_methods_warning(centered_eight):
-    loo_result = loo(centered_eight, pointwise=True)
-    kfold_result = copy.deepcopy(loo_result)
-    kfold_result.kind = "loo_kfold"
-
-    in_dict = {
-        "model1": loo_result,
-        "model2": kfold_result,
-    }
-
-    with pytest.warns(UserWarning, match="Comparing LOO-CV to K-fold-CV"):
-        result = _calculate_ics(in_dict)
-
-    assert "model1" in result
-    assert "model2" in result
-    assert result["model1"].kind == "loo"
-    assert result["model2"].kind == "loo_kfold"
-
-
 def test_compare_mixed_elpd_methods(centered_eight, non_centered_eight):
     loo_result = loo(centered_eight, pointwise=True)
     kfold_result = loo(non_centered_eight, pointwise=True)


### PR DESCRIPTION
This adds more informative errors for `compare()`. See the discussion in https://github.com/stan-dev/loo/issues/296 for aligning certain error messages.

---
Resolves [#179](https://github.com/arviz-devs/arviz-stats/issues/179)

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--184.org.readthedocs.build/en/184/

<!-- readthedocs-preview arviz-stats end -->