### PR TITLE
Add callable log likelihood argument to `loo_i()`

### DIFF
--- a/src/arviz_stats/loo/loo.py
+++ b/src/arviz_stats/loo/loo.py
@@ -210,9 +210,11 @@ def loo_i(
         Custom log-likelihood function for a single observation. The signature must be
         ``log_lik_fn(observed, data)`` where ``observed`` is the observed data and ``data``
         is the full :class:`~arviz_base.DataTree` or :class:`~arviz_base.InferenceData`.
-        The function must return an :class:`~xarray.DataArray` with dimensions ``("chain", "draw")``
-        containing the per-draw log-likelihood values for that single observation. When provided,
-        ``loo_i`` uses this function instead of the ``log_likelihood`` group.
+        The function must return either a :class:`~xarray.DataArray` or a :class:`~numpy.ndarray`
+        with dimensions ``("chain", "draw")`` containing the per-draw log-likelihood values for
+        that single observation. Array outputs are automatically wrapped in a DataArray before
+        further validation. When provided, ``loo_i`` uses this function instead of the
+        ``log_likelihood`` group.
     log_weights : DataArray, optional
         Smoothed log weights. It must have the same shape as the log likelihood data.
         Defaults to None. If not provided, it will be computed using the PSIS-LOO method.

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -94,13 +94,14 @@ def loo_subsample(
         (default) to use all posterior draws. This value is stored in the returned
         ``ELPDData`` object and will be automatically used by ``update_subsample``.
     log_lik_fn : callable, optional
-        Function that computes the log-likelihood for observations given posterior parameters.
-        Required when ``method="plpd"`` or when ``method="lpd"`` and custom likelihood is needed.
-        The function signature is ``log_lik_fn(observations, data)`` where observations
-        is a :class:`~xarray.DataArray` of observed data and data is a
-        :class:`~xarray.DataTree` object. For ``method="plpd"``, posterior means are computed
-        automatically and passed in the posterior group. For ``method="lpd"``, full posterior
-        samples are passed. All other groups remain unchanged for direct access.
+        Custom log-likelihood function. The signature must be ``log_lik_fn(observed, data)``
+        where ``observed`` is an :class:`~xarray.DataArray` containing one or more observations
+        and ``data`` is the full :class:`~arviz_base.DataTree` or
+        :class:`~arviz_base.InferenceData`. The function must return a
+        :class:`~xarray.DataArray`. For ``method="lpd"`` it must include dimensions
+        ``("chain", "draw", *obs_dims)`` and contain the per-draw log-likelihood values. For
+        ``method="plpd"`` it must have dimensions matching the observation dimensions
+        ``obs_dims`` and provide the pointwise log predictive density.
     param_names : list, optional
         List of parameter names to extract from the posterior. If None, all parameters are used.
         Recommended to pass the required parameter names from the posterior group that are
@@ -448,15 +449,16 @@ def update_subsample(
         - ``lpd``: Use standard log predictive density approximation (default)
         - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``.
     log_lik_fn : callable, optional
-        Function that computes the log-likelihood for observations given posterior parameters.
-        Required when ``method="plpd"`` or when ``method="lpd"`` and custom likelihood is needed.
-        The function signature is ``log_lik_fn(observations, datatree)`` where observations
-        is a :class:`~xarray.DataArray` of observed data and datatree is a
-        :class:`~xarray.DataTree` object. For ``method="plpd"``, posterior means are computed
-        automatically and passed in the posterior group. For ``method="lpd"``, full posterior
-        samples are passed. All other groups remain unchanged for direct access.
-        Recommended to pass the required parameter names from the posterior group that are
-        necessary for the log-likelihood function.
+        Custom log-likelihood function. The signature must be ``log_lik_fn(observed, data)``
+        where ``observed`` is an :class:`~xarray.DataArray` containing one or more observations
+        and ``data`` is the full :class:`~arviz_base.DataTree` or
+        :class:`~arviz_base.InferenceData`.
+        The function must return an :class:`~xarray.DataArray`. For ``method="lpd"`` it must
+        include dimensions ``("chain", "draw", *obs_dims)`` and contain the per-draw
+        log-likelihood values. For ``method="plpd"`` it must have dimensions matching the
+        observation dimensions ``obs_dims`` and provide the pointwise log predictive density.
+        Posterior draws (full or mean-reduced) are provided in the ``posterior`` group depending
+        on the chosen method, while auxiliary groups remain aligned for direct access.
     param_names: list, optional
         List of parameter names to extract from the posterior. If None, all parameters are used.
     log: bool, optional

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -450,13 +450,12 @@ def update_subsample(
         - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``.
     log_lik_fn : callable, optional
         Custom log-likelihood function. The signature must be ``log_lik_fn(observed, data)``
-        where ``observed`` is an :class:`~xarray.DataArray` containing one or more observations
+        where ``observed`` is a :class:`~xarray.DataArray` containing one or more observations
         and ``data`` is the full :class:`~arviz_base.DataTree` or
-        :class:`~arviz_base.InferenceData`.
-        The function must return an :class:`~xarray.DataArray`. For ``method="lpd"`` it must
-        include dimensions ``("chain", "draw", *obs_dims)`` and contain the per-draw
-        log-likelihood values. For ``method="plpd"`` it must have dimensions matching the
-        observation dimensions ``obs_dims`` and provide the pointwise log predictive density.
+        :class:`~arviz_base.InferenceData`. The function must return a :class:`~xarray.DataArray`.
+        For ``method="lpd"`` it must include dimensions ``("chain", "draw", *obs_dims)`` and contain
+        the per-draw log-likelihood values. For ``method="plpd"`` it must have dimensions matching
+        the observation dimensions ``obs_dims`` and provide the pointwise log predictive density.
         Posterior draws (full or mean-reduced) are provided in the ``posterior`` group depending
         on the chosen method, while auxiliary groups remain aligned for direct access.
     param_names: list, optional

--- a/tests/test_helper_loo.py
+++ b/tests/test_helper_loo.py
@@ -23,7 +23,6 @@ from arviz_stats.loo.helper_loo import (
     _diff_srs_estimator,
     _extract_loo_data,
     _generate_subsample_indices,
-    _get_log_weights_i,
     _get_r_eff,
     _prepare_loo_inputs,
     _prepare_subsample,
@@ -616,51 +615,6 @@ def test_split_moment_match_errors():
             log_prob_upars_fn=lambda x: x,
             log_lik_i_upars_fn=lambda x, _i: x,
         )
-
-
-def test_get_log_weights_i():
-    chain_size, draw_size, obs_size = 2, 100, 8
-    log_weights = xr.DataArray(
-        np.random.randn(chain_size, draw_size, obs_size),
-        dims=["chain", "draw", "school"],
-        coords={
-            "chain": np.arange(chain_size),
-            "draw": np.arange(draw_size),
-            "school": np.arange(obs_size),
-        },
-    )
-
-    i = 3
-    result = _get_log_weights_i(log_weights, i, obs_dims=["school"])
-    assert result.dims == ("chain", "draw")
-    assert result.shape == (chain_size, draw_size)
-    xr.testing.assert_equal(result, log_weights.isel(school=i))
-
-    obs_size_2 = 4
-    log_weights_2d = xr.DataArray(
-        np.random.randn(chain_size, draw_size, obs_size, obs_size_2),
-        dims=["chain", "draw", "school", "subject"],
-        coords={
-            "chain": np.arange(chain_size),
-            "draw": np.arange(draw_size),
-            "school": np.arange(obs_size),
-            "subject": np.arange(obs_size_2),
-        },
-    )
-
-    i = 10
-    result_2d = _get_log_weights_i(log_weights_2d, i, obs_dims=["school", "subject"])
-    assert result_2d.dims == ("chain", "draw")
-    assert result_2d.shape == (chain_size, draw_size)
-
-    with pytest.raises(ValueError, match="log_weights must have observation dimensions"):
-        _get_log_weights_i(log_weights, 0, obs_dims=[])
-
-    with pytest.raises(IndexError, match="Index -1 is out of bounds"):
-        _get_log_weights_i(log_weights, -1, obs_dims=["school"])
-
-    with pytest.raises(IndexError, match="Index 8 is out of bounds"):
-        _get_log_weights_i(log_weights, 8, obs_dims=["school"])
 
 
 @pytest.mark.parametrize("method", ["lpd", "plpd"])


### PR DESCRIPTION
Adds the ability to pass a custom log-likelihood function to `loo_i()` for quick testing and debugging.

---
Resolves [#191](https://github.com/arviz-devs/arviz-stats/issues/191)