### PR TITLE
Fix numba backend: handle scalar quantile and validate kde kwargs

### DIFF
--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -71,9 +71,11 @@ class NumbaArray(BaseArray):
             ary = ary.ravel()
 
         # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
-        result = _quantile_ufunc(ary, quantile, axes=axes)
-        if np.ndim(quantile) == 0:
-            return result
+        scalar_quantile = np.ndim(quantile) == 0
+        quantile = np.atleast_1d(quantile)
+        result = _quantile_ufunc(ary, quantile, axes=axes) if axes is not None else _quantile_ufunc(ary, quantile)
+        if scalar_quantile:
+            return result.squeeze(axis=0)
         return np.moveaxis(result, 0, -1)
 
     def _histogram(self, ary, bins=None, range=None, weights=None, density=True):  # pylint: disable=redefined-builtin
@@ -127,7 +129,6 @@ class NumbaArray(BaseArray):
 
     def kde(self, ary, axis=-1, circular=False, grid_len=512, **kwargs):
         """Compute the guvectorized kde.
-
         Notes
         -----
         There currenly is no jit compiling of the kde computation steps other than the
@@ -135,6 +136,10 @@ class NumbaArray(BaseArray):
         The ufunc is cached the first time to avoid unnecessary compilation while
         ensuring the proper method of the initialized class is the one being guvectorized.
         """
+        valid_kwargs = {"bw", "adaptive", "axes", "bound_correction"}
+        invalid = set(kwargs) - valid_kwargs
+        if invalid:
+            raise TypeError(f"kde() got unexpected keyword argument(s): {invalid}")
         if axis is not None:
             ary, axis = process_ary_axes(ary, axis)
             kwargs["axes"] = [(-1,), (0,), (), (), ()]


### PR DESCRIPTION
## What this PR does
fixes two bugs in the `numba` backend that were causing 113 test failures when `stats.module` is set to `numba`

## Changes
1. Scalar quantile fix (`_quantile_ufunc`)
numba `_quantile_ufunc` gufunc has signature `(n),(m)->(m)` which requires the quantile argument to have at least 1 dimension. When a scalar quantile was passed (e.g. `0.5`), it would fail with,
```
ValueError: _quantile_ufunc: Input operand 1 does not have enough dimensions
```
**Fix:** wrap `quantile` with `np.atleast_1d()` before passing to the `ufunc` and squeeze the result back if the original input was scalar

2. kde kwargs validation
numba `kde` method accepted `**kwargs` and silently ignored unknown keyword arguments, while the base backend would raise a `TypeError`. This inconsistency caused `test_extra_kwargs_raise[kde]` to fail
**Fix:** explicitly validate kwargs at the start of the method and raise `TypeError` for any unrecognised ones, matching the behaviour of the base backend

## Testing
Ran the full arviz-stats test suite (2632 tests) with `stats.module : numba` set in `arvizrc`
`2632 passed, 2 skipped, 0 failed`
previously 113 failed

## Related
enables the `auto` option in `stats.module` to work correctly when `numba` is installed(arviz-devs/arviz-base#172)