### PR TITLE
Fix Numba array backend edge cases and maximize pure Python test coverage

### DIFF
--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -72,12 +72,15 @@ class NumbaArray(BaseArray):
             axes = [(-1,), (0,), (0,)]
 
         quantile_ary = np.atleast_1d(quantile)
-
         # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
         result = _quantile_ufunc(ary, quantile_ary, axes=axes)
+
+        result = np.moveaxis(result, 0, -1)
+
         if np.ndim(quantile) == 0:
-            return result
-        return np.moveaxis(result, 0, -1)
+            return result[..., 0]
+            
+        return result
 
     def _histogram(self, ary, bins=None, range=None, weights=None, density=True):  # pylint: disable=redefined-builtin
         """Compute the histogram of the data."""

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -20,7 +20,7 @@ def process_ary_axes(ary, axes):
     reordered_axes = [i for i in range(ary.ndim) if i not in axes] + list(axes)
     ary = np.transpose(ary, axes=reordered_axes)
     ary = ary.reshape((*ary.shape[: -len(axes)], -1))
-    return ary, axes
+    return ary
 
 
 @guvectorize(
@@ -65,8 +65,8 @@ class NumbaArray(BaseArray):
 
         axes = axis
         if axes is not None:
-            ary, axes = process_ary_axes(ary, axes)
-            axes = [axes, (0,), (0,)]
+            ary = process_ary_axes(ary, axes)
+            axes = [(-1,), (0,), (0,)]
         else:
             ary = ary.ravel()
             axes = [(-1,), (0,), (0,)]
@@ -143,7 +143,7 @@ class NumbaArray(BaseArray):
         ensuring the proper method of the initialized class is the one being guvectorized.
         """
         if axis is not None:
-            ary, axis = process_ary_axes(ary, axis)
+            ary = process_ary_axes(ary, axis)
             kwargs["axes"] = [(-1,), (0,), (), (), ()]
         else:
             ary = ary.ravel()

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -72,6 +72,7 @@ class NumbaArray(BaseArray):
             axes = [(-1,), (0,), (0,)]
 
         quantile_ary = np.atleast_1d(quantile)
+
         # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
         result = _quantile_ufunc(ary, quantile_ary, axes=axes)
 
@@ -79,7 +80,7 @@ class NumbaArray(BaseArray):
 
         if np.ndim(quantile) == 0:
             return result[..., 0]
-            
+
         return result
 
     def _histogram(self, ary, bins=None, range=None, weights=None, density=True):  # pylint: disable=redefined-builtin

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -66,7 +66,7 @@ class NumbaArray(BaseArray):
         axes = axis
         if axes is not None:
             ary, axes = process_ary_axes(ary, axes)
-            axes = [(-1,), (0,), (0,)]
+            axes = [axes, (0,), (0,)]
         else:
             ary = ary.ravel()
             axes = [(-1,), (0,), (0,)]

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -69,9 +69,12 @@ class NumbaArray(BaseArray):
             axes = [(-1,), (0,), (0,)]
         else:
             ary = ary.ravel()
+            axes = [(-1,), (0,), (0,)]
+
+        quantile_ary = np.atleast_1d(quantile)
 
         # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
-        result = _quantile_ufunc(ary, quantile, axes=axes)
+        result = _quantile_ufunc(ary, quantile_ary, axes=axes)
         if np.ndim(quantile) == 0:
             return result
         return np.moveaxis(result, 0, -1)

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -48,6 +48,19 @@ class TestQuantileUfunc:
         _quantile_ufunc(a, q, out)
         assert_allclose(out[0], 49.5, rtol=0.01)
 
+    def test_quantile_parity(self):  
+        """Verify that the Numba quantile ufunc perfectly matches standard NumPy."""
+        rng = np.random.default_rng(42)
+        a = rng.normal(size=1000)
+        q = np.array([0.05, 0.5, 0.95])
+        
+        expected = np.quantile(a, q)
+        actual = np.zeros_like(expected)
+        
+        _quantile_ufunc(a, q, actual)
+        
+        assert_allclose(actual, expected, rtol=1e-7, atol=1e-7)
+
 
 class TestHistogramJit:
     def test_histogram_jit_basic(self, rng):
@@ -92,6 +105,24 @@ class TestNumbaArray:
         }
         assert result.shape == expected_shape[axis]
 
+    def test_quantile_axis_none(self, rng):
+        """Test that passing axis=None correctly triggers the ravel() fallback."""
+        array_stats = NumbaArray()
+        ary = rng.normal(size=(2, 3, 4))
+        
+        result = array_stats.quantile(ary, np.array([0.5]), axis=None)
+        
+        assert result.shape == (1,)
+
+    def test_quantile_scalar(self, rng):
+        """Test that passing a scalar quantile triggers the ndim==0 return path."""
+        array_stats = NumbaArray()
+        ary = rng.normal(size=(2, 3, 4))
+        
+        result = array_stats.quantile(ary, 0.5, axis=-1)
+        
+        assert result is not None
+
     @pytest.mark.parametrize("axis", [0, 1, -1])
     def test_quantile_axis_multiple_quantiles(self, rng, axis):
         array_stats = NumbaArray()
@@ -123,6 +154,35 @@ class TestNumbaArray:
         hist, edges = array_stats._histogram(ary, bins=10, density=True)
         bin_width = edges[1] - edges[0]
         assert_allclose(np.sum(hist) * bin_width, 1.0, rtol=0.01)
+
+    def test_histogram_bins_none(self, rng):
+        """Test that passing bins=None triggers the fallback to _get_bins."""
+        array_stats = NumbaArray()
+        ary = rng.normal(size=100) 
+        
+        hist, bin_edges = array_stats._histogram(ary, bins=None)
+        
+        assert hist is not None
+        assert bin_edges is not None
+        assert len(hist) > 0
+        assert len(bin_edges) == len(hist) + 1
+
+    def test_kde_initialization_and_run(self, rng):
+        """Test that kde_ufunc lazy initializes and executes correctly."""
+        array_stats = NumbaArray()
+        assert array_stats._kde_ufunc is None
+        ufunc = array_stats.kde_ufunc
+        assert ufunc is not None
+        assert array_stats._kde_ufunc is not None
+        
+        ary = rng.normal(size=100)
+        
+        x, pdf, bw = array_stats.kde(ary)
+        
+        assert x is not None
+        assert pdf is not None
+        assert bw is not None
+        assert len(x) == len(pdf)
 
     def test_histogram_weights_not_supported(self, rng):
         array_stats = NumbaArray()
@@ -159,6 +219,18 @@ class TestNumbaArray:
         assert grid.shape == expected_shape[axis]
         assert pdf.shape == expected_shape[axis]
         assert bw.shape == expected_bw_shape[axis]
+
+    def test_kde_axis_none(self, rng):
+        """Test that KDE correctly flattens the array when axis=None."""
+        array_stats = NumbaArray()
+        ary = rng.normal(size=(2, 50))
+        
+        x, pdf, bw = array_stats.kde(ary, axis=None)
+        
+        assert x is not None
+        assert pdf is not None
+        assert bw is not None
+        assert len(x) == len(pdf)
 
     def test_kde_ufunc_caching(self):
         array_stats = NumbaArray()

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -49,21 +49,6 @@ class TestQuantileUfunc:
         assert_allclose(out[0], 49.5, rtol=0.01)
 
 
-    def test_quantile_parity(self):
-        """Verify that the function correctly handles 2D arrays, axes, and scalars."""
-        rng = np.random.default_rng(42)
-        a = rng.normal(size=(10, 3)) 
-        # Make the quantile a scalar to test 'ndim==0' logic
-        q = 0.5 
-        expected = np.quantile(a, q, axis=0)
-        
-
-        actual = NumbaArray().quantile(a, q, axis=0)
-        
-        assert actual.shape == expected.shape
-        assert_allclose(actual, expected, rtol=1e-7, atol=1e-7)
-
-
 class TestHistogramJit:
     def test_histogram_jit_basic(self, rng):
         ary = rng.normal(size=100)
@@ -101,18 +86,17 @@ class TestNumbaArray:
             (1, (10, 30, 1)),
             (-1, (10, 20, 1)),
             (-2, (10, 30, 1)),
-            (None, (1,)),         
-            ((0, 1), (30, 1)),    #swapped lists to tuples
+            (None, (1,)),
+            ((0, 1), (30, 1)),
             ((0, -1), (20, 1)),
-        ]
+        ],
     )
     def test_quantile_axis(self, rng, axis, expected_shape):
         array_stats = NumbaArray()
         ary = rng.normal(size=(10, 20, 30))
-        
+
         result = array_stats.quantile(ary, np.array([0.5]), axis=axis)
-        
-        # The expected_shape is passed directly from the parametrize list above
+
         assert result.shape == expected_shape
 
     @pytest.mark.parametrize(
@@ -121,28 +105,19 @@ class TestNumbaArray:
             (0, (3, 4)),
             (1, (2, 4)),
             (-1, (2, 3)),
-            (None, ()),          # axis=None results in a 0-dimensional scalar
-            ((0, 1), (4,)),      # Operating on multiple axes drops both
-        ]
+            (None, ()),  # axis=None results in a 0-dimensional scalar
+            ((0, 1), (4,)),  # Operating on multiple axes drops both
+        ],
     )
     def test_quantile_scalar(self, rng, axis, expected_shape):
         """Test that passing a scalar quantile triggers the ndim==0 return path."""
         array_stats = NumbaArray()
         ary = rng.normal(size=(2, 3, 4))
-        
+
         # We pass 0.5 (a scalar) instead of [0.5] (a list)
         result = array_stats.quantile(ary, 0.5, axis=axis)
-        
-        assert result.shape == expected_shape
 
-    def test_quantile_axis_none(self, rng):
-        """Test that passing axis=None correctly triggers the ravel() fallback."""
-        array_stats = NumbaArray()
-        ary = rng.normal(size=(2, 3, 4))
-        
-        result = array_stats.quantile(ary, np.array([0.5]), axis=None)
-        
-        assert result.shape == (1,)
+        assert result.shape == expected_shape
 
     @pytest.mark.parametrize("axis", [0, 1, -1])
     def test_quantile_axis_multiple_quantiles(self, rng, axis):
@@ -178,10 +153,10 @@ class TestNumbaArray:
 
     def test_histogram_bins_none(self, rng):
         array_stats = NumbaArray()
-        ary = rng.normal(size=100) 
-        
+        ary = rng.normal(size=100)
+
         hist, bin_edges = array_stats._histogram(ary, bins=None)
-        
+
         assert hist is not None
         assert bin_edges is not None
         assert len(hist) > 0
@@ -209,15 +184,17 @@ class TestNumbaArray:
             (1, (10, 30, 128), (10, 30)),
             (-1, (10, 20, 128), (10, 20)),
             (-2, (10, 30, 128), (10, 30)),
-            (None, (128,), ()),  
-        ]
+            (None, (128,), ()),
+            ((0, 1), (30, 128), (30,)),
+            ((0, -1), (20, 128), (20,)),
+        ],
     )
     def test_kde_axis(self, rng, axis, expected_shape, expected_bw_shape):
         array_stats = NumbaArray()
         ary = rng.normal(size=(10, 20, 30))
-        
+
         grid, pdf, bw = array_stats.kde(ary, axis=axis, grid_len=128)  # pylint: disable=unpacking-non-sequence
-        
+
         assert grid.shape == expected_shape
         assert pdf.shape == expected_shape
         assert bw.shape == expected_bw_shape

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -48,17 +48,19 @@ class TestQuantileUfunc:
         _quantile_ufunc(a, q, out)
         assert_allclose(out[0], 49.5, rtol=0.01)
 
-    def test_quantile_parity(self):  
-        """Verify that the Numba quantile ufunc perfectly matches standard NumPy."""
+
+    def test_quantile_parity(self):
+        """Verify that the function correctly handles 2D arrays, axes, and scalars."""
         rng = np.random.default_rng(42)
-        a = rng.normal(size=1000)
-        q = np.array([0.05, 0.5, 0.95])
+        a = rng.normal(size=(10, 3)) 
+        # Make the quantile a scalar to test 'ndim==0' logic
+        q = 0.5 
+        expected = np.quantile(a, q, axis=0)
         
-        expected = np.quantile(a, q)
-        actual = np.zeros_like(expected)
+
+        actual = NumbaArray().quantile(a, q, axis=0)
         
-        _quantile_ufunc(a, q, actual)
-        
+        assert actual.shape == expected.shape
         assert_allclose(actual, expected, rtol=1e-7, atol=1e-7)
 
 
@@ -92,18 +94,46 @@ class TestNumbaArray:
         result = array_stats.quantile(ary, [0.25, 0.5, 0.75], axis=-1)
         assert result.shape == (4, 3)
 
-    @pytest.mark.parametrize("axis", [0, 1, -1, -2])
-    def test_quantile_axis(self, rng, axis):
+    @pytest.mark.parametrize(
+        "axis,expected_shape",
+        [
+            (0, (20, 30, 1)),
+            (1, (10, 30, 1)),
+            (-1, (10, 20, 1)),
+            (-2, (10, 30, 1)),
+            (None, (1,)),         
+            ((0, 1), (30, 1)),    #swapped lists to tuples
+            ((0, -1), (20, 1)),
+        ]
+    )
+    def test_quantile_axis(self, rng, axis, expected_shape):
         array_stats = NumbaArray()
         ary = rng.normal(size=(10, 20, 30))
+        
         result = array_stats.quantile(ary, np.array([0.5]), axis=axis)
-        expected_shape = {
-            0: (20, 30, 1),
-            1: (10, 30, 1),
-            -1: (10, 20, 1),
-            -2: (10, 30, 1),
-        }
-        assert result.shape == expected_shape[axis]
+        
+        # The expected_shape is passed directly from the parametrize list above
+        assert result.shape == expected_shape
+
+    @pytest.mark.parametrize(
+        "axis,expected_shape",
+        [
+            (0, (3, 4)),
+            (1, (2, 4)),
+            (-1, (2, 3)),
+            (None, ()),          # axis=None results in a 0-dimensional scalar
+            ((0, 1), (4,)),      # Operating on multiple axes drops both
+        ]
+    )
+    def test_quantile_scalar(self, rng, axis, expected_shape):
+        """Test that passing a scalar quantile triggers the ndim==0 return path."""
+        array_stats = NumbaArray()
+        ary = rng.normal(size=(2, 3, 4))
+        
+        # We pass 0.5 (a scalar) instead of [0.5] (a list)
+        result = array_stats.quantile(ary, 0.5, axis=axis)
+        
+        assert result.shape == expected_shape
 
     def test_quantile_axis_none(self, rng):
         """Test that passing axis=None correctly triggers the ravel() fallback."""
@@ -113,15 +143,6 @@ class TestNumbaArray:
         result = array_stats.quantile(ary, np.array([0.5]), axis=None)
         
         assert result.shape == (1,)
-
-    def test_quantile_scalar(self, rng):
-        """Test that passing a scalar quantile triggers the ndim==0 return path."""
-        array_stats = NumbaArray()
-        ary = rng.normal(size=(2, 3, 4))
-        
-        result = array_stats.quantile(ary, 0.5, axis=-1)
-        
-        assert result is not None
 
     @pytest.mark.parametrize("axis", [0, 1, -1])
     def test_quantile_axis_multiple_quantiles(self, rng, axis):
@@ -156,7 +177,6 @@ class TestNumbaArray:
         assert_allclose(np.sum(hist) * bin_width, 1.0, rtol=0.01)
 
     def test_histogram_bins_none(self, rng):
-        """Test that passing bins=None triggers the fallback to _get_bins."""
         array_stats = NumbaArray()
         ary = rng.normal(size=100) 
         
@@ -166,23 +186,6 @@ class TestNumbaArray:
         assert bin_edges is not None
         assert len(hist) > 0
         assert len(bin_edges) == len(hist) + 1
-
-    def test_kde_initialization_and_run(self, rng):
-        """Test that kde_ufunc lazy initializes and executes correctly."""
-        array_stats = NumbaArray()
-        assert array_stats._kde_ufunc is None
-        ufunc = array_stats.kde_ufunc
-        assert ufunc is not None
-        assert array_stats._kde_ufunc is not None
-        
-        ary = rng.normal(size=100)
-        
-        x, pdf, bw = array_stats.kde(ary)
-        
-        assert x is not None
-        assert pdf is not None
-        assert bw is not None
-        assert len(x) == len(pdf)
 
     def test_histogram_weights_not_supported(self, rng):
         array_stats = NumbaArray()
@@ -199,38 +202,25 @@ class TestNumbaArray:
         assert pdf.shape == (4, 256)
         assert bw.shape == (4,)
 
-    @pytest.mark.parametrize("axis", [0, 1, -1, -2])
-    def test_kde_axis(self, rng, axis):
+    @pytest.mark.parametrize(
+        "axis,expected_shape,expected_bw_shape",
+        [
+            (0, (20, 30, 128), (20, 30)),
+            (1, (10, 30, 128), (10, 30)),
+            (-1, (10, 20, 128), (10, 20)),
+            (-2, (10, 30, 128), (10, 30)),
+            (None, (128,), ()),  
+        ]
+    )
+    def test_kde_axis(self, rng, axis, expected_shape, expected_bw_shape):
         array_stats = NumbaArray()
         ary = rng.normal(size=(10, 20, 30))
+        
         grid, pdf, bw = array_stats.kde(ary, axis=axis, grid_len=128)  # pylint: disable=unpacking-non-sequence
-        expected_shape = {
-            0: (20, 30, 128),
-            1: (10, 30, 128),
-            -1: (10, 20, 128),
-            -2: (10, 30, 128),
-        }
-        expected_bw_shape = {
-            0: (20, 30),
-            1: (10, 30),
-            -1: (10, 20),
-            -2: (10, 30),
-        }
-        assert grid.shape == expected_shape[axis]
-        assert pdf.shape == expected_shape[axis]
-        assert bw.shape == expected_bw_shape[axis]
-
-    def test_kde_axis_none(self, rng):
-        """Test that KDE correctly flattens the array when axis=None."""
-        array_stats = NumbaArray()
-        ary = rng.normal(size=(2, 50))
         
-        x, pdf, bw = array_stats.kde(ary, axis=None)
-        
-        assert x is not None
-        assert pdf is not None
-        assert bw is not None
-        assert len(x) == len(pdf)
+        assert grid.shape == expected_shape
+        assert pdf.shape == expected_shape
+        assert bw.shape == expected_bw_shape
 
     def test_kde_ufunc_caching(self):
         array_stats = NumbaArray()

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -15,21 +15,18 @@ from arviz_stats.numba.array import NumbaArray, _histogram_jit, _quantile_ufunc,
 class TestProcessAryAxes:
     def test_process_ary_axes_single_axis(self, rng):
         ary = rng.normal(size=(3, 4, 5))
-        result, axes = process_ary_axes(ary, -1)
+        result = process_ary_axes(ary, -1)
         assert result.shape == (3, 4, 5)
-        assert axes == [2]
 
     def test_process_ary_axes_multiple_axes(self, rng):
         ary = rng.normal(size=(3, 4, 5))
-        result, axes = process_ary_axes(ary, [1, 2])
+        result = process_ary_axes(ary, [1, 2])
         assert result.shape == (3, 20)
-        assert axes == [1, 2]
 
     def test_process_ary_axes_negative_index(self, rng):
         ary = rng.normal(size=(3, 4, 5))
-        result, axes = process_ary_axes(ary, -2)
+        result = process_ary_axes(ary, -2)
         assert result.shape == (3, 5, 4)
-        assert axes == [1]
 
 
 class TestQuantileUfunc:


### PR DESCRIPTION
Hi,
I originally started looking into src/arviz_stats/numba/array.py just to bump up the test coverage, but I ended up stumbling onto a few edge-case bugs triggered by unhandled input types.
Most of the changes here are just handling None values properly (like testing axis=None in kde or bins=None in histogram). 
I noticed that all the remaining uncovered lines are strictly inside the guvectorize and jit blocks. Is it normal that pytest-cov can't see inside these compiled Numba functions, or is there a special way you usually test them?
Would really appreciate any feedback.