### PR TITLE
Add filterwarnings = ['error'] to [tool.pytest.ini_options]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ disallow_untyped_defs = true
 testpaths = [
     "tests",
 ]
+filterwarnings = ["error"]
 
 [tool.coverage.run]
 source = ["arviz_stats"]


### PR DESCRIPTION
Adds `filterwarnings = ["error"]` to `[tool.pytest.ini_options]` 
to align with arviz-base.

Running the test suite with this change reveals 5 pre-existing
RuntimeWarnings in `arviz_stats/base/core.py` :

- `TestStd::test_std_single_value` -> numpy "Degrees of freedom <= 0"
- `TestStd::test_std_empty` -> same
- `TestVar::test_var_single_value` -> same
- `TestVar::test_var_empty` -> same
- `TestMAD::test_mad_empty` -> numpy "Mean of empty slice"

These are pre-existing issues in `_std`, `_var`, and `_mad` in
`core.py`, not introduced by this PR. Fixing them is out of scope here
but they are now visible and can be addressed separately.

Closes #325