### PR TITLE
DOC: Improve the API formatting for `arviz_stats.compare`

### DIFF
--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -52,7 +52,6 @@ def compare(
         The columns are:
 
         - **rank**: The rank-order of the models. 0 is the best.
-        - **elpd**: ELPD estimated either using (PSIS-LOO-CV `elpd_loo` or WAIC `elpd_waic`).
         - **elpd**: ELPD estimated using PSIS-LOO-CV (`elpd_loo`).
           Higher ELPD indicates higher out-of-sample predictive fit ("better" model).
         - **pIC**: Estimated effective number of parameters.

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -69,7 +69,7 @@ def compare(
         - **dSE**: Standard error of the difference in ELPD between each model
           and the top-ranked model. It's always 0 for the top-ranked model.
         - **warning**: A value of 1 indicates that the computation of the ELPD may not be reliable.
-          This could be indication of WAIC/LOO starting to fail see
+          This could be indication of LOO starting to fail see
           http://arxiv.org/abs/1507.04544 for details.
 
     Examples

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -53,6 +53,7 @@ def compare(
 
         - **rank**: The rank-order of the models. 0 is the best.
         - **elpd**: ELPD estimated either using (PSIS-LOO-CV `elpd_loo` or WAIC `elpd_waic`).
+        - **elpd**: ELPD estimated using PSIS-LOO-CV (`elpd_loo`).
           Higher ELPD indicates higher out-of-sample predictive fit ("better" model).
         - **pIC**: Estimated effective number of parameters.
         - **elpd_diff**: The difference in ELPD between two models.

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -22,7 +22,7 @@ def compare(
     r"""Compare models based on their expected log pointwise predictive density (ELPD).
 
     The ELPD is estimated by Pareto smoothed importance sampling leave-one-out
-    cross-validation, the same method used by ``func:arviz_stats.loo``.
+    cross-validation, the same method used by :func:`arviz_stats.loo`.
     The method is described in [1]_ and [2]_.
     By default, the weights are estimated using ``"stacking"`` as described in [3]_.
 
@@ -46,26 +46,29 @@ def compare(
 
     Returns
     -------
-    A DataFrame, ordered from best to worst model (measured by the ELPD).
-    The index reflects the key with which the models are passed to this function. The columns are:
-    rank: The rank-order of the models. 0 is the best.
-    elpd: ELPD estimated either using (PSIS-LOO-CV `elpd_loo` or WAIC `elpd_waic`).
-        Higher ELPD indicates higher out-of-sample predictive fit ("better" model).
-    pIC: Estimated effective number of parameters.
-    elpd_diff: The difference in ELPD between two models.
-        If more than two models are compared, the difference is computed relative to the
-        top-ranked model, that always has a elpd_diff of 0.
-    weight: Relative weight for each model.
-        This can be loosely interpreted as the probability of each model (among the compared model)
-        given the data. By default the uncertainty in the weights estimation is considered using
-        Bayesian bootstrap.
-    SE: Standard error of the ELPD estimate.
-        If method = BB-pseudo-BMA these values are estimated using Bayesian bootstrap.
-    dSE: Standard error of the difference in ELPD between each model and the top-ranked model.
-        It's always 0 for the top-ranked model.
-    warning: A value of 1 indicates that the computation of the ELPD may not be reliable.
-        This could be indication of WAIC/LOO starting to fail see
-        http://arxiv.org/abs/1507.04544 for details.
+    DataFrame
+        A DataFrame, ordered from best to worst model (measured by the ELPD).
+        The index reflects the key with which the models are passed to this function.
+        The columns are:
+        
+        - **rank**: The rank-order of the models. 0 is the best.
+        - **elpd**: ELPD estimated either using (PSIS-LOO-CV `elpd_loo` or WAIC `elpd_waic`).
+          Higher ELPD indicates higher out-of-sample predictive fit ("better" model).
+        - **pIC**: Estimated effective number of parameters.
+        - **elpd_diff**: The difference in ELPD between two models.
+          If more than two models are compared, the difference is computed relative to the
+          top-ranked model, that always has an `elpd_diff` of 0.
+        - **weight**: Relative weight for each model.
+          This can be loosely interpreted as the probability of each model (among the compared models)
+          given the data. By default the uncertainty in the weights estimation is considered using
+          Bayesian bootstrap.
+        - **SE**: Standard error of the ELPD estimate.
+          If method = BB-pseudo-BMA these values are estimated using Bayesian bootstrap.
+        - **dSE**: Standard error of the difference in ELPD between each model and the top-ranked model.
+          It's always 0 for the top-ranked model.
+        - **warning**: A value of 1 indicates that the computation of the ELPD may not be reliable.
+          This could be indication of WAIC/LOO starting to fail see
+          http://arxiv.org/abs/1507.04544 for details.
 
     Examples
     --------

--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -50,7 +50,7 @@ def compare(
         A DataFrame, ordered from best to worst model (measured by the ELPD).
         The index reflects the key with which the models are passed to this function.
         The columns are:
-        
+
         - **rank**: The rank-order of the models. 0 is the best.
         - **elpd**: ELPD estimated either using (PSIS-LOO-CV `elpd_loo` or WAIC `elpd_waic`).
           Higher ELPD indicates higher out-of-sample predictive fit ("better" model).
@@ -59,13 +59,14 @@ def compare(
           If more than two models are compared, the difference is computed relative to the
           top-ranked model, that always has an `elpd_diff` of 0.
         - **weight**: Relative weight for each model.
-          This can be loosely interpreted as the probability of each model (among the compared models)
+          This can be loosely interpreted as the probability of each model
+          (among the compared models)
           given the data. By default the uncertainty in the weights estimation is considered using
           Bayesian bootstrap.
         - **SE**: Standard error of the ELPD estimate.
           If method = BB-pseudo-BMA these values are estimated using Bayesian bootstrap.
-        - **dSE**: Standard error of the difference in ELPD between each model and the top-ranked model.
-          It's always 0 for the top-ranked model.
+        - **dSE**: Standard error of the difference in ELPD between each model
+          and the top-ranked model. It's always 0 for the top-ranked model.
         - **warning**: A value of 1 indicates that the computation of the ELPD may not be reliable.
           This could be indication of WAIC/LOO starting to fail see
           http://arxiv.org/abs/1507.04544 for details.


### PR DESCRIPTION
Improve the API formatting for `arviz_stats.compare`:
https://arviz-stats.readthedocs.io/en/latest/api/generated/arviz_stats.compare.html

For the **Returns** section, I followed the format in `arviz_stats.loo`:
https://arviz-stats.readthedocs.io/en/latest/api/generated/arviz_stats.loo.html



<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--202.org.readthedocs.build/en/202/

<!-- readthedocs-preview arviz-stats end -->