### PR TITLE
Add top_only argument and match density

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -570,7 +570,17 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             **kwargs,
         )
 
-    def qds(self, ary, nquantiles=100, binwidth=None, dotsize=1, stackratio=1, axis=-1, **kwargs):
+    def qds(
+        self,
+        ary,
+        nquantiles=100,
+        binwidth=None,
+        dotsize=1,
+        stackratio=1,
+        top_only=False,
+        axis=-1,
+        **kwargs,
+    ):
         """Compute quantile dot."""
         ary, axes = process_ary_axes(ary, axis)
         qd_ufunc = make_ufunc(
@@ -585,10 +595,11 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         return qd_ufunc(
             ary,
             out_shape=((out_s,), (out_s,), ()),
-            nquantiles=nquantiles,
+            nquantiles=out_s,
             binwidth=binwidth,
             dotsize=dotsize,
             stackratio=stackratio,
+            top_only=top_only,
             **kwargs,
         )
 

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -246,7 +246,17 @@ class BaseDataArray:
         out = concat((grid, pdf), dim=plot_axis)
         return out.assign_coords({"bw" if da.name is None else f"bw_{da.name}": bw})
 
-    def qds(self, da, nquantiles=100, binwidth=None, dotsize=1, stackratio=1, dim=None, **kwargs):
+    def qds(
+        self,
+        da,
+        nquantiles=100,
+        binwidth=None,
+        dotsize=1,
+        stackratio=1,
+        top_only=False,
+        dim=None,
+        **kwargs,
+    ):
         """Compute quantile dots on DataArray input."""
         dims = validate_dims(dim)
         x, y, radius = apply_ufunc(
@@ -257,6 +267,7 @@ class BaseDataArray:
                 "binwidth": binwidth,
                 "dotsize": dotsize,
                 "stackratio": stackratio,
+                "top_only": top_only,
                 "axis": np.arange(-len(dims), 0, 1),
                 **kwargs,
             },

--- a/src/arviz_stats/visualization.py
+++ b/src/arviz_stats/visualization.py
@@ -532,6 +532,7 @@ def qds(
     binwidth=None,
     dotsize=1,
     stackratio=1,
+    top_only=False,
     **kwargs,
 ):
     r"""Compute the marginal quantile dots.
@@ -565,6 +566,8 @@ def qds(
     coords : dict, optional
         Dictionary of dimension/index names to coordinate values defining a subset
         of the data for which to perform the computation.
+    nquantiles : int, default 100
+        Number of quantiles (i.e., dots) to compute.
     binwidth : float, optional
         Width of the bin for the dots.
     dotsize : float, default 1
@@ -573,6 +576,8 @@ def qds(
     stackratio : float, default 1
         The distance between the center of the dots in the same stack relative to the bin height.
         The default makes dots in the same stack just touch each other.
+    top_only : bool, default False
+        If true, only the top dots of each stack are returned.
     **kwargs : any, optional
         Forwarded to the array or dataarray interface for quantile dots.
 
@@ -634,5 +639,6 @@ def qds(
         binwidth=binwidth,
         dotsize=dotsize,
         stackratio=stackratio,
+        top_only=top_only,
         **kwargs,
     )


### PR DESCRIPTION
Add a top_only argument, which will allow for a ppc plot like this

<img width="1223" height="559" alt="output" src="https://github.com/user-attachments/assets/71be6ed7-46f5-48ef-b437-4ed9ebd85c39" />


as discussed in https://arxiv.org/abs/2503.01509

This also ensures that the dots represent a density. For instance, when overlaying a KDE and a dot plot, the line of the KDE will approximately be the envelope of the dots.