### PR TITLE
Patch computations in `compare()` for subsampling

### DIFF
--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -311,7 +311,8 @@ def _compute_elpd_diff_subsampled(elpd_a, elpd_b, elpd_i_a, elpd_i_b, name_a=Non
 
     intersect_idx = set(elpd_a.loo_subsample_observations) & set(elpd_b.loo_subsample_observations)
 
-    if not intersect_idx:
+    # Need at least 2 overlapping observations to compute variance for difference estimator
+    if len(intersect_idx) < 2:
         model_names = ""
         if name_a and name_b:
             model_names = f" in '{name_a}' and '{name_b}'"

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -1225,7 +1225,7 @@ def test_compare_subsampled(centered_eight_with_sigma, centered_eight):
     assert "subsampling_dse" in comparison_updated.columns
     assert np.isfinite(comparison_updated["subsampling_dse"].values).all()
 
-    with pytest.warns(UserWarning, match="Different subsamples in 'model_a' and 'model_b'"):
+    with pytest.warns(UserWarning, match="Different subsamples used in 'model_a' and 'model_b'"):
         comparison_diff_subsample = compare({"model_a": loo_sub1, "model_b": loo_sub3})
     assert "subsampling_dse" in comparison_diff_subsample.columns
     assert np.isfinite(comparison_diff_subsample["subsampling_dse"].values).all()

--- a/tests/test_loo.py
+++ b/tests/test_loo.py
@@ -1217,20 +1217,20 @@ def test_compare_subsampled(centered_eight_with_sigma, centered_eight):
 
     comparison_subsampled = compare({"model1": loo_sub1, "model2": loo_sub2})
     assert "subsampling_dse" in comparison_subsampled.columns
-    assert not np.isnan(comparison_subsampled["subsampling_dse"].values).any()
-    assert not np.isnan(comparison_subsampled["dse"].values).any()
+    assert np.isfinite(comparison_subsampled["subsampling_dse"].values).all()
+    assert np.isfinite(comparison_subsampled["dse"].values).all()
     assert_almost_equal(comparison_subsampled["elpd_diff"].iloc[0], 0.0, decimal=4)
 
     comparison_updated = compare({"model1": loo_sub1, "model2": loo_updated})
     assert "subsampling_dse" in comparison_updated.columns
-    assert not np.isnan(comparison_updated["subsampling_dse"].values).any()
+    assert np.isfinite(comparison_updated["subsampling_dse"].values).all()
 
-    with pytest.warns(UserWarning, match="Different subsamples used in 'model_a' and 'model_b'"):
+    with pytest.warns(UserWarning, match="Different subsamples in 'model_a' and 'model_b'"):
         comparison_diff_subsample = compare({"model_a": loo_sub1, "model_b": loo_sub3})
     assert "subsampling_dse" in comparison_diff_subsample.columns
-    assert not np.isnan(comparison_diff_subsample["subsampling_dse"].values).any()
+    assert np.isfinite(comparison_diff_subsample["subsampling_dse"].values).all()
 
     comparison_regular = compare({"model1": loo_full, "model2": loo_full})
     assert "subsampling_dse" not in comparison_regular.columns
-    assert not np.isnan(comparison_regular["dse"].values).any()
+    assert np.isfinite(comparison_regular["dse"].values).all()
     assert_almost_equal(comparison_regular["elpd_diff"].iloc[0], 0.0, decimal=4)


### PR DESCRIPTION
This fixes some issues in how we compute ELPD differences for subsampled models. Previously, we had some minor problems that led to slight miscalculations in variance estimates. This new approach converts everything to numpy arrays and flattens before indexing to avoid any dimension issues.

We effectively need to  address three distinct cases: 

1. when neither model uses subsampling, we compute standard pointwise differences
2. when only one model uses subsampling, we compute on overlapping observations and combine uncertainties
3. when both models use subsampling, we use the difference-of-estimators approach on the intersection of subsamples, with a fallback to naive diff when subsamples don't overlap

We also add some warnings to the user for certain scenarios.