### PR TITLE
Add original Pareto k to `ELPDData` for moment matching

### DIFF
--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -129,7 +129,7 @@ def loo_moment_match(
           ``pointwise=True``.
         - **approx_posterior**: False (not used for standard LOO)
         - **log_weights**: Smoothed log weights.
-        - **pareto_k_original**: :class:`~xarray.DataArray` with original (pre-moment-matching)
+        - **influence_pareto_k**: :class:`~xarray.DataArray` with original (pre-moment-matching)
           Pareto shape values, only if ``pointwise=True``.
 
     Examples
@@ -414,7 +414,7 @@ def loo_moment_match(
     if k_threshold is None:
         k_threshold = min(1 - 1 / np.log10(n_samples), 0.7) if n_samples > 1 else 0.7
 
-    loo_data.pareto_k_original = loo_data.pareto_k.copy()
+    loo_data.influence_pareto_k = loo_data.pareto_k.copy()
 
     ks = loo_data.pareto_k.stack(__obs__=obs_dims).transpose("__obs__").values
     bad_obs_indices = np.where(ks > k_threshold)[0]
@@ -424,7 +424,7 @@ def loo_moment_match(
         if not pointwise:
             loo_data.elpd_i = None
             loo_data.pareto_k = None
-            loo_data.pareto_k_original = None
+            loo_data.influence_pareto_k = None
             if hasattr(loo_data, "p_loo_i"):
                 loo_data.p_loo_i = None
         return loo_data
@@ -519,7 +519,7 @@ def loo_moment_match(
     if not pointwise:
         loo_data.elpd_i = None
         loo_data.pareto_k = None
-        loo_data.pareto_k_original = None
+        loo_data.influence_pareto_k = None
         if hasattr(loo_data, "p_loo_i"):
             loo_data.p_loo_i = None
     return loo_data

--- a/src/arviz_stats/utils.py
+++ b/src/arviz_stats/utils.py
@@ -191,7 +191,7 @@ class ELPDData:  # pylint: disable=too-many-ancestors, too-many-instance-attribu
     loo_subsample_observations: np.ndarray = None
     elpd_loo_approx: DataArray = None
     log_jacobian: DataArray = None
-    pareto_k_original: DataArray = None
+    influence_pareto_k: DataArray = None
 
     def __str__(self):
         """Print elpd data in a user friendly way."""


### PR DESCRIPTION
This adds the original Pareto k pointwise values as well as the Pareto k values after moment matching. It would be useful for the user to be able to compare these after moment matching.