### PR TITLE
heterogeneous computation fixes

### DIFF
--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -388,6 +388,7 @@ class BaseDataArray:
     def ecdf(self, da, npoints=200, pit=False, dim=None, **kwargs):
         """Compute empirical cumulative distribution function on DataArray input."""
         dims = validate_dims(dim)
+        ecdf_dim = "ecdf_dim" if da.name is None else f"ecdf_dim_{da.name}"
         x, y = apply_ufunc(
             self.array_class.ecdf,
             da,
@@ -398,7 +399,7 @@ class BaseDataArray:
                 **kwargs,
             },
             input_core_dims=[dims],
-            output_core_dims=[["ecdf_dim"], ["ecdf_dim"]],
+            output_core_dims=[[ecdf_dim], [ecdf_dim]],
         )
         plot_axis = DataArray(["x", "y"], dims="plot_axis")
         return concat((x, y), dim=plot_axis)
@@ -406,6 +407,7 @@ class BaseDataArray:
     def uniformity_test(self, da, dim=None, method="pot_c", **kwargs):
         """Pointwise uniformity test on DataArray input."""
         dims = validate_dims(dim)
+        pit_dim = "pit_dim" if da.name is None else f"pit_dim_{da.name}"
         n_points = 1
         for d in dims:
             n_points *= da.sizes[d]
@@ -418,7 +420,7 @@ class BaseDataArray:
                 **kwargs,
             },
             input_core_dims=[dims],
-            output_core_dims=[[], ["pit_dim"], ["pit_dim"]],
+            output_core_dims=[[], [pit_dim], [pit_dim]],
         )
         return p_value, shapley, shapley_unsorted
 

--- a/src/arviz_stats/utils.py
+++ b/src/arviz_stats/utils.py
@@ -287,7 +287,9 @@ def _warn_non_unique_coords(xr_obj, dims_to_reduce):
     non_unique_coords = [
         dim
         for dim in xr_obj.dims
-        if len(np.unique(xr_obj.coords[dim])) != xr_obj.sizes[dim] and dim not in dims_to_reduce
+        if (dim not in dims_to_reduce)
+        and (dim in xr_obj.coords)
+        and (len(np.unique(xr_obj.coords[dim])) != xr_obj.sizes[dim])
     ]
     if non_unique_coords:
         warnings.warn(

--- a/tests/base/test_stats.py
+++ b/tests/base/test_stats.py
@@ -254,14 +254,20 @@ def test_ecdf(centered_eight):
     accessor = centered_eight.posterior.ds.azstats
     result = accessor.ecdf()
     assert isinstance(result, xr.Dataset)
-    assert result.sizes == {"plot_axis": 2, "ecdf_dim": 200, "school": 8}
+    assert result.sizes == {
+        "plot_axis": 2,
+        "ecdf_dim_mu": 200,
+        "ecdf_dim_theta": 200,
+        "ecdf_dim_tau": 200,
+        "school": 8,
+    }
 
 
 def test_ecdf_idata_varnames(centered_eight):
     accessor = centered_eight.posterior.ds.azstats
     result = accessor.filter_vars(var_names=["mu", "theta"]).ecdf()
     assert isinstance(result, xr.Dataset)
-    assert result.sizes == {"plot_axis": 2, "ecdf_dim": 200, "school": 8}
+    assert result.sizes == {"plot_axis": 2, "ecdf_dim_mu": 200, "ecdf_dim_theta": 200, "school": 8}
     assert list(result.data_vars.keys()) == ["mu", "theta"]
 
 


### PR DESCRIPTION
More fixes and improvements out of my pydata tutorial.
Most changes here are to allow functions to work on more heterogeneous input.
That is, groupby things, posterior predictive group with multiple variables and each of different
shape and dimension names...

Needs more testing before merging. Will create the PR as draft and mark it as ready once I get to
them.
