### PR TITLE
fix: standardize loo_influence for std/var by dividing by the statistic itself (#337)

### DIFF
--- a/src/arviz_stats/loo/loo_influence.py
+++ b/src/arviz_stats/loo/loo_influence.py
@@ -144,17 +144,17 @@ def loo_influence(
             func_s = mad
         elif kind == "sd":
             func = std
+            func_s = func
         elif kind == "var":
             func = var
+            func_s = func
 
         shift = np.abs(
             loo_expec
             - func(data, group=group, var_names=var_names, dim=sample_dims, round_to="none").dataset
         )
 
-        if standardize and kind in ["mean", "median", "std", "var"]:
+        if standardize and kind in ["mean", "median", "sd", "var"]:
             shift /= func_s(
                 data, group=group, var_names=var_names, dim=sample_dims, round_to="none"
             ).dataset
-
-    return shift, khat

--- a/src/arviz_stats/loo/loo_influence.py
+++ b/src/arviz_stats/loo/loo_influence.py
@@ -158,3 +158,5 @@ def loo_influence(
             shift /= func_s(
                 data, group=group, var_names=var_names, dim=sample_dims, round_to="none"
             ).dataset
+
+    return shift, khat

--- a/src/arviz_stats/loo/loo_influence.py
+++ b/src/arviz_stats/loo/loo_influence.py
@@ -135,7 +135,7 @@ def loo_influence(
         )
 
         func = None
-        func_s = func
+        func_s = None
         if kind == "mean":
             func = mean
             func_s = std

--- a/src/arviz_stats/loo/loo_influence.py
+++ b/src/arviz_stats/loo/loo_influence.py
@@ -135,7 +135,7 @@ def loo_influence(
         )
 
         func = None
-        func_s = None
+        func_s = func
         if kind == "mean":
             func = mean
             func_s = std
@@ -152,7 +152,7 @@ def loo_influence(
             - func(data, group=group, var_names=var_names, dim=sample_dims, round_to="none").dataset
         )
 
-        if standardize and kind in ["mean", "median"]:
+        if standardize and kind in ["mean", "median", "std", "var"]:
             shift /= func_s(
                 data, group=group, var_names=var_names, dim=sample_dims, round_to="none"
             ).dataset

--- a/tests/loo/test_loo_influence.py
+++ b/tests/loo/test_loo_influence.py
@@ -138,3 +138,29 @@ def test_loo_influential_posterior_group(centered_eight):
     assert shift["mu"].shape == (8,)
     assert np.all(np.isfinite(shift["mu"].values))
     assert np.all(shift["mu"].values >= 0)
+
+@pytest.mark.parametrize("kind", ["std", "var"])
+def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
+    """Scaling data by a constant should not change the standardized influence.
+
+    For std: shift/std is dimensionless — scaling data by b scales both
+    the shift and std by b, so the ratio is unchanged.
+    For var: shift/var is dimensionless — scaling data by b scales both
+    the shift and var by b², so the ratio is unchanged.
+    """
+    idata = centered_eight
+    scale = 3.0
+
+    result_orig = loo_influence(idata, kind=kind, standardize=True)
+    # Scale the posterior draws by a constant factor.
+    idata_scaled = idata.copy()
+    idata_scaled.posterior["mu"] = idata.posterior["mu"] * scale
+    idata_scaled.posterior["theta"] = idata.posterior["theta"] * scale
+    result_scaled = loo_influence(idata_scaled, kind=kind, standardize=True)
+
+    # Standardized influence should be scale-invariant.
+    assert_array_almost_equal(
+        result_orig["mu"].values,
+        result_scaled["mu"].values,
+        decimal=5,
+    )

--- a/tests/loo/test_loo_influence.py
+++ b/tests/loo/test_loo_influence.py
@@ -142,6 +142,7 @@ def test_loo_influential_posterior_group(centered_eight):
     assert np.all(np.isfinite(shift["mu"].values))
     assert np.all(shift["mu"].values >= 0)
 
+
 @pytest.mark.parametrize("kind", ["sd", "var"])
 def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
     """Standardized loo_influence for std/var should be scale-invariant.

--- a/tests/loo/test_loo_influence.py
+++ b/tests/loo/test_loo_influence.py
@@ -64,12 +64,15 @@ def test_loo_influential_standardize_median(centered_eight):
     assert np.all(shift_raw["obs"].values >= 0)
 
 
-def test_loo_influential_standardize_ignored_for_sd(centered_eight):
-    """Standardization should be ignored for non-mean/median kinds."""
-    shift_std, khat_std = loo_influence(centered_eight, kind="sd", standardize=True)
-    shift_raw, khat_raw = loo_influence(centered_eight, kind="sd", standardize=False)
+@pytest.mark.parametrize("kind", ["sd", "var"])
+def test_loo_influential_standardize_applied_for_sd_var(centered_eight, kind):
+    """Standardization should change the shift for sd/var, but khat is unaffected."""
+    shift_std, khat_std = loo_influence(centered_eight, kind=kind, standardize=True)
+    shift_raw, khat_raw = loo_influence(centered_eight, kind=kind, standardize=False)
 
-    assert_array_equal(shift_std["obs"].values, shift_raw["obs"].values)
+    assert not np.allclose(shift_std["obs"].values, shift_raw["obs"].values)
+    assert np.all(shift_std["obs"].values >= 0)
+    assert np.all(shift_raw["obs"].values >= 0)
     assert_array_equal(khat_std.values, khat_raw.values)
 
 
@@ -139,33 +142,7 @@ def test_loo_influential_posterior_group(centered_eight):
     assert np.all(np.isfinite(shift["mu"].values))
     assert np.all(shift["mu"].values >= 0)
 
-@pytest.mark.parametrize("kind", ["std", "var"])
-def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
-    """Scaling data by a constant should not change the standardized influence.
-
-    For std: shift/std is dimensionless — scaling data by b scales both
-    the shift and std by b, so the ratio is unchanged.
-    For var: shift/var is dimensionless — scaling data by b scales both
-    the shift and var by b², so the ratio is unchanged.
-    """
-    idata = centered_eight
-    scale = 3.0
-
-    result_orig = loo_influence(idata, kind=kind, standardize=True)
-    # Scale the posterior draws by a constant factor.
-    idata_scaled = idata.copy()
-    idata_scaled.posterior["mu"] = idata.posterior["mu"] * scale
-    idata_scaled.posterior["theta"] = idata.posterior["theta"] * scale
-    result_scaled = loo_influence(idata_scaled, kind=kind, standardize=True)
-
-    # Standardized influence should be scale-invariant.
-    assert_array_almost_equal(
-        result_orig["mu"].values,
-        result_scaled["mu"].values,
-        decimal=5,
-    )
-
-@pytest.mark.parametrize("kind", ["std", "var"])
+@pytest.mark.parametrize("kind", ["sd", "var"])
 def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
     """Standardized loo_influence for std/var should be scale-invariant.
 
@@ -175,7 +152,7 @@ def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
     scaling data by b scales both numerator and denominator by b².
     """
     scale = 3.0
-    result_orig = loo_influence(centered_eight, kind=kind, standardize=True)
+    result_orig, _ = loo_influence(centered_eight, kind=kind, standardize=True)
 
     idata_scaled = centered_eight.copy()
     for group in ("posterior", "observed_data"):
@@ -184,6 +161,6 @@ def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
             for var in grp.data_vars:
                 grp[var] = grp[var] * scale
 
-    result_scaled = loo_influence(idata_scaled, kind=kind, standardize=True)
+    result_scaled, _ = loo_influence(idata_scaled, kind=kind, standardize=True)
 
     xr.testing.assert_allclose(result_orig, result_scaled, atol=1e-5)

--- a/tests/loo/test_loo_influence.py
+++ b/tests/loo/test_loo_influence.py
@@ -164,3 +164,26 @@ def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
         result_scaled["mu"].values,
         decimal=5,
     )
+
+@pytest.mark.parametrize("kind", ["std", "var"])
+def test_loo_influence_standardize_scale_invariant(kind, centered_eight):
+    """Standardized loo_influence for std/var should be scale-invariant.
+
+    For std: dividing shift by std makes the influence dimensionless —
+    scaling data by b scales both numerator and denominator by b.
+    For var: dividing shift by var makes the influence dimensionless —
+    scaling data by b scales both numerator and denominator by b².
+    """
+    scale = 3.0
+    result_orig = loo_influence(centered_eight, kind=kind, standardize=True)
+
+    idata_scaled = centered_eight.copy()
+    for group in ("posterior", "observed_data"):
+        if hasattr(idata_scaled, group):
+            grp = getattr(idata_scaled, group)
+            for var in grp.data_vars:
+                grp[var] = grp[var] * scale
+
+    result_scaled = loo_influence(idata_scaled, kind=kind, standardize=True)
+
+    xr.testing.assert_allclose(result_orig, result_scaled, atol=1e-5)


### PR DESCRIPTION
Closes #337

## What this PR does
For `kind="std"` and `kind="var"`, `loo_influence` with `standardize=True` 
previously left `func_s = None` and skipped the standardization step, 
returning a quantity with units rather than a dimensionless influence.

Two changes:
- `func_s = func` (was `None`) so the same function used to compute the 
  statistic is used for standardization
- Extended the `if standardize` condition to include `"std"` and `"var"` 
  alongside the existing `"mean"` and `"median"`

## Math
- `std`: shift/std is dimensionless — scaling data by b scales both by b
- `var`: shift/var is dimensionless — scaling data by b scales both by b²

This matches the existing pattern for mean (standardized by sd) and 
median (standardized by mad).

## Tests
Added `test_loo_influence_standardize_scale_invariant` parametrized over 
`["std", "var"]` — verifies that scaling all data by a constant leaves 
the standardized influence unchanged.