### PR TITLE
scale ISJ bw estimate by grid range rather than data range

### DIFF
--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -74,7 +74,7 @@ class _DensityBase(_CoreBase):
         out = t - (2 * n * np.pi**0.5 * f) ** (-0.4)
         return out
 
-    def _root(self, function, n, args, x, x_range):
+    def _root(self, function, n, args, x, grid_range):
         # The right bound is at most 0.01
         found = False
         n = max(min(1050, n), 50)
@@ -89,7 +89,7 @@ class _DensityBase(_CoreBase):
                 tol *= 2.0
                 found = False
             if bw <= 0 or tol >= 1:
-                bw = (self.bw_silverman(x) / x_range) ** 2
+                bw = (self.bw_silverman(x) / grid_range) ** 2
                 return bw
         return bw
 
@@ -110,7 +110,7 @@ class _DensityBase(_CoreBase):
         bw = 0.9 * a * len(x) ** (-0.2)
         return bw
 
-    def bw_isj(self, x, grid_counts=None, x_std=None, x_range=None):
+    def bw_isj(self, x, grid_counts=None, x_std=None, grid_range=None):
         """Improved Sheather-Jones bandwidth estimation.
 
         Notes
@@ -126,17 +126,16 @@ class _DensityBase(_CoreBase):
         Ann. Statist. 38 (2010), no. 5, 2916--2957.
         """
         x_len = len(x)
-        if x_range is None:
-            x_min = np.min(x)
-            x_max = np.max(x)
-            x_range = x_max - x_min
 
         # Relative frequency per bin
         if grid_counts is None:
+            x_min = np.min(x)
+            x_max = np.max(x)
             x_std = np.std(x)
             grid_len = 256
             grid_min = x_min - 0.5 * x_std
             grid_max = x_max + 0.5 * x_std
+            grid_range = grid_max - grid_min
             grid_counts, _ = self._histogram(
                 x, bins=grid_len, range=(grid_min, grid_max), density=False
             )
@@ -151,17 +150,17 @@ class _DensityBase(_CoreBase):
         k_sq = np.arange(1, grid_len) ** 2
         a_sq = a_k[range(1, grid_len)] ** 2
 
-        t = self._root(self._fixed_point, x_len, args=(x_len, k_sq, a_sq), x=x, x_range=x_range)
-        h = t**0.5 * x_range
+        t = self._root(self._fixed_point, x_len, args=(x_len, k_sq, a_sq), x=x, grid_range=grid_range)
+        h = t**0.5 * grid_range
         return h
 
-    def bw_experimental(self, x, grid_counts=None, x_std=None, x_range=None):
+    def bw_experimental(self, x, grid_counts=None, x_std=None, grid_range=None):
         """Experimental bandwidth estimator."""
         bw_silverman = self.bw_silverman(x, x_std=x_std)
-        bw_isj = self.bw_isj(x, grid_counts=grid_counts, x_range=x_range)
+        bw_isj = self.bw_isj(x, grid_counts=grid_counts, grid_range=grid_range)
         return 0.5 * (bw_silverman + bw_isj)
 
-    def get_bw(self, x, bw, grid_counts=None, x_std=None, x_range=None):
+    def get_bw(self, x, bw, grid_counts=None, x_std=None, grid_range=None):
         """Compute bandwidth for a given data `x` and `bw`.
 
         Also checks `bw` is correctly specified.
@@ -200,7 +199,7 @@ class _DensityBase(_CoreBase):
                 )
 
             bw_fun = getattr(self, f"bw_{bw}")
-            bw = bw_fun(x, grid_counts=grid_counts, x_std=x_std, x_range=x_range)
+            bw = bw_fun(x, grid_counts=grid_counts, x_std=x_std, grid_range=grid_range)
         else:
             raise ValueError(
                 "Unrecognized `bw` argument.\n"
@@ -450,18 +449,18 @@ class _DensityBase(_CoreBase):
         x_min = x.min()
         x_max = x.max()
         x_std = np.std(x)
-        x_range = x_max - x_min
 
         # Determine grid
         grid_min, grid_max, grid_len = self.get_grid(
             x_min, x_max, x_std, extend_fct, grid_len, custom_lims, extend, bound_correction
         )
+        grid_range = grid_max - grid_min
         grid_counts, grid_edges = self._histogram(
             x, bins=grid_len, range=(grid_min, grid_max), density=False
         )
 
         # Bandwidth estimation
-        bw = bw_fct * self.get_bw(x, bw, grid_counts, x_std, x_range)
+        bw = bw_fct * self.get_bw(x, bw, grid_counts, x_std, grid_range)
 
         # Density estimation
         if adaptive:

--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -150,7 +150,9 @@ class _DensityBase(_CoreBase):
         k_sq = np.arange(1, grid_len) ** 2
         a_sq = a_k[range(1, grid_len)] ** 2
 
-        t = self._root(self._fixed_point, x_len, args=(x_len, k_sq, a_sq), x=x, grid_range=grid_range)
+        t = self._root(
+            self._fixed_point, x_len, args=(x_len, k_sq, a_sq), x=x, grid_range=grid_range
+        )
         h = t**0.5 * grid_range
         return h
 

--- a/tests/base/test_density.py
+++ b/tests/base/test_density.py
@@ -68,7 +68,7 @@ class TestBandwidthEstimators:
         x_std = np.std(x)
         x_range = x.max() - x.min()
         grid_counts, _ = density._histogram(x, bins=256)
-        bw = density.bw_isj(x, grid_counts=grid_counts, x_std=x_std, x_range=x_range)
+        bw = density.bw_isj(x, grid_counts=grid_counts, x_std=x_std, grid_range=x_range)
         assert bw > 0
 
     def test_bw_experimental(self, density, rng):


### PR DESCRIPTION
The ISJ bandwidth is incorrectly rescaled from [0, 1] (over which `t_star` is estimated) back to the data domain - it should be rescaled by the width of the implemented grid (in data units) rather than just the range of the data. See https://github.com/tommyod/KDEpy/issues/199 for the brief discussion that led to this conclusion. The fix amounts to a wholesale replacement of `x_range` with `grid_range = grid_max - grid_min` in `density.py` (i.e., I checked that all instances should indeed be changed).

To further illustrate the improvement, ISJ bandwidth's variation with grid width, computed with
```python
import numpy as np
from arviz_stats.base import array_stats
from scipy.stats import norm
data = norm().rvs(10000)
np.array([array_stats.kde_linear(data, extend=True, bound_correction=False, extend_fct=f, bw="isj")[-1] for f in np.linspace(0, 2, 11)])
```
gives
```
array([0.17038331, 0.16231991, 0.15425661, 0.14671877, 0.13987671,
       0.13480469, 0.12944809, 0.12408305, 0.11988148, 0.11580617,
       0.11172394])
```
on main and
```
array([0.17310286, 0.17306596, 0.17305311, 0.17314323, 0.17296685,
       0.17303633, 0.17308081, 0.17317929, 0.17306257, 0.17254111,
       0.17325904])
```
on this PR, i.e., the result is much more stable to small variations in the grid width.