### PR TITLE
Add pareto_pit

### DIFF
--- a/src/arviz_stats/accessors.py
+++ b/src/arviz_stats/accessors.py
@@ -221,6 +221,7 @@ class _BaseAccessor:
         pareto_k=None,
         sample_dims=None,
         random_state=None,
+        pareto_pit=False,
         **kwargs,
     ):
         """Compute LOO-PIT values with PSIS-LOO-CV weights."""
@@ -233,6 +234,7 @@ class _BaseAccessor:
             pareto_k=pareto_k,
             sample_dims=sample_dims,
             random_state=random_state,
+            pareto_pit=pareto_pit,
             **kwargs,
         )
 

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -1240,6 +1240,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         chain_axis=-2,
         draw_axis=-1,
         random_state=None,
+        pareto_pit=False,
     ):
         """Compute LOO-PIT values with PSIS-LOO-CV weights.
 
@@ -1257,6 +1258,8 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             Axis for draws.
         random_state : int or Generator, optional
             Random seed or Generator for tie-breaking. If None, uses seed 214.
+        pareto_pit : bool, optional
+            If True, use Pareto-smoothed PIT values. Default is False.
 
         Returns
         -------
@@ -1275,7 +1278,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             rng = np.random.default_rng(random_state)
 
         loo_pit_ufunc = make_ufunc(self._loo_pit, n_output=1, n_input=3, n_dims=len(axes))
-        return loo_pit_ufunc(ary, y_obs, log_weights, rng=rng)
+        return loo_pit_ufunc(ary, y_obs, log_weights, rng=rng, pareto_pit=pareto_pit)
 
     def loo_expectation(
         self,

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -1277,8 +1277,12 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
         else:
             rng = np.random.default_rng(random_state)
 
-        loo_pit_ufunc = make_ufunc(self._loo_pit, n_output=1, n_input=3, n_dims=len(axes))
-        return loo_pit_ufunc(ary, y_obs, log_weights, rng=rng, pareto_pit=pareto_pit)
+        n_sample_dims = len(axes)
+        sample_size = int(np.prod(ary.shape[-n_sample_dims:]))
+        ary = ary.reshape(*ary.shape[:-n_sample_dims], sample_size)
+        log_weights = log_weights.reshape(*log_weights.shape[:-n_sample_dims], sample_size)
+
+        return self._loo_pit(ary, y_obs, log_weights, rng=rng, pareto_pit=pareto_pit)
 
     def loo_expectation(
         self,

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -690,6 +690,7 @@ class BaseDataArray:
         pareto_k=None,
         sample_dims=None,
         random_state=None,
+        pareto_pit=False,
     ):
         """Compute LOO-PIT values on DataArray input.
 
@@ -737,6 +738,7 @@ class BaseDataArray:
                 "chain_axis": chain_axis,
                 "draw_axis": draw_axis,
                 "random_state": random_state,
+                "pareto_pit": pareto_pit,
             },
         )
         return pit_values, pareto_k

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -518,8 +518,7 @@ class _DiagnosticsBase(_CoreBase):
         return -(loo_weighted_abs_error / gini_mean_difference) - 0.5 * np.log(gini_mean_difference)
 
     def _loo_pit(self, ary, y_obs, log_weights, rng=None, pareto_pit=False):
-        """
-        Compute LOO-PIT value for a single observation.
+        """Compute LOO-PIT value.
 
         Parameters
         ----------
@@ -529,39 +528,37 @@ class _DiagnosticsBase(_CoreBase):
             Observed value.
         log_weights : np.ndarray
             1D array of pre-computed PSIS log weights.
-        rng : np.random.Generator, optional
-            Random number generator for tie-breaking. If None, uses midpoint.
+        rng : np.random.Generator
+            Random number generator for tie-breaking.
         pareto_pit : bool, optional
             If True, use Pareto-smoothed PIT values. Default is False.
-
-        Returns
-        -------
-        pit : float
-            LOO-PIT value in [0, 1].
         """
-        ary = np.asarray(ary).ravel()
-        log_weights = np.asarray(log_weights).ravel()
-        y_obs_val = np.asarray(y_obs).ravel()[0]
+        ary = np.asarray(ary, dtype=float)
+        log_weights = np.asarray(log_weights, dtype=float)
+        y_obs_1d = np.asarray(y_obs, dtype=float).ravel()
+
+        obs_shape = ary.shape[:-1]
+        ary_2d = ary.reshape(-1, ary.shape[-1])
+        log_weights_2d = log_weights.reshape(-1, log_weights.shape[-1])
 
         if pareto_pit:
-            return self._pareto_pit(ary, y_obs_val, log_weights=log_weights, rng=rng)
+            pit = self._pareto_pit_vec(ary_2d, y_obs_1d, log_weights=log_weights_2d, rng=rng)
+        else:
+            log_norm = logsumexp(log_weights_2d, axis=-1, keepdims=True)
+            weights = np.exp(log_weights_2d - log_norm)
 
-        log_norm = logsumexp(log_weights)
-        weights = np.exp(log_weights - log_norm)
+            y_obs_col = y_obs_1d[:, None]
+            pit_lower = np.sum(weights * (ary_2d < y_obs_col), axis=-1)
+            pit_at_obs = np.sum(weights * (ary_2d == y_obs_col), axis=-1)
+            if rng is None:
+                pit = pit_lower + 0.5 * pit_at_obs
+            else:
+                urvs = rng.uniform(size=pit_lower.shape)
+                pit = pit_lower + urvs * pit_at_obs
 
-        sel_below = ary < y_obs_val
-        pit_lower = np.sum(weights[sel_below])
-
-        sel_equal = ary == y_obs_val
-        if np.any(sel_equal):
-            pit_at_obs = np.sum(weights[sel_equal])
-            pit_upper = pit_lower + pit_at_obs
-
-            if rng is not None:
-                return rng.uniform(pit_lower, pit_upper)
-            return (pit_lower + pit_upper) / 2.0
-
-        return pit_lower
+        if obs_shape:
+            return pit.reshape(obs_shape)
+        return pit[0]
 
     def _loo_expectation(self, ary, log_weights, kind):
         """
@@ -937,8 +934,8 @@ class _DiagnosticsBase(_CoreBase):
         lppd = elpd + p_loo
         return elpd, se, p_loo, lppd
 
-    def _pareto_pit(self, ary, y_obs, log_weights=None, rng=None):
-        """Compute Pareto-smoothed PIT for a single observation.
+    def _pareto_pit_vec(self, draws_matrix, y_obs_array, log_weights=None, rng=None):
+        """Compute Pareto-smoothed PIT.
 
         Compute PIT value using the ECDF, then refine in the tails by fitting a
         generalized Pareto distribution (GPD) to the tail draws. This gives smoother, more
@@ -947,10 +944,10 @@ class _DiagnosticsBase(_CoreBase):
 
         Parameters
         ----------
-        ary : np.ndarray
-            1D array of posterior predictive draws.
-        y_obs : float
-            Observed value.
+        draws_matrix : np.ndarray
+            2D array of posterior predictive draws with shape (n_obs, n_draws).
+        y_obs_array : np.ndarray
+            1D array of observed values with shape (n_obs,).
         log_weights : np.ndarray, optional
             1D array of normalized log weights matching ary.
             If None, uniform weights are used.
@@ -962,11 +959,7 @@ class _DiagnosticsBase(_CoreBase):
         pit : float
             Pareto-smoothed PIT value, clamped to [1/(n*1e4), 1 - 1/(n*1e4)].
         """
-        draws = np.asarray(ary, dtype=float).ravel()
-        y_val = float(np.asarray(y_obs).flat[0])
-        lw = np.asarray(log_weights, dtype=float).ravel() if log_weights is not None else None
-
-        n_draws = len(draws)
+        n_draws = draws_matrix.shape[-1]
         ndraws_tail = self._get_ps_tails(n_draws, 1, tail="right")
 
         gpd_ok = ndraws_tail >= 5
@@ -976,6 +969,29 @@ class _DiagnosticsBase(_CoreBase):
             gpd_ok = False
 
         tail_ids = np.arange(n_draws - ndraws_tail, n_draws, dtype=int)
+        min_tail_prob = 1.0 / n_draws / 1e4
+
+        results = np.array(
+            [
+                self._pareto_pit_single(
+                    draws,
+                    y,
+                    None if log_weights is None else log_weights[idx],
+                    rng,
+                    gpd_ok,
+                    tail_ids,
+                    ndraws_tail,
+                )
+                for idx, (draws, y) in enumerate(zip(draws_matrix, y_obs_array))
+            ]
+        )
+        return np.clip(results, min_tail_prob, 1.0 - min_tail_prob)
+
+    def _pareto_pit_single(self, draws, y_val, lw, rng, gpd_ok, tail_ids, ndraws_tail):
+        """Compute Pareto-smoothed PIT for a single observation."""
+        draws = np.asarray(draws, dtype=float).ravel()
+        y_val = float(y_val)
+        n_draws = len(draws)
 
         # --- raw PIT ---
         sel_below = draws < y_val
@@ -1031,7 +1047,7 @@ class _DiagnosticsBase(_CoreBase):
         if not right_replaced:
             left_ord = np.argsort(-draws)
             left_sorted = -draws[left_ord]
-            lw_left = lw[left_ord] if lw is not None else None
+            lw_left_sorted = lw[left_ord] if lw is not None else None
 
             left_tail = left_sorted[tail_ids]
             if not np.all(left_tail == left_tail[0]):
@@ -1039,21 +1055,21 @@ class _DiagnosticsBase(_CoreBase):
                 if left_cutoff == left_tail[0]:
                     left_cutoff -= np.finfo(float).eps
 
-                left_wt = np.exp(lw_left[tail_ids]) if lw_left is not None else None
+                left_wt = np.exp(lw_left_sorted[tail_ids]) if lw_left_sorted is not None else None
                 khat, sigma = self._gpdfit(left_tail - left_cutoff, weights=left_wt)
 
                 if np.isfinite(khat) and not np.isnan(sigma) and -y_val > left_cutoff:
                     gpd_cdf = float(
                         self.pgeneralized_pareto(-y_val, mu=left_cutoff, sigma=sigma, k=khat)
                     )
-                    if lw_left is not None:
-                        left_proportion = np.exp(logsumexp(lw_left[tail_ids]))
-                    else:
-                        left_proportion = tail_proportion
+                    left_proportion = (
+                        np.exp(logsumexp(lw_left_sorted[tail_ids]))
+                        if lw_left_sorted is not None
+                        else tail_proportion
+                    )
                     raw_pit = left_proportion * (1.0 - gpd_cdf)
 
-        min_tail_prob = 1.0 / n_draws / 1e4
-        return float(np.clip(raw_pit, min_tail_prob, 1.0 - min_tail_prob))
+        return raw_pit
 
     def _pareto_khat(self, ary, r_eff=None, tail="both", log_weights=False):
         """

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -944,7 +944,7 @@ class _DiagnosticsBase(_CoreBase):
 
         Parameters
         ----------
-        draws_matrix : np.ndarray
+        draws_matrix : np.ndarray of shape (n_obs, n_draws)
             2D array of posterior predictive draws with shape (n_obs, n_draws).
         y_obs_array : np.ndarray
             1D array of observed values with shape (n_obs,).

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1256,8 +1256,14 @@ class _DiagnosticsBase(_CoreBase):
             weights = np.asarray(weights, dtype=float)
             weights = weights / weights.sum() * n
 
+        xstar = ary[int((n / 4 + 0.5) - 1)]  # first quartile of sample
+        if xstar <= ary[0]:
+            # first quartile is not bigger than the minimum, which indicates
+            # that the distribution is far from a generalized Pareto distribution
+            return np.nan, np.nan
+
         b_ary = 1 - np.sqrt(m_est / (np.arange(1, m_est + 1, dtype=float) - 0.5))
-        b_ary /= prior_bs * ary[int(n / 4 + 0.5) - 1]
+        b_ary /= prior_bs * xstar
         b_ary += 1 / ary[-1]
 
         log1p_mat = np.log1p(-b_ary[:, None] * ary)
@@ -1287,6 +1293,9 @@ class _DiagnosticsBase(_CoreBase):
         # add prior for kappa
         sigma = -kappa / b_post
         kappa = (n * kappa + prior_k * 0.5) / (n + prior_k)
+
+        if np.isnan(kappa):
+            return np.inf, np.nan
 
         return kappa, sigma
 

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -517,8 +517,7 @@ class _DiagnosticsBase(_CoreBase):
         gini_mean_difference = 2.0 * np.sum(weights_sorted * values_sorted * bracket)
         return -(loo_weighted_abs_error / gini_mean_difference) - 0.5 * np.log(gini_mean_difference)
 
-    @staticmethod
-    def _loo_pit(ary, y_obs, log_weights, rng=None):
+    def _loo_pit(self, ary, y_obs, log_weights, rng=None, pareto_pit=False):
         """
         Compute LOO-PIT value for a single observation.
 
@@ -532,6 +531,8 @@ class _DiagnosticsBase(_CoreBase):
             1D array of pre-computed PSIS log weights.
         rng : np.random.Generator, optional
             Random number generator for tie-breaking. If None, uses midpoint.
+        pareto_pit : bool, optional
+            If True, use Pareto-smoothed PIT values. Default is False.
 
         Returns
         -------
@@ -541,6 +542,10 @@ class _DiagnosticsBase(_CoreBase):
         ary = np.asarray(ary).ravel()
         log_weights = np.asarray(log_weights).ravel()
         y_obs_val = np.asarray(y_obs).ravel()[0]
+
+        if pareto_pit:
+            return self._pareto_pit(ary, y_obs_val, log_weights=log_weights, rng=rng)
+
         log_norm = logsumexp(log_weights)
         weights = np.exp(log_weights - log_norm)
 
@@ -932,6 +937,124 @@ class _DiagnosticsBase(_CoreBase):
         lppd = elpd + p_loo
         return elpd, se, p_loo, lppd
 
+    def _pareto_pit(self, ary, y_obs, log_weights=None, rng=None):
+        """Compute Pareto-smoothed PIT for a single observation.
+
+        Compute PIT value using the ECDF, then refine in the tails by fitting a
+        generalized Pareto distribution (GPD) to the tail draws. This gives smoother, more
+        accurate PIT values in the tails, and avoids PIT values of 0 and 1.
+        The PIT values are not anymore rank based and continuous uniformity test is appropriate.
+
+        Parameters
+        ----------
+        ary : np.ndarray
+            1D array of posterior predictive draws.
+        y_obs : float
+            Observed value.
+        log_weights : np.ndarray, optional
+            1D array of normalized log weights matching ary.
+            If None, uniform weights are used.
+        rng : np.random.Generator, optional
+            Random number generator for tie-breaking. If None, midpoint is used.
+
+        Returns
+        -------
+        pit : float
+            Pareto-smoothed PIT value, clamped to [1/(n*1e4), 1 - 1/(n*1e4)].
+        """
+        draws = np.asarray(ary, dtype=float).ravel()
+        y_val = float(np.asarray(y_obs).flat[0])
+        lw = np.asarray(log_weights, dtype=float).ravel() if log_weights is not None else None
+
+        n_draws = len(draws)
+        ndraws_tail = self._get_ps_tails(n_draws, 1, tail="right")
+
+        gpd_ok = ndraws_tail >= 5
+        if gpd_ok and ndraws_tail > n_draws // 2:
+            ndraws_tail = n_draws // 2
+        if gpd_ok and ndraws_tail >= n_draws:
+            gpd_ok = False
+
+        tail_ids = np.arange(n_draws - ndraws_tail, n_draws, dtype=int)
+
+        # --- raw PIT ---
+        sel_below = draws < y_val
+        if not np.any(sel_below):
+            raw_pit = 0.0
+        elif lw is None:
+            raw_pit = np.mean(sel_below)
+        else:
+            raw_pit = np.exp(logsumexp(lw[sel_below]))
+
+        sel_equal = draws == y_val
+        if np.any(sel_equal):
+            if lw is None:
+                pit_upper = raw_pit + np.mean(sel_equal)
+            else:
+                pit_upper = raw_pit + np.exp(logsumexp(lw[sel_equal]))
+            raw_pit = rng.uniform(raw_pit, pit_upper)
+
+        # --- GPD tail refinement ---
+        if not gpd_ok or not np.all(np.isfinite(draws)):
+            min_tail_prob = 1.0 / n_draws / 1e4
+            return float(np.clip(raw_pit, min_tail_prob, 1.0 - min_tail_prob))
+
+        ord_idx = np.argsort(draws)
+        sorted_draws = draws[ord_idx]
+        lw_sorted = lw[ord_idx] if lw is not None else None
+
+        if lw_sorted is not None:
+            tail_proportion = np.exp(logsumexp(lw_sorted[tail_ids]))
+        else:
+            tail_proportion = ndraws_tail / n_draws
+
+        # --- right tail ---
+        right_tail = sorted_draws[tail_ids]
+        right_replaced = False
+
+        if not np.all(right_tail == right_tail[0]):
+            right_cutoff = sorted_draws[tail_ids[0] - 1]
+            if right_cutoff == right_tail[0]:
+                right_cutoff -= np.finfo(float).eps
+
+            right_wt = np.exp(lw_sorted[tail_ids]) if lw_sorted is not None else None
+            khat, sigma = self._gpdfit(right_tail - right_cutoff, weights=right_wt)
+
+            if np.isfinite(khat) and not np.isnan(sigma) and y_val > right_cutoff:
+                gpd_cdf = float(
+                    self.pgeneralized_pareto(y_val, mu=right_cutoff, sigma=sigma, k=khat)
+                )
+                raw_pit = 1.0 - tail_proportion * (1.0 - gpd_cdf)
+                right_replaced = True
+
+        # --- left tail (negate trick) ---
+        if not right_replaced:
+            left_ord = np.argsort(-draws)
+            left_sorted = -draws[left_ord]
+            lw_left = lw[left_ord] if lw is not None else None
+
+            left_tail = left_sorted[tail_ids]
+            if not np.all(left_tail == left_tail[0]):
+                left_cutoff = left_sorted[tail_ids[0] - 1]
+                if left_cutoff == left_tail[0]:
+                    left_cutoff -= np.finfo(float).eps
+
+                left_wt = np.exp(lw_left[tail_ids]) if lw_left is not None else None
+                khat, sigma = self._gpdfit(left_tail - left_cutoff, weights=left_wt)
+
+                if np.isfinite(khat) and not np.isnan(sigma) and -y_val > left_cutoff:
+                    gpd_cdf = float(
+                        self.pgeneralized_pareto(-y_val, mu=left_cutoff, sigma=sigma, k=khat)
+                    )
+                    if lw_left is not None:
+                        left_proportion = np.exp(logsumexp(lw_left[tail_ids]))
+                    else:
+                        left_proportion = tail_proportion
+                    raw_pit = left_proportion * (1.0 - gpd_cdf)
+
+        min_tail_prob = 1.0 / n_draws / 1e4
+        return float(np.clip(raw_pit, min_tail_prob, 1.0 - min_tail_prob))
+
     def _pareto_khat(self, ary, r_eff=None, tail="both", log_weights=False):
         """
         Compute Pareto k-hat diagnostic.
@@ -1082,7 +1205,7 @@ class _DiagnosticsBase(_CoreBase):
         return ary, khat
 
     @staticmethod
-    def _gpdfit(ary):
+    def _gpdfit(ary, weights=None):
         """Estimate the parameters for the Generalized Pareto Distribution (GPD).
 
         Empirical Bayes estimate for the parameters (kappa, sigma) of the generalized Pareto
@@ -1097,6 +1220,9 @@ class _DiagnosticsBase(_CoreBase):
         ----------
         ary: array
             sorted 1D data array
+        weights: array, optional
+            observation weights. If provided, a weighted fit is performed.
+            Weights are normalized internally to sum to ``len(ary)``.
 
         Returns
         -------
@@ -1110,26 +1236,38 @@ class _DiagnosticsBase(_CoreBase):
         n = len(ary)
         m_est = 30 + int(n**0.5)
 
+        if weights is not None:
+            weights = np.asarray(weights, dtype=float)
+            weights = weights / weights.sum() * n
+
         b_ary = 1 - np.sqrt(m_est / (np.arange(1, m_est + 1, dtype=float) - 0.5))
         b_ary /= prior_bs * ary[int(n / 4 + 0.5) - 1]
         b_ary += 1 / ary[-1]
 
-        k_ary = np.mean(np.log1p(-b_ary[:, None] * ary), axis=1)
+        log1p_mat = np.log1p(-b_ary[:, None] * ary)
+        if weights is not None:
+            k_ary = log1p_mat @ weights / n
+        else:
+            k_ary = np.mean(log1p_mat, axis=1)
+
         len_scale = n * (np.log(-b_ary / k_ary) - k_ary - 1)
-        weights = np.exp(len_scale - logsumexp(len_scale))
+        w_theta = np.exp(len_scale - logsumexp(len_scale))
 
         # remove negligible weights
-        real_idxs = weights >= 10 * np.finfo(float).eps
+        real_idxs = w_theta >= 10 * np.finfo(float).eps
         if not np.all(real_idxs):
-            weights = weights[real_idxs]
+            w_theta = w_theta[real_idxs]
             b_ary = b_ary[real_idxs]
         # normalise weights
-        weights /= weights.sum()
+        w_theta /= w_theta.sum()
 
         # posterior mean for b
-        b_post = np.sum(b_ary * weights)
+        b_post = np.sum(b_ary * w_theta)
         # estimate for k
-        kappa = np.mean(np.log1p(-b_post * ary))
+        if weights is not None:
+            kappa = np.sum(weights * np.log1p(-b_post * ary)) / n
+        else:
+            kappa = np.mean(np.log1p(-b_post * ary))
         # add prior for kappa
         sigma = -kappa / b_post
         kappa = (n * kappa + prior_k * 0.5) / (n + prior_k)
@@ -1148,6 +1286,31 @@ class _DiagnosticsBase(_CoreBase):
             q = mu + sigma * np.expm1(-kappa * np.log1p(-probs)) / kappa
 
         return q
+
+    @staticmethod
+    def pgeneralized_pareto(q, mu=0, sigma=1, k=0, lower_tail=True, log_p=False):
+        q = np.asarray(q, dtype=float)
+
+        if np.isnan(sigma) or sigma <= 0:
+            return np.full(q.shape, np.nan)
+
+        z = (q - mu) / sigma
+
+        if abs(k) < 1e-15:
+            p = -np.expm1(-z)
+        else:
+            with np.errstate(divide="ignore"):
+                p = -np.expm1(np.log1p(np.maximum(k * z, -1)) / -k)
+
+        p = np.clip(p, 0, 1)
+
+        if not lower_tail:
+            p = 1 - p
+
+        if log_p:
+            p = np.log(p)
+
+        return p
 
     def _power_scale_sense(self, ary, lower_w, upper_w, lower_alpha, upper_alpha):
         """Compute power-scaling sensitivity by finite difference second derivative of CJS."""

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -948,7 +948,7 @@ class _DiagnosticsBase(_CoreBase):
             2D array of posterior predictive draws with shape (n_obs, n_draws).
         y_obs_array : np.ndarray of shape (n_obs,)
             1D array of observed values with shape (n_obs,).
-        log_weights : np.ndarray, optional
+        log_weights : np.ndarray of shape (n_obs, n_draws) and dtype float, optional
             1D array of normalized log weights matching ary.
             If None, uniform weights are used.
         rng : np.random.Generator, optional

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -946,7 +946,7 @@ class _DiagnosticsBase(_CoreBase):
         ----------
         draws_matrix : np.ndarray of shape (n_obs, n_draws)
             2D array of posterior predictive draws with shape (n_obs, n_draws).
-        y_obs_array : np.ndarray
+        y_obs_array : np.ndarray of shape (n_obs,)
             1D array of observed values with shape (n_obs,).
         log_weights : np.ndarray, optional
             1D array of normalized log weights matching ary.

--- a/src/arviz_stats/loo/loo_pit.py
+++ b/src/arviz_stats/loo/loo_pit.py
@@ -13,6 +13,7 @@ def loo_pit(
     log_weights=None,
     pareto_k=None,
     random_state=None,
+    pareto_pit=False,
 ):
     r"""Compute leave one out (PSIS-LOO) probability integral transform (PIT) values.
 
@@ -126,6 +127,7 @@ def loo_pit(
                 r_eff=r_eff,
                 sample_dims=sample_dims,
                 random_state=random_state,
+                pareto_pit=pareto_pit,
             )
         else:
             log_ratios = -log_likelihood[var]
@@ -135,6 +137,7 @@ def loo_pit(
                 r_eff=r_eff,
                 sample_dims=sample_dims,
                 random_state=random_state,
+                pareto_pit=pareto_pit,
             )
         loo_pit_values[var] = pit_values
 

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -504,7 +504,7 @@ def test_pareto_pit_constant_draws():
     """Constant draws should not error; falls back to raw PIT."""
     draws = np.full(200, 5.0)
     y_obs = 5.0
-    result = array_stats._pareto_pit(draws, y_obs)
+    result = array_stats._pareto_pit(draws, y_obs, rng=np.random.default_rng(203))
     assert isinstance(result, float)
     assert 0 <= result <= 1
 
@@ -514,7 +514,7 @@ def test_pareto_pit_non_finite_draws_fallback():
     draws = np.arange(1, 100, dtype=float)
     draws = np.append(draws, np.nan)
     y_obs = 50.0
-    result = array_stats._pareto_pit(draws, y_obs)
+    result = array_stats._pareto_pit(draws, y_obs, rng=np.random.default_rng(203))
     assert isinstance(result, float)
     assert 0 <= result <= 1
 

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -388,11 +388,20 @@ def test_split_chain_dims(rng, chains, draws):
     assert split_data.shape == (chains * 2, draws // 2)
 
 
+def _pareto_pit_vec_test(draws, y_obs, log_weights=None, rng=None):
+    draws = np.atleast_2d(np.asarray(draws, dtype=float))
+    y_obs = np.atleast_1d(np.asarray(y_obs, dtype=float))
+    if log_weights is not None:
+        log_weights = np.atleast_2d(np.asarray(log_weights, dtype=float))
+    result = array_stats._pareto_pit_vec(draws, y_obs, log_weights=log_weights, rng=rng)
+    return result[0] if result.size == 1 else result
+
+
 def test_pareto_pit_returns_scalar_in_valid_range():
     rng = np.random.default_rng(1)
     draws = rng.normal(size=500)
     y_obs = 0.5
-    result = array_stats._pareto_pit(draws, y_obs)
+    result = _pareto_pit_vec_test(draws, y_obs)
     assert isinstance(result, float)
     assert 0 <= result <= 1
 
@@ -400,12 +409,11 @@ def test_pareto_pit_returns_scalar_in_valid_range():
 def test_pareto_pit_bulk_values_match_raw_pit():
     """For observations well inside the bulk, pareto_pit and raw ECDF PIT should agree."""
     rng = np.random.default_rng(42)
-    draws = rng.normal(size=1000)
-    y_obs = 0.0  # near the median
+    draws = rng.normal(size=(3, 1000))
+    y_obs = np.array([0.0, 0.1, -0.1])
 
-    refined = array_stats._pareto_pit(draws, y_obs, rng=rng)
-    # raw ECDF PIT
-    raw = np.mean(draws < y_obs)
+    refined = _pareto_pit_vec_test(draws, y_obs, rng=rng)
+    raw = np.mean(draws < y_obs[:, None], axis=1)
 
     np.testing.assert_allclose(refined, raw, atol=0.05)
 
@@ -413,14 +421,14 @@ def test_pareto_pit_bulk_values_match_raw_pit():
 def test_pareto_pit_differs_from_ecdf_in_tails():
     """Pareto-smoothed PIT should differ from raw ECDF in the tails."""
     rng = np.random.default_rng(42)
-    draws = rng.normal(size=1000)
-    y_obs = 4.0  # far right tail
+    draws = rng.normal(size=(2, 1000))
+    y_obs = np.array([-4.0, 4.0])
 
-    refined = array_stats._pareto_pit(draws, y_obs)
-    raw = np.mean(draws < y_obs)
+    refined = _pareto_pit_vec_test(draws, y_obs)
+    raw = np.mean(draws < y_obs[:, None], axis=1)
 
-    assert refined != raw
-    assert 0 <= refined <= 1
+    assert not np.allclose(refined, raw)
+    assert np.all((0 <= refined) & (refined <= 1))
 
 
 def test_pareto_pit_right_tail_closer_to_true_cdf():
@@ -436,9 +444,9 @@ def test_pareto_pit_right_tail_closer_to_true_cdf():
     raw_errors = []
     refined_errors = []
     for _ in range(n_reps):
-        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        draws = sp_stats.t.rvs(df=3, size=(1, ndraws), random_state=rng)
         raw = np.mean(draws < y_obs)
-        refined = array_stats._pareto_pit(draws, y_obs)
+        refined = _pareto_pit_vec_test(draws, y_obs)
         raw_errors.append((raw - true_prob) ** 2)
         refined_errors.append((refined - true_prob) ** 2)
 
@@ -458,9 +466,9 @@ def test_pareto_pit_left_tail_closer_to_true_cdf():
     raw_errors = []
     refined_errors = []
     for _ in range(n_reps):
-        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        draws = sp_stats.t.rvs(df=3, size=(1, ndraws), random_state=rng)
         raw = np.mean(draws < y_obs)
-        refined = array_stats._pareto_pit(draws, y_obs)
+        refined = _pareto_pit_vec_test(draws, y_obs)
         raw_errors.append((raw - true_prob) ** 2)
         refined_errors.append((refined - true_prob) ** 2)
 
@@ -479,9 +487,9 @@ def test_pareto_pit_extreme_tail_more_varied_than_ecdf():
     raw_vals = []
     refined_vals = []
     for _ in range(n_reps):
-        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        draws = sp_stats.t.rvs(df=3, size=(1, ndraws), random_state=rng)
         raw_vals.append(np.mean(draws < y_obs))
-        refined_vals.append(array_stats._pareto_pit(draws, y_obs))
+        refined_vals.append(_pareto_pit_vec_test(draws, y_obs))
 
     assert len(set(np.round(refined_vals, 6))) > len(set(np.round(raw_vals, 6)))
 
@@ -494,7 +502,7 @@ def test_pareto_pit_discrete_randomization():
     results = []
     for seed in range(100):
         rng = np.random.default_rng(seed)
-        results.append(array_stats._pareto_pit(draws, y_obs, rng=rng))
+        results.append(_pareto_pit_vec_test(draws, y_obs, rng=rng))
 
     assert np.std(results) > 0
     assert all(0 <= r <= 1 for r in results)
@@ -504,7 +512,7 @@ def test_pareto_pit_constant_draws():
     """Constant draws should not error; falls back to raw PIT."""
     draws = np.full(200, 5.0)
     y_obs = 5.0
-    result = array_stats._pareto_pit(draws, y_obs, rng=np.random.default_rng(203))
+    result = _pareto_pit_vec_test(draws, y_obs, rng=np.random.default_rng(203))
     assert isinstance(result, float)
     assert 0 <= result <= 1
 
@@ -514,7 +522,7 @@ def test_pareto_pit_non_finite_draws_fallback():
     draws = np.arange(1, 100, dtype=float)
     draws = np.append(draws, np.nan)
     y_obs = 50.0
-    result = array_stats._pareto_pit(draws, y_obs, rng=np.random.default_rng(203))
+    result = _pareto_pit_vec_test(draws, y_obs, rng=np.random.default_rng(203))
     assert isinstance(result, float)
     assert 0 <= result <= 1
 
@@ -522,10 +530,9 @@ def test_pareto_pit_non_finite_draws_fallback():
 def test_pareto_pit_observation_beyond_all_draws():
     """Observations far beyond draws should give near-0 or near-1 PIT values."""
     rng = np.random.default_rng(42)
-    draws = rng.normal(size=500)
+    draws = rng.normal(size=(2, 500))
 
-    result_right = array_stats._pareto_pit(draws, 100.0)
-    result_left = array_stats._pareto_pit(draws, -100.0)
+    result_right, result_left = _pareto_pit_vec_test(draws, [100.0, -100.0])
 
     assert result_right > 0.99
     assert result_left < 0.01
@@ -536,25 +543,24 @@ def test_pareto_pit_values_always_in_valid_range():
     rng = np.random.default_rng(42)
     from scipy import stats as sp_stats
 
-    draws = rng.normal(size=500)
     quantiles = [0.001, 0.01, 0.05, 0.1, 0.3, 0.7, 0.9, 0.95, 0.99, 0.999]
+    draws = rng.normal(size=(len(quantiles), 500))
+    y_obs = sp_stats.norm.ppf(quantiles)
 
-    for q in quantiles:
-        y_obs = sp_stats.norm.ppf(q)
-        result = array_stats._pareto_pit(draws, y_obs)
-        assert 0 <= result <= 1, f"PIT out of range for quantile {q}: {result}"
+    result = _pareto_pit_vec_test(draws, y_obs)
+    assert np.all((0 <= result) & (result <= 1))
 
 
 def test_pareto_pit_with_log_weights():
     """pareto_pit should work with importance weights."""
     rng = np.random.default_rng(42)
-    draws = rng.normal(size=500)
-    log_weights = -np.log(500) * np.ones(500)  # uniform weights
-    y_obs = 0.0
+    draws = rng.normal(size=(4, 500))
+    log_weights = -np.log(500) * np.ones((4, 500))
+    y_obs = np.array([-3.0, 0.0, 1.0, 3.0])
 
-    result_weighted = array_stats._pareto_pit(draws, y_obs, log_weights=log_weights)
-    result_unweighted = array_stats._pareto_pit(draws, y_obs)
+    result_weighted = _pareto_pit_vec_test(draws, y_obs, log_weights=log_weights)
+    result_unweighted = _pareto_pit_vec_test(draws, y_obs)
 
     # Uniform weights should give similar results to no weights
     np.testing.assert_allclose(result_weighted, result_unweighted, atol=0.05)
-    assert 0 <= result_weighted <= 1
+    assert np.all((0 <= result_weighted) & (result_weighted <= 1))

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -1,6 +1,7 @@
 """Test Diagnostic methods"""
 
 # pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
 import os
 
 import numpy as np
@@ -381,7 +382,179 @@ def test_split_chain_dims(rng, chains, draws):
         data = rng.normal(size=draws)
     else:
         data = rng.normal(size=(chains, draws))
-    split_data = array_stats._split_chains(data)  # pylint: disable=protected-access
+    split_data = array_stats._split_chains(data)
     if chains is None:
         chains = 1
     assert split_data.shape == (chains * 2, draws // 2)
+
+
+def test_pareto_pit_returns_scalar_in_valid_range():
+    rng = np.random.default_rng(1)
+    draws = rng.normal(size=500)
+    y_obs = 0.5
+    result = array_stats._pareto_pit(draws, y_obs)
+    assert isinstance(result, float)
+    assert 0 <= result <= 1
+
+
+def test_pareto_pit_bulk_values_match_raw_pit():
+    """For observations well inside the bulk, pareto_pit and raw ECDF PIT should agree."""
+    rng = np.random.default_rng(42)
+    draws = rng.normal(size=1000)
+    y_obs = 0.0  # near the median
+
+    refined = array_stats._pareto_pit(draws, y_obs, rng=rng)
+    # raw ECDF PIT
+    raw = np.mean(draws < y_obs)
+
+    np.testing.assert_allclose(refined, raw, atol=0.05)
+
+
+def test_pareto_pit_differs_from_ecdf_in_tails():
+    """Pareto-smoothed PIT should differ from raw ECDF in the tails."""
+    rng = np.random.default_rng(42)
+    draws = rng.normal(size=1000)
+    y_obs = 4.0  # far right tail
+
+    refined = array_stats._pareto_pit(draws, y_obs)
+    raw = np.mean(draws < y_obs)
+
+    assert refined != raw
+    assert 0 <= refined <= 1
+
+
+def test_pareto_pit_right_tail_closer_to_true_cdf():
+    """On average, pareto_pit should be closer to the true CDF in the right tail."""
+    rng = np.random.default_rng(123)
+    from scipy import stats as sp_stats
+
+    ndraws = 500
+    n_reps = 200
+    true_prob = 0.999
+    y_obs = sp_stats.t.ppf(true_prob, df=3)
+
+    raw_errors = []
+    refined_errors = []
+    for _ in range(n_reps):
+        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        raw = np.mean(draws < y_obs)
+        refined = array_stats._pareto_pit(draws, y_obs)
+        raw_errors.append((raw - true_prob) ** 2)
+        refined_errors.append((refined - true_prob) ** 2)
+
+    assert np.mean(refined_errors) < np.mean(raw_errors)
+
+
+def test_pareto_pit_left_tail_closer_to_true_cdf():
+    """On average, pareto_pit should be closer to the true CDF in the left tail."""
+    rng = np.random.default_rng(123)
+    from scipy import stats as sp_stats
+
+    ndraws = 500
+    n_reps = 200
+    true_prob = 0.001
+    y_obs = sp_stats.t.ppf(true_prob, df=3)
+
+    raw_errors = []
+    refined_errors = []
+    for _ in range(n_reps):
+        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        raw = np.mean(draws < y_obs)
+        refined = array_stats._pareto_pit(draws, y_obs)
+        raw_errors.append((raw - true_prob) ** 2)
+        refined_errors.append((refined - true_prob) ** 2)
+
+    assert np.mean(refined_errors) < np.mean(raw_errors)
+
+
+def test_pareto_pit_extreme_tail_more_varied_than_ecdf():
+    """In extreme tails, GPD extrapolation should give more varied estimates than ECDF."""
+    rng = np.random.default_rng(123)
+    from scipy import stats as sp_stats
+
+    ndraws = 500
+    n_reps = 200
+    y_obs = sp_stats.t.ppf(0.9995, df=3)
+
+    raw_vals = []
+    refined_vals = []
+    for _ in range(n_reps):
+        draws = sp_stats.t.rvs(df=3, size=ndraws, random_state=rng)
+        raw_vals.append(np.mean(draws < y_obs))
+        refined_vals.append(array_stats._pareto_pit(draws, y_obs))
+
+    assert len(set(np.round(refined_vals, 6))) > len(set(np.round(raw_vals, 6)))
+
+
+def test_pareto_pit_discrete_randomization():
+    """With discrete observations matching draws, randomization should produce variation."""
+    draws = np.repeat([0, 1, 2, 3], 250).astype(float)
+    y_obs = 2.0
+
+    results = []
+    for seed in range(100):
+        rng = np.random.default_rng(seed)
+        results.append(array_stats._pareto_pit(draws, y_obs, rng=rng))
+
+    assert np.std(results) > 0
+    assert all(0 <= r <= 1 for r in results)
+
+
+def test_pareto_pit_constant_draws():
+    """Constant draws should not error; falls back to raw PIT."""
+    draws = np.full(200, 5.0)
+    y_obs = 5.0
+    result = array_stats._pareto_pit(draws, y_obs)
+    assert isinstance(result, float)
+    assert 0 <= result <= 1
+
+
+def test_pareto_pit_non_finite_draws_fallback():
+    """Non-finite draws should fall back to raw PIT without error."""
+    draws = np.arange(1, 100, dtype=float)
+    draws = np.append(draws, np.nan)
+    y_obs = 50.0
+    result = array_stats._pareto_pit(draws, y_obs)
+    assert isinstance(result, float)
+    assert 0 <= result <= 1
+
+
+def test_pareto_pit_observation_beyond_all_draws():
+    """Observations far beyond draws should give near-0 or near-1 PIT values."""
+    rng = np.random.default_rng(42)
+    draws = rng.normal(size=500)
+
+    result_right = array_stats._pareto_pit(draws, 100.0)
+    result_left = array_stats._pareto_pit(draws, -100.0)
+
+    assert result_right > 0.99
+    assert result_left < 0.01
+
+
+def test_pareto_pit_values_always_in_valid_range():
+    """PIT values should be in [0, 1] across various quantiles."""
+    rng = np.random.default_rng(42)
+    from scipy import stats as sp_stats
+
+    draws = rng.normal(size=500)
+    quantiles = [0.001, 0.01, 0.05, 0.1, 0.3, 0.7, 0.9, 0.95, 0.99, 0.999]
+
+    for q in quantiles:
+        y_obs = sp_stats.norm.ppf(q)
+        result = array_stats._pareto_pit(draws, y_obs)
+        assert 0 <= result <= 1, f"PIT out of range for quantile {q}: {result}"
+
+
+def test_pareto_pit_with_log_weights():
+    """pareto_pit should work with importance weights."""
+    rng = np.random.default_rng(42)
+    draws = rng.normal(size=500)
+    log_weights = -np.log(500) * np.ones(500)  # uniform weights
+    y_obs = 0.0
+
+    result_weighted = array_stats._pareto_pit(draws, y_obs, log_weights=log_weights)
+    result_unweighted = array_stats._pareto_pit(draws, y_obs)
+
+    # Uniform weights should give similar results to no weights
+    np.testing.assert_allclose(result_weighted, result_unweighted, atol=0.05)
+    assert 0 <= result_weighted <= 1


### PR DESCRIPTION
The function `_pareto_pit`  computes PIT values using the ECDF, then refines the tails by fitting a generalized Pareto distribution (GPD) to the tail draws. This gives smoother, more accurate PIT values in the tails and avoids PIT values of 0 and 1. 

This follows the implementation in posterior package https://github.com/stan-dev/posterior/blob/727ac83cb52babb6eb54bdd1ce15f90439626945/R/pit.R#L238