### PR TITLE
fix(summary): preserve numeric dtypes by removing string formatting in _round_summary

### DIFF
--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -275,7 +275,6 @@ def _round_summary(summary_result, round_val):
     result = summary_result.copy()
     columns = result.columns
     rounded_columns = set()
-    use_scientific = {}
 
     # Rule 1: ESS columns and min_ss are rounded down to int
     ess_cols = [col for col in columns if col.startswith("ess_") or col == "min_ss"]
@@ -306,10 +305,7 @@ def _round_summary(summary_result, round_val):
             if not np.isfinite(se_val):
                 continue
             decimal_places = get_decimal_places_from_se(se_val)
-            if decimal_places < 0:
-                use_scientific[(idx, stat_col)] = True
-            else:
-                result.loc[idx, stat_col] = round_num(stat_val, decimal_places)
+            result.loc[idx, stat_col] = round_num(stat_val, decimal_places)
 
         rounded_columns.add(stat_col)
         rounded_columns.add(se_col)
@@ -319,23 +315,6 @@ def _round_summary(summary_result, round_val):
         if col not in rounded_columns:
             if result[col].dtype.kind == "f":
                 result[col] = result[col].apply(lambda x: round_num(x, round_val))
-
-    # Rule 5: Format
-    for col in columns:
-        if result[col].dtype.kind == "f":
-            if col == "r_hat":
-                result[col] = result[col].apply(lambda x: f"{x:.2f}" if np.isfinite(x) else x)
-            else:
-                formatted_values = []
-                for idx, val in zip(result.index, result[col]):
-                    if not np.isfinite(val):
-                        formatted_values.append(val)
-                    elif use_scientific.get((idx, col), False):
-                        formatted_values.append(f"{val:.0e}")
-                    else:
-                        formatted_values.append(f"{val:g}")
-
-                result[col] = formatted_values
 
     return result
 


### PR DESCRIPTION
## Summary

Fixes #[arviz-devs/arviz#2591](https://github.com/arviz-devs/arviz/issues/2591) — `az.summary()` returns `object` dtype columns when `round_to="auto"`, breaking downstream numeric operations like `.mean()`, comparisons, and plotting.

## Root cause

`_round_summary` in `summary.py` had a Rule 5 block that applied Python f-string formatting to all float columns before returning:

```python
# Rule 5 (old) — converted floats to strings
result[col] = result[col].apply(lambda x: f"{x:.2f}" if np.isfinite(x) else x)
# or
result[col] = [f"{val:g}" or f"{val:.0e}" for ...]
```

Once any cell in a column becomes a Python string, pandas promotes the entire column dtype to `object`. This affected every float column in the summary output.

## Fix

- Removed the `use_scientific` dict and the scientific-notation branching in Rule 3
- Removed Rule 5 entirely — values stay as native Python floats
- Rule 3 now always calls `round_num(stat_val, decimal_places)` without conditionally converting to strings

## Before / after

```python
# Before
summary = az.summary(idata)
print(summary.dtypes)
# mean      object  ← broken
# sd        object
# hdi_3%    object

# After
summary = az.summary(idata)
print(summary.dtypes)
# mean      float64  ← correct
# sd        float64
# hdi_3%    float64
```

## Notes

Display formatting (scientific notation, significant figures) was the original intent of Rule 5, but that concern belongs at the render layer (e.g. `pd.options.display.float_format`), not in the data layer. The numeric values themselves are now correctly rounded via `round_num` and stay as floats.