### PR TITLE
Fix return docstrings for loo functions

### DIFF
--- a/src/arviz_stats/loo/loo.py
+++ b/src/arviz_stats/loo/loo.py
@@ -65,20 +65,24 @@ def loo(
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo"
         - **elpd**: expected log pointwise predictive density
         - **se**: standard error of the elpd
         - **p**: effective number of parameters
         - **n_samples**: number of samples
         - **n_data_points**: number of data points
+        - **scale**: "log"
         - **warning**: True if the estimated shape parameter of Pareto distribution is greater
           than ``good_k``.
-        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
-          ``pointwise=True``
-        - **pareto_k**: array of Pareto shape values, only if ``pointwise=True``
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
-        - **approx_posterior**: True if approximate posterior was used.
+        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
+          ``pointwise=True``
+        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values,
+          only if ``pointwise=True``
+        - **approx_posterior**: False (not used for standard LOO)
         - **log_weights**: Smoothed log weights.
+        - **log_jacobian**: Log-Jacobian adjustment for variable transformations.
 
     Examples
     --------
@@ -234,18 +238,23 @@ def loo_i(
     ELPDData
         Object with the following attributes:
 
-        - **elpd**: expected log pointwise predictive density for observation i
+        - **kind**: "loo"
+        - **elpd**: expected log pointwise predictive density for observation :math:`i`
         - **se**: standard error (set to 0.0 as SE is undefined for a single observation)
-        - **p**: effective number of parameters for observation i
+        - **p**: effective number of parameters for observation :math:`i`
         - **n_samples**: number of samples
         - **n_data_points**: 1 (single observation)
+        - **scale**: "log"
         - **warning**: True if the estimated shape parameter of Pareto distribution is greater
           than ``good_k``
-        - **elpd_i**: :class:`~xarray.DataArray` with single value
-        - **pareto_k**: :class:`~xarray.DataArray` with single Pareto shape value
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
-        - **log_weights**: Smoothed log weights for observation i
+        - **elpd_i**: scalar value of the expected log pointwise predictive density for observation
+          :math:`i`
+        - **pareto_k**: scalar Pareto shape value for observation :math:`i`
+        - **approx_posterior**: False (not used for standard LOO)
+        - **log_weights**: Smoothed log weights for observation :math:`i`
+        - **log_jacobian**: Log-Jacobian adjustment for variable transformations.
 
     Notes
     -----

--- a/src/arviz_stats/loo/loo_approximate_posterior.py
+++ b/src/arviz_stats/loo/loo_approximate_posterior.py
@@ -52,19 +52,22 @@ def loo_approximate_posterior(data, log_p, log_q, pointwise=None, var_name=None,
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo"
         - **elpd**: expected log pointwise predictive density
         - **se**: standard error of the elpd
         - **p**: effective number of parameters
         - **n_samples**: number of samples
         - **n_data_points**: number of data points
+        - **scale**: "log"
         - **warning**: True if the estimated shape parameter of Pareto distribution is greater
           than ``good_k``.
-        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
-          ``pointwise=True``
-        - **pareto_k**: array of Pareto shape values, only if ``pointwise=True``
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
-        - **approx_posterior**: True if approximate posterior was used.
+        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy,
+          only if ``pointwise=True``
+        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values,
+          only if ``pointwise=True``
+        - **approx_posterior**: True (approximate posterior correction applied)
 
     Examples
     --------

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -69,21 +69,23 @@ def loo_kfold(
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo_kfold"
         - **elpd**: expected log pointwise predictive density
         - **se**: standard error of the elpd
         - **p**: effective number of parameters
         - **n_samples**: number of samples per fold
         - **n_data_points**: number of data points
-        - **warning**: True if any issues occurred during fitting
-        - **elpd_i**: pointwise predictive accuracy (if ``pointwise=True``)
-        - **p_kfold_i**: pointwise effective number of parameters (if ``pointwise=True``)
-        - **pareto_k**: None (not applicable for k-fold)
         - **scale**: "log"
-
-        Additional attributes when ``save_fits=True``:
-
-        - **fold_fits**: Dictionary containing fitted models for each fold
-        - **fold_indices**: Dictionary containing test indices for each fold
+        - **warning**: False (not applicable for :math:`k`-fold)
+        - **good_k**: None (not applicable for :math:`k`-fold)
+        - **elpd_i**: :class:`~xarray.DataArray` with pointwise predictive accuracy,
+          only if ``pointwise=True``
+        - **pareto_k**: None (not applicable for :math:`k`-fold)
+        - **n_folds**: number of folds (:math:`k`)
+        - **p_kfold_i**: :class:`~xarray.DataArray` with pointwise effective number of parameters,
+          only if ``pointwise=True``
+        - **fold_fits**: Dictionary containing fitted models for each fold,
+          only if ``save_fits=True``
 
     Examples
     --------

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -112,19 +112,23 @@ def loo_moment_match(
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo"
         - **elpd**: expected log pointwise predictive density
         - **se**: standard error of the elpd
         - **p**: effective number of parameters
         - **n_samples**: number of samples
         - **n_data_points**: number of data points
+        - **scale**: "log"
         - **warning**: True if the estimated shape parameter of Pareto distribution is greater
           than ``good_k``.
-        - **elp_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
-          ``pointwise=True``
-        - **pareto_k**: array of Pareto shape values, only if ``pointwise=True``
         - **good_k**: For a sample size S, the threshold is computed as
           ``min(1 - 1/log10(S), 0.7)``
-        - **approx_posterior**: True if approximate posterior was used.
+        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
+          ``pointwise=True``.
+        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values, only if
+          ``pointwise=True``.
+        - **approx_posterior**: False (not used for standard LOO)
+        - **log_weights**: Smoothed log weights.
 
     Examples
     --------

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -126,28 +126,29 @@ def loo_subsample(
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo"
         - **elpd**: approximated expected log pointwise predictive density (elpd)
-        - **se**: standard error of the elpd (includes approximation and sampling uncertainty)
+        - **se**: standard error of the elpd
         - **p**: effective number of parameters
         - **n_samples**: number of samples in the posterior
-        - **n_data_points**: total number of data points (N)
-        - **warning**: True if the estimated shape parameter k of the Pareto distribution
+        - **n_data_points**: total number of data points (:math:`N`)
+        - **scale**: "log"
+        - **warning**: True if the estimated shape parameter of the Pareto distribution
           is > ``good_k`` for any observation in the subsample.
-        - **elpd_i**: :class:`~xarray.DataArray` with pointwise elpd values (filled with NaNs
-          for non-subsampled points), only if ``pointwise=True``.
-        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values for the subsample
-          (filled with NaNs for non-subsampled points), only if ``pointwise=True``.
-        - **scale**: scale of the elpd results ("log", "negative_log", or "deviance").
         - **good_k**: Threshold for Pareto k warnings.
+        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise elpd values, only if
+          ``pointwise=True``.
+        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values, only if
+          ``pointwise=True``.
         - **approx_posterior**: True if approximate posterior was used.
         - **subsampling_se**: Standard error estimate from subsampling uncertainty only.
-        - **subsample_size**: Number of observations in the subsample (m).
+        - **subsample_size**: Number of observations in the subsample (:math:`m`).
         - **log_p**: Log density of the target posterior.
         - **log_q**: Log density of the proposal posterior.
-        - **thin**: Thinning factor for posterior draws.
+        - **thin_factor**: Thinning factor for posterior draws.
         - **log_weights**: Smoothed log weights.
         - **loo_subsample_observations**: Indices of subsampled observations.
-        - **elpd_loo_approx**: Approximation for all N observations.
+        - **elpd_loo_approx**: Approximation for all :math:`N` observations.
         - **log_jacobian**: Log-Jacobian adjustment for variable transformations.
 
     Examples
@@ -498,26 +499,28 @@ def update_subsample(
     ELPDData
         Object with the following attributes:
 
+        - **kind**: "loo"
         - **elpd**: updated approximated expected log pointwise predictive density (elpd)
         - **se**: standard error of the elpd (includes approximation and sampling uncertainty)
         - **p**: effective number of parameters
         - **n_samples**: number of samples in the posterior
         - **n_data_points**: total number of data points (N)
+        - **scale**: "log"
         - **warning**: True if the estimated shape parameter k of the Pareto distribution
           is > ``good_k`` for any observation in the subsample.
+        - **good_k**: Threshold for Pareto k warnings.
         - **elpd_i**: :class:`~xarray.DataArray` with pointwise elpd values (filled with NaNs
           for non-subsampled points), only if ``pointwise=True``.
         - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values for the subsample
           (filled with NaNs for non-subsampled points), only if ``pointwise=True``.
-        - **scale**: scale of the elpd results ("log", "negative_log", or "deviance").
-        - **good_k**: Threshold for Pareto k warnings.
         - **approx_posterior**: True if approximate posterior was used.
         - **subsampling_se**: Standard error estimate from subsampling uncertainty only.
         - **subsample_size**: Number of observations in the subsample (original + new).
         - **log_p**: Log density of the target posterior.
         - **log_q**: Log density of the proposal posterior.
-        - **thin**: Thinning factor for posterior draws.
+        - **thin_factor**: Thinning factor for posterior draws.
         - **log_weights**: Smoothed log weights.
+        - **n_folds**: None (not applicable for subsampled LOO)
         - **loo_subsample_observations**: Indices of subsampled observations.
         - **elpd_loo_approx**: Approximation for all N observations.
         - **log_jacobian**: Log-Jacobian adjustment for variable transformations.

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -72,8 +72,25 @@ def reloo(
     Returns
     -------
     ELPDData
-        Updated LOO results where high Pareto k observations have been
-        replaced with exact LOO-CV values from refitting.
+        Updated LOO results with the following attributes:
+
+        - **kind**: "loo"
+        - **elpd**: expected log pointwise predictive density
+        - **se**: standard error of the elpd
+        - **p**: effective number of parameters
+        - **n_samples**: number of samples
+        - **n_data_points**: number of data points
+        - **scale**: "log"
+        - **warning**: True if the estimated shape parameter of Pareto distribution is greater
+          than ``good_k``.
+        - **good_k**: For a sample size S, the threshold is computed as
+          ``min(1 - 1/log10(S), 0.7)``
+        - **elpd_i**: :class:`~xarray.DataArray` with the pointwise predictive accuracy, only if
+          ``pointwise=True``
+        - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values,
+          only if ``pointwise=True``
+        - **approx_posterior**: False (not used for standard LOO)
+        - **log_weights**: Smoothed log weights.
 
     Notes
     -----


### PR DESCRIPTION
Standardizes the return docstrings for various LOO functions

<!-- readthedocs-preview arviz-stats start -->
----
📚 Documentation preview 📚: https://arviz-stats--233.org.readthedocs.build/en/233/

<!-- readthedocs-preview arviz-stats end -->