### PR TITLE
DOC: Document kwargs for kde across all layers

### DIFF
--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -123,7 +123,7 @@ class _BaseAccessor:
         dim : str or sequence of str, optional
             Dimension(s) over which to compute the KDE.
         **kwargs : any, optional
-            Additional keyword arguments forwarded to the array or dataarray interface. 
+            Additional keyword arguments forwarded to the array or dataarray interface.
             See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Returns

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -124,7 +124,7 @@ class _BaseAccessor:
             Dimension(s) over which to compute the KDE.
         **kwargs : any, optional
             Additional keyword arguments forwarded to the array or dataarray interface. 
-            See the base ``kde`` for the full list of supported arguments.
+            See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Returns
         -------

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -116,7 +116,23 @@ class _BaseAccessor:
         return self._apply("mcse", sample_dims=sample_dims, method=method, prob=prob, **kwargs)
 
     def kde(self, dim=None, **kwargs):
-        """Compute the KDE for all variables in the dataset."""
+        """Compute the KDE for all variables in the dataset.
+
+        Parameters
+        ----------
+        dim : str or sequence of str, optional
+            Dimension(s) over which to compute the KDE.
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the underlying KDE 
+            implementations. Supported arguments include `bw`, `adaptive`, 
+            `circular`, and `grid_len`. See the array-level `kde` methods 
+            for full details on these parameters.
+
+        Returns
+        -------
+        xarray.Dataset
+            A dataset containing the KDE grids and pdf values for each variable.
+        """
         return self._apply("kde", dim=dim, **kwargs)
 
     def qds(self, dim=None, **kwargs):

--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -122,11 +122,9 @@ class _BaseAccessor:
         ----------
         dim : str or sequence of str, optional
             Dimension(s) over which to compute the KDE.
-        **kwargs : dict, optional
-            Additional keyword arguments passed to the underlying KDE 
-            implementations. Supported arguments include `bw`, `adaptive`, 
-            `circular`, and `grid_len`. See the array-level `kde` methods 
-            for full details on these parameters.
+        **kwargs : any, optional
+            Additional keyword arguments forwarded to the array or dataarray interface. 
+            See the base ``kde`` for the full list of supported arguments.
 
         Returns
         -------

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -595,7 +595,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             * custom_lims : list or tuple, optional
                 Custom bounds for the range of `ary`. Defaults to None.
             * cumulative : bool, optional
-                If True, returns the cumulative PDF instead of the PDF. Defaults to False.
+                If True, returns the CDF instead of the PDF. Defaults to False.
 
         Returns
         -------

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -573,22 +573,22 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         circular : bool, default False
         grid_len : int, default 512
         **kwargs
-            Additional keyword arguments passed to the underlying KDE implementation. 
+            Additional keyword arguments passed to the underlying KDE implementation.
             Depending on whether `circular` is True or False, supported arguments include:
-            
+
             * bw : int, float, or str, optional
-                The bandwidth or the method to estimate it. Options include "scott", 
-                "silverman", "isj", "experimental", or "taylor" (if circular). 
+                The bandwidth or the method to estimate it. Options include "scott",
+                "silverman", "isj", "experimental", or "taylor" (if circular).
                 Defaults to "experimental" (or "taylor" if circular).
             * bw_fct : float, optional
                 A multiplier for `bw` to tune smoothness manually. Defaults to 1.
             * adaptive : bool, optional
-                If True, uses an adaptive bandwidth. Not compatible with circular KDE. 
+                If True, uses an adaptive bandwidth. Not compatible with circular KDE.
                 Defaults to False.
             * extend : bool, optional
                 If True, extends the observed range for linear KDE. Defaults to False.
             * extend_fct : float, optional
-                Number of standard deviations to widen bounds if `extend` is True. 
+                Number of standard deviations to widen bounds if `extend` is True.
                 Defaults to 0.5.
             * bound_correction : bool, optional
                 Whether to perform boundary correction on linear bounds. Defaults to True.

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Class with array functions.
 
 "array" functions work on any dimension array,

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -564,7 +564,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         return histogram_ufunc(ary, bins, range, shape_from_1st=True)
 
     def kde(self, ary, axis=-1, circular=False, grid_len=512, **kwargs):
-        """Compute of kde on array-like inputs.
+        """Compute KDE on array-like inputs.
 
         Parameters
         ----------
@@ -572,13 +572,21 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         axis : int, sequence of int or None, default -1
         circular : bool, default False
         grid_len : int, default 512
-        **kwargs
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the KDE implementation.
+            Supported arguments include:
+            
+            * bw : str or float, optional
+                The bandwidth of the kernel. Options include "scott" (default),
+                "silverman", "isj", and "experimental", or a positive float.
+            * adaptive : bool, optional
+                Whether to use an adaptive KDE. Defaults to False.
 
         Returns
         -------
         grid, pdf, bw : array-like
             `grid` and `pdf` will have the same shape: the same as `ary` minus the dimensions
-            in `axis` plus an extra dimension of lenght `grid_len`. Same for `bw`
+            in `axis` plus an extra dimension of length `grid_len`. Same for `bw`
             except it will not have the extra dimension.
         """
         ary, axes = process_ary_axes(ary, axis)

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -572,15 +572,30 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         axis : int, sequence of int or None, default -1
         circular : bool, default False
         grid_len : int, default 512
-        **kwargs : dict, optional
-            Additional keyword arguments passed to the KDE implementation.
-            Supported arguments include:
+        **kwargs
+            Additional keyword arguments passed to the underlying KDE implementation. 
+            Depending on whether `circular` is True or False, supported arguments include:
             
-            * bw : str or float, optional
-                The bandwidth of the kernel. Options include "scott" (default),
-                "silverman", "isj", and "experimental", or a positive float.
+            * bw : int, float, or str, optional
+                The bandwidth or the method to estimate it. Options include "scott", 
+                "silverman", "isj", "experimental", or "taylor" (if circular). 
+                Defaults to "experimental" (or "taylor" if circular).
+            * bw_fct : float, optional
+                A multiplier for `bw` to tune smoothness manually. Defaults to 1.
             * adaptive : bool, optional
-                Whether to use an adaptive KDE. Defaults to False.
+                If True, uses an adaptive bandwidth. Not compatible with circular KDE. 
+                Defaults to False.
+            * extend : bool, optional
+                If True, extends the observed range for linear KDE. Defaults to False.
+            * extend_fct : float, optional
+                Number of standard deviations to widen bounds if `extend` is True. 
+                Defaults to 0.5.
+            * bound_correction : bool, optional
+                Whether to perform boundary correction on linear bounds. Defaults to True.
+            * custom_lims : list or tuple, optional
+                Custom bounds for the range of `ary`. Defaults to None.
+            * cumulative : bool, optional
+                If True, returns the cumulative PDF instead of the PDF. Defaults to False.
 
         Returns
         -------

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -241,10 +241,9 @@ class BaseDataArray:
             Whether the data is circular (e.g., angles).
         grid_len : int, default 512
             Number of points on the KDE grid.
-        **kwargs : dict, optional
-            Additional keyword arguments passed to the array-level KDE
-            implementation. See the underlying array `kde` method for a 
-            complete list of supported arguments (like `bw` and `adaptive`).
+        **kwargs : any, optional
+            Additional keyword arguments forwarded to the array or dataarray interface. 
+            See the base ``kde`` for the full list of supported arguments.
 
         Returns
         -------

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -242,13 +242,13 @@ class BaseDataArray:
         grid_len : int, default 512
             Number of points on the KDE grid.
         **kwargs : any, optional
-            Additional keyword arguments forwarded to the array or dataarray interface. 
+            Additional keyword arguments forwarded to the array or dataarray interface.
             See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Returns
         -------
         out : xarray.DataArray
-            An xarray DataArray containing the grid and pdf values along the 
+            An xarray DataArray containing the grid and pdf values along the
             `plot_axis` dimension, with the bandwidth `bw` stored as a coordinate.
         """
         dims = validate_dims(dim)

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -229,7 +229,29 @@ class BaseDataArray:
         return out
 
     def kde(self, da, dim=None, circular=False, grid_len=512, **kwargs):
-        """Compute kde on DataArray input."""
+        """Compute KDE on DataArray input.
+
+        Parameters
+        ----------
+        da : xarray.DataArray
+            Input data.
+        dim : str or sequence of str, optional
+            Dimension(s) over which to compute the KDE.
+        circular : bool, default False
+            Whether the data is circular (e.g., angles).
+        grid_len : int, default 512
+            Number of points on the KDE grid.
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the array-level KDE
+            implementation. See the underlying array `kde` method for a 
+            complete list of supported arguments (like `bw` and `adaptive`).
+
+        Returns
+        -------
+        out : xarray.DataArray
+            An xarray DataArray containing the grid and pdf values along the 
+            `plot_axis` dimension, with the bandwidth `bw` stored as a coordinate.
+        """
         dims = validate_dims(dim)
         grid, pdf, bw = apply_ufunc(
             self.array_class.kde,

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -243,7 +243,7 @@ class BaseDataArray:
             Number of points on the KDE grid.
         **kwargs : any, optional
             Additional keyword arguments forwarded to the array or dataarray interface. 
-            See the base ``kde`` for the full list of supported arguments.
+            See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Returns
         -------

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -146,7 +146,7 @@ class NumbaArray(BaseArray):
         grid_len : int, default 512
             Number of points on the KDE grid.
         **kwargs : any, optional
-            Additional keyword arguments forwarded to the array or dataarray interface. 
+            Additional keyword arguments forwarded to the array or dataarray interface.
             See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Notes

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -135,6 +135,26 @@ class NumbaArray(BaseArray):
     def kde(self, ary, axis=-1, circular=False, grid_len=512, **kwargs):
         """Compute the guvectorized kde.
 
+        Parameters
+        ----------
+        ary : array-like
+            Input array.
+        axis : int, sequence of int or None, default -1
+            Axis or axes along which the KDE is computed.
+        circular : bool, default False
+            Whether the data is circular (e.g., angles).
+        grid_len : int, default 512
+            Number of points on the KDE grid.
+        **kwargs : dict, optional
+            Additional keyword arguments passed to the KDE implementation.
+            Supported arguments include:
+
+            * bw : str or float, optional
+                The bandwidth of the kernel. Options include "scott" (default),
+                "silverman", "isj", and "experimental", or a positive float.
+            * adaptive : bool, optional
+                Whether to use an adaptive KDE. Defaults to False.
+
         Notes
         -----
         There currenly is no jit compiling of the kde computation steps other than the

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -147,7 +147,7 @@ class NumbaArray(BaseArray):
             Number of points on the KDE grid.
         **kwargs : any, optional
             Additional keyword arguments forwarded to the array or dataarray interface. 
-            See the base ``kde`` for the full list of supported arguments.
+            See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
         Notes
         -----

--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -145,15 +145,9 @@ class NumbaArray(BaseArray):
             Whether the data is circular (e.g., angles).
         grid_len : int, default 512
             Number of points on the KDE grid.
-        **kwargs : dict, optional
-            Additional keyword arguments passed to the KDE implementation.
-            Supported arguments include:
-
-            * bw : str or float, optional
-                The bandwidth of the kernel. Options include "scott" (default),
-                "silverman", "isj", and "experimental", or a positive float.
-            * adaptive : bool, optional
-                Whether to use an adaptive KDE. Defaults to False.
+        **kwargs : any, optional
+            Additional keyword arguments forwarded to the array or dataarray interface. 
+            See the base ``kde`` for the full list of supported arguments.
 
         Notes
         -----

--- a/src/arviz_stats/visualization.py
+++ b/src/arviz_stats/visualization.py
@@ -467,7 +467,8 @@ def kde(
         of the data for which to perform the computation.
     circular : bool, default False
     **kwargs : any, optional
-        Forwarded to the array or dataarray interface for KDE.
+            Forwarded to the array or dataarray interface for KDE.
+            See the base ``kde`` for the full list of supported arguments.
 
     Returns
     -------

--- a/src/arviz_stats/visualization.py
+++ b/src/arviz_stats/visualization.py
@@ -468,7 +468,7 @@ def kde(
     circular : bool, default False
     **kwargs : any, optional
             Forwarded to the array or dataarray interface for KDE.
-            See the base ``kde`` for the full list of supported arguments.
+            See :func:`arviz_stats.base.array_stats.kde` for the full list of supported arguments.
 
     Returns
     -------


### PR DESCRIPTION
This PR resolves issue #318 by properly documenting the `**kwargs` passed to the `kde` function so users know they can use arguments like `bw` and `adaptive`.

**Note on scope:** I noticed that other functions in `accessors.py` (like `rhat`, `mcse`, `histogram`, etc.) should also be fixed. I kept this PR strictly scoped to `kde` , we could fix them in a separate PR for them!