### PR TITLE
pin numba version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ funding = "https://opencollective.com/arviz"
 xarray = [
   "arviz-base @ git+https://github.com/arviz-devs/arviz-base",
   "xarray-einstats",
-  "numba",
+  "numba<=0.62.1",
 ]
 test = [
     "pytest",
@@ -66,7 +66,7 @@ doc = [
     "sphinx_autosummary_accessors",
 ]
 numba = [
-  "numba",
+  "numba<=0.62.1",
   "xarray_einstats[einops]",
 ]
 


### PR DESCRIPTION
I noticed slowdowns with the recently released version of numba, 0.62.0 

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--210.org.readthedocs.build/en/210/

<!-- readthedocs-preview arviz-stats end -->