### PR TITLE
fix: convert ary to mutable numpy array in _ps_tail to support JAX arrays

### DIFF
--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1164,6 +1164,9 @@ class _DiagnosticsBase(_CoreBase):
         k : float
             Estimated shape parameter.
         """
+        # JAX arrays are immutable; copy to a plain numpy array so in-place assignments work.
+        ary = np.asarray(ary).copy()
+
         if log_weights:
             ary = ary - np.max(ary)
 

--- a/tests/loo/test_loo.py
+++ b/tests/loo/test_loo.py
@@ -554,3 +554,20 @@ def test_loo_mixture(centered_eight):
     assert np.isfinite(result_mix.elpd)
     assert np.all(np.isfinite(result_mix.elpd_i.values))
     assert np.all(np.isfinite(result_mix.pareto_k.values))
+
+
+def test_loo_jax_arrays(centered_eight):
+    """loo() must not raise when log_likelihood contains JAX arrays (immutability regression)."""
+    jnp = importorskip("jax.numpy")
+
+    # Copy first: centered_eight is a session-scoped fixture and must not be mutated.
+    data = centered_eight.copy()
+    # Replace the log_likelihood group values with JAX arrays to simulate a JAX backend.
+    obs = data.log_likelihood["obs"]
+    data.log_likelihood["obs"] = xr.DataArray(
+        jnp.asarray(obs.values), dims=obs.dims, coords=obs.coords
+    )
+
+    result = loo(data, pointwise=True)
+    assert np.isfinite(result.elpd)
+    assert np.all(np.isfinite(result.pareto_k.values))

--- a/tests/loo/test_loo_moment_matching_helpers.py
+++ b/tests/loo/test_loo_moment_matching_helpers.py
@@ -142,6 +142,9 @@ class TestMomentMatchFunctions:
             draws=50,
             tune=50,
             chains=2,
+            # sample sequentially, forking workers triggers a RuntimeWarning
+            # from JAX's at-fork handler that our filterwarnings turns into an error
+            cores=1,
             random_seed=3,
             progressbar=False,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ extras =
     numba
 deps =
     pymc>=6
+    jax
 setenv =
     ARVIZ_REQUIRE_ALL_DEPS=TRUE
 


### PR DESCRIPTION
Fixes #367.

## Summary

- `_ps_tail` performs an in-place assignment (`ary[ordered[tail_ids]] = smoothed`) that crashes when `ary` is a JAX array, because JAX arrays are immutable.
- Add `ary = np.asarray(ary).copy()` at the top of `_ps_tail` to ensure it always works on a mutable numpy array before doing any operations.
- Add a regression test in `tests/loo/test_loo.py` that passes JAX arrays as the log-likelihood values and asserts `loo()` completes without error.

## Test plan

- [ ] `test_loo_jax_arrays` — new test, passes a `jnp.array`-backed log-likelihood group through `loo()` and checks it doesn't raise and returns finite values. Skipped automatically if JAX is not installed.
- [ ] Full `tests/loo/test_loo.py` suite — all 30 existing tests still pass.