### PR TITLE
DOC: Add the reference Säilynoja et al. (2022) from EABM

### DIFF
--- a/src/arviz_stats/manipulation.py
+++ b/src/arviz_stats/manipulation.py
@@ -63,7 +63,7 @@ def thin(
 
     .. [1] Säilynoja, T., Bürkner, PC. & Vehtari, A. "Graphical test for discrete
            uniformity and its applications in goodness-of-fit evaluation and
-           multiple sample comparison." Statistics and Computing 32, 32 (2022).
+           multiple sample comparison." Statistics and Computing 32(2), 32 (2022).
            https://doi.org/10.1007/s11222-022-10090-6
 
     Examples


### PR DESCRIPTION
In the [arviz_stats.thin](https://arviz-stats.readthedocs.io/en/latest/api/generated/arviz_stats.thin.html) documentation, we need to add the reference **Säilynoja et al. (2022)** from [EABM](https://arviz-devs.github.io/EABM/Chapters/References.html): 

Säilynoja, Teemu, Paul-Christian Bürkner, and Aki Vehtari. 2022. “Graphical Test for Discrete Uniformity and Its Applications in Goodness-of-Fit Evaluation and Multiple Sample Comparison.” Statistics and Computing 32 (2): 32. https://doi.org/10.1007/s11222-022-10090-6.

Säilynoja co-published many research papers, so I hope this one is the correct citation.