### PR TITLE
Add order statistic diagnostic for `compare()`

### DIFF
--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -558,14 +558,12 @@ def _order_stat_check(ics_dict, model_order, has_subsampling):
     baseline_model = model_order[baseline_idx]
     baseline_elpd = ics_dict[baseline_model]
 
-    elpd_diffs = []
-    for model_name in model_order:
-        if model_name == baseline_model:
-            elpd_diffs.append(0.0)
-        else:
-            elpd_a_vals = np.asarray(baseline_elpd.elpd_i).flatten()
-            elpd_b_vals = np.asarray(ics_dict[model_name].elpd_i).flatten()
-            elpd_diffs.append(np.sum(elpd_b_vals - elpd_a_vals))
+    elpd_diffs = np.zeros(len(model_order))
+    for idx, model_name in enumerate(model_order):
+        if model_name != baseline_model:
+            elpd_a_vals = np.ravel(baseline_elpd.elpd_i)
+            elpd_b_vals = np.ravel(ics_dict[model_name].elpd_i)
+            elpd_diffs[idx] = np.sum(elpd_b_vals - elpd_a_vals)
 
     elpd_diffs = np.array(elpd_diffs)
     diff_median = np.median(elpd_diffs)


### PR DESCRIPTION
This implements the order statistic diagnostic for detecting selection induced bias when comparing many models in `compare()`. When more than 11 models are compared using full PSIS-LOO-CV, the diagnostic estimates whether the observed performance difference could be due to chance by comparing the best model's ELPD difference against the expected maximum order statistic under a null hypothesis of equal performance. 

This diagnostic is not done for the subsampling case. As far as I can tell, it isn't done here either https://github.com/stan-dev/loo/blob/d6fe380161fcd3ba07065ce0a525146abdb2c1d7/R/loo_compare.psis_loo_ss_list.R. I'm not exactly sure why this is, but my guess is that the the theoretical assumptions underlying the test don't account for the additional variance and approximation bias introduced by subsampling, making it unclear whether the null distribution would be properly calibrated in that setting.

---
Resolves https://github.com/arviz-devs/arviz-stats/issues/234