### PR TITLE
Add numba to docs tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,7 @@ setenv =
 extras =
     doc
     xarray
+    numba
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
 


### PR DESCRIPTION
The local docs build with `tox -e docs` fails because we don't have the `numba` dependency. If we don't need this, I think another solution would be to use `autodoc_mock_imports` in the sphinx config to mock the `numba` dependency. Need to double check this though.

If this isn't necessary we can close this, but I personally like to build the docs locally to catch anything before opening a PR.