### PR TITLE
Make pareto_khat consistent with pareto_min_ss

### DIFF
--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -147,11 +147,9 @@ class _BaseAccessor:
         """Pareto smoothed importance sampling."""
         return self._apply("psislw", dim=dim, **kwargs)
 
-    def pareto_khat(self, dims=None, r_eff=1.0, tail="both", log_weights=False, **kwargs):
+    def pareto_khat(self, sample_dims=None, **kwargs):
         """Compute Pareto k-hat diagnostic."""
-        return self._apply(
-            "pareto_khat", dims=dims, r_eff=r_eff, tail=tail, log_weights=log_weights, **kwargs
-        )
+        return self._apply("pareto_khat", sample_dims=sample_dims, **kwargs)
 
     def power_scale_lw(self, dim=None, **kwargs):
         """Compute log weights for power-scaling of the DataTree."""

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -367,16 +367,17 @@ class BaseDataArray:
             kwargs={"axis": np.arange(-len(dims), 0, 1)},
         )
 
-    def pareto_khat(self, da, dims=None, r_eff=1.0, tail="both", log_weights=False):
+    def pareto_khat(self, da, sample_dims=None, r_eff=1.0, tail="both", log_weights=False):
         """Compute Pareto k-hat diagnostic on DataArray input."""
-        dims = validate_dims(dims)
+        dims, chain_axis, draw_axis = validate_dims_chain_draw_axis(sample_dims)
         return apply_ufunc(
             self.array_class.pareto_khat,
             da,
             input_core_dims=[dims],
             output_core_dims=[[]],
             kwargs={
-                "axis": np.arange(-len(dims), 0, 1),
+                "chain_axis": chain_axis,
+                "draw_axis": draw_axis,
                 "r_eff": r_eff,
                 "tail": tail,
                 "log_weights": log_weights,

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -345,11 +345,9 @@ class _DiagnosticsBase(_CoreBase):
             )
             return np.nan
 
-        ary_flatten = ary.flatten()
-
         r_eff = self._ess_tail(ary, prob=0.05, relative=True)
 
-        _, kappa = self._pareto_khat(ary_flatten, r_eff=r_eff, tail="both", log_weights=False)
+        _, kappa = self._pareto_khat(ary, r_eff=r_eff, tail="both", log_weights=False)
 
         # This should be 1, but to avoid overflow we use 0.99
         # we could even use a lower value as this will give
@@ -395,6 +393,7 @@ class _DiagnosticsBase(_CoreBase):
         if log_weights:
             tail = "right"
 
+        ary = ary.flatten()
         n_draws = len(ary)
 
         n_draws_tail = self._get_ps_tails(n_draws, r_eff, tail=tail)

--- a/src/arviz_stats/loo/loo_expectations.py
+++ b/src/arviz_stats/loo/loo_expectations.py
@@ -257,7 +257,9 @@ def _get_function_khat(
 
     # Get right tail khat
     try:
-        khat_r_da = r_theta_da.azstats.pareto_khat(dims="sample", tail="right", log_weights=False)
+        khat_r_da = r_theta_da.azstats.pareto_khat(
+            sample_dims="sample", tail="right", log_weights=False
+        )
         khat_r = khat_r_da.item()
     except ValueError:
         khat_r = np.nan
@@ -279,7 +281,9 @@ def _get_function_khat(
     hr_theta_da = xr.DataArray(h_theta_values * r_theta_da.values, dims=["sample"])
 
     try:
-        khat_hr_da = hr_theta_da.azstats.pareto_khat(dims="sample", tail="both", log_weights=False)
+        khat_hr_da = hr_theta_da.azstats.pareto_khat(
+            sample_dims="sample", tail="both", log_weights=False
+        )
         khat_hr = khat_hr_da.item()
     except ValueError:
         khat_hr = np.nan


### PR DESCRIPTION
There were a few differences between these functions, for instance, the array interface returned one value per chain instead of 1 per sample (as pareto_min_ss) does. Also, it did not have default arguments. The behavior of the accessor was inconsistent, too.

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--206.org.readthedocs.build/en/206/

<!-- readthedocs-preview arviz-stats end -->