### PR TITLE
Change internal Pareto stacking dimension name

### DIFF
--- a/src/arviz_stats/loo/helper_loo.py
+++ b/src/arviz_stats/loo/helper_loo.py
@@ -337,7 +337,7 @@ def _extract_loo_data(loo_orig):
 
     sample_dims = ["chain", "draw"]
     obs_dims = [dim for dim in elpd_values.dims if dim not in sample_dims]
-    stacked_obs_dim = "__obs__"
+    stacked_obs_dim = "__pareto_obs_stacked__"
 
     if len(obs_dims) == 1:
         obs_dim = obs_dims[0]

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -369,7 +369,11 @@ def loo_moment_match(
 
     loo_data.influence_pareto_k = loo_data.pareto_k.copy()
 
-    ks = loo_data.pareto_k.stack(__obs__=obs_dims).transpose("__obs__").values
+    ks = (
+        loo_data.pareto_k.stack(__pareto_obs_stacked__=obs_dims)
+        .transpose("__pareto_obs_stacked__")
+        .values
+    )
     bad_obs_indices = np.where(ks > k_threshold)[0]
 
     if len(bad_obs_indices) == 0:
@@ -452,7 +456,11 @@ def loo_moment_match(
                     idx_dict = dict(zip(obs_dims, coords))
                 loo_data.p_loo_i[idx_dict] = loo_orig.p_loo_i[idx_dict]
 
-    final_ks = loo_data.pareto_k.stack(__obs__=obs_dims).transpose("__obs__").values
+    final_ks = (
+        loo_data.pareto_k.stack(__pareto_obs_stacked__=obs_dims)
+        .transpose("__pareto_obs_stacked__")
+        .values
+    )
 
     if np.any(final_ks[bad_obs_indices] > k_threshold):
         warnings.warn(


### PR DESCRIPTION
This uses `__pareto_obs_stacked__` as internal stacking dimension name in `loo_moment_match()` instead of `__obs__` to avoid conflicts with  user defined dimension names that could potentially cause an `xarray` error