### PR TITLE
DOC: remove `khat` display in example docstring

### DIFF
--- a/src/arviz_stats/loo/loo_expectations.py
+++ b/src/arviz_stats/loo/loo_expectations.py
@@ -96,10 +96,6 @@ def loo_expectations(
            ...: loo_expec, khat = loo_expectations(dt, kind="quantile", probs=[0.25, 0.75])
            ...: loo_expec
 
-    .. ipython::
-
-        In [2]: khat
-
     Compute LOO posterior mean for the parameter ``mu``:
 
     .. ipython::
@@ -111,6 +107,7 @@ def loo_expectations(
 
     References
     ----------
+
     .. [1] Vehtari et al. *Practical Bayesian model evaluation using
         leave-one-out cross-validation and WAIC*. Statistics and Computing,
         27(5) (2017). https://doi.org/10.1007/s11222-016-9696-4


### PR DESCRIPTION
This doesn't add any value and takes up a lot of space in the example section of the API docs. I added this a while back and I'm not sure why.