### PR TITLE
REF: refactor `loo_kfold` to fix group assignment

### DIFF
--- a/src/arviz_stats/loo/helper_loo_kfold.py
+++ b/src/arviz_stats/loo/helper_loo_kfold.py
@@ -215,40 +215,18 @@ def _kfold_split_grouped(k=10, x=None):
     k = _validate_k_value(k, len(x))
 
     unique_vals = np.unique(x)
-    x_int = np.zeros(len(x), dtype=int)
-    for i, val in enumerate(unique_vals):
-        x_int[x == val] = i + 1
-
     n_levels = len(unique_vals)
 
     if n_levels < k:
         raise ValueError("k must not be bigger than the number of levels/groups in x")
 
+    level_of_obs = np.searchsorted(unique_vals, x) + 1
+
     if n_levels == k:
-        return x_int
+        return level_of_obs
 
-    s1 = int(np.ceil(n_levels / k))
-    n_s2 = s1 * k - n_levels
-    n_s1 = k - n_s2
-
-    rng = np.random.default_rng()
-    perm = rng.permutation(n_levels) + 1
-
-    breaks = []
-    if n_s1 > 0:
-        breaks.extend(np.arange(s1 + 0.5, s1 * n_s1 + 0.5, s1))
-    if n_s2 > 0:
-        start = breaks[-1] if breaks else 0.5
-        breaks.extend(np.arange(start + s1 - 1, start + (s1 - 1) * n_s2, s1 - 1))
-
-    breaks = np.array(breaks)
-    groups = np.searchsorted(breaks, perm, side="right") + 1
-
-    bins = np.zeros(len(x), dtype=int)
-    for j in range(1, n_levels + 1):
-        bins[x_int == j] = groups[j - 1]
-
-    return bins
+    fold_of_level = _kfold_split_random(k=k, n=n_levels)
+    return fold_of_level[level_of_obs - 1]
 
 
 def _extract_fold_data(data, fold_indices, train=True):

--- a/tests/loo/test_helper_kfold.py
+++ b/tests/loo/test_helper_kfold.py
@@ -171,8 +171,7 @@ def test_kfold_split_grouped_many_groups():
     x_many_groups = np.repeat(np.arange(10), 3)
     k = 3
     folds = _kfold_split_grouped(k=k, x=x_many_groups)
-    assert len(set(folds)) <= k
-    assert len(set(folds)) >= 1
+    assert set(folds.tolist()) == set(range(1, k + 1))
     assert min(folds) >= 1
     assert max(folds) <= k
 
@@ -483,3 +482,47 @@ def test_get_fold_indices_unequal_folds():
     np.testing.assert_array_equal(fold_indices[1]["test_indices"], [0, 1, 2])
     np.testing.assert_array_equal(fold_indices[2]["test_indices"], [3, 4])
     np.testing.assert_array_equal(fold_indices[3]["test_indices"], [5])
+
+
+@pytest.mark.parametrize(
+    "n_levels,k",
+    [
+        (3, 2),
+        (5, 2),
+        (5, 3),
+        (7, 3),
+        (10, 4),
+        (6, 4),
+        (9, 4),
+        (13, 5),
+    ],
+)
+def test_kfold_split_grouped_always_produces_k_folds(n_levels, k):
+    x = np.repeat(np.arange(n_levels), 3)
+    for _ in range(50):
+        folds = _kfold_split_grouped(k=k, x=x)
+        assert set(folds.tolist()) == set(range(1, k + 1)), (
+            f"grouped split produced folds {sorted(set(folds.tolist()))} "
+            f"for n_levels={n_levels}, k={k}; expected exactly {k} folds"
+        )
+        for group_id in np.unique(x):
+            group_folds = folds[x == group_id]
+            assert len(set(group_folds.tolist())) == 1
+
+
+@pytest.mark.parametrize(
+    "n_levels,k",
+    [
+        (7, 3),
+        (10, 4),
+        (13, 5),
+        (11, 3),
+    ],
+)
+def test_kfold_split_grouped_balanced_fold_sizes(n_levels, k):
+    x = np.repeat(np.arange(n_levels), 2)
+    folds = _kfold_split_grouped(k=k, x=x)
+    groups_per_fold = [
+        len({g for g in np.unique(x) if folds[x == g][0] == fold}) for fold in range(1, k + 1)
+    ]
+    assert max(groups_per_fold) - min(groups_per_fold) <= 1

--- a/tests/loo/test_helper_kfold.py
+++ b/tests/loo/test_helper_kfold.py
@@ -522,7 +522,7 @@ def test_kfold_split_grouped_always_produces_k_folds(n_levels, k):
 def test_kfold_split_grouped_balanced_fold_sizes(n_levels, k):
     x = np.repeat(np.arange(n_levels), 2)
     folds = _kfold_split_grouped(k=k, x=x)
-    groups_per_fold = [
-        len({g for g in np.unique(x) if folds[x == g][0] == fold}) for fold in range(1, k + 1)
-    ]
-    assert max(groups_per_fold) - min(groups_per_fold) <= 1
+    _, unique_indices = np.unique(x, return_index=True)
+    group_folds = folds[unique_indices]
+    _, fold_counts = np.unique(group_folds, return_counts=True)
+    assert fold_counts.max() - fold_counts.min() <= 1

--- a/tests/loo/test_loo_kfold.py
+++ b/tests/loo/test_loo_kfold.py
@@ -254,3 +254,14 @@ def test_loo_kfold_se_positive(centered_eight, fresh_wrapper):
 def test_loo_kfold_p_positive(centered_eight, fresh_wrapper):
     result = loo_kfold(data=centered_eight, wrapper=fresh_wrapper, k=4, pointwise=False)
     assert result.p > 0
+
+
+def test_loo_kfold_grouped_ngroups_not_multiple_of_k(centered_eight, fresh_wrapper):
+    groups = np.array([1, 1, 2, 2, 3, 3, 3, 3])
+    result = loo_kfold(
+        data=centered_eight, wrapper=fresh_wrapper, k=2, group_by=groups, pointwise=True
+    )
+    assert result.n_folds == 2
+    assert fresh_wrapper.fit_count == 2
+    assert np.isfinite(result.elpd)
+    assert result.elpd_i.size == 8


### PR DESCRIPTION
Fixes grouped k-fold split to always produce exactly k folds.

`loo_kfold(..., group_by=...)` (via `_kfold_split_grouped`) produced the wrong number of folds whenever the number of groups was not an exact multiple of `k`. Instead of `k` folds it returned fewer, with one or more empty folds, and for cases like an odd number of groups with `k=2`, it collapsed every group into a single fold. Downstream, an empty fold gets fed into the `elpd` computation and crashes `loo_kfold` with an `IndexError`. Since `k` defaults to 10, essentially any grouped dataset whose group count isn't a multiple of `k` was affected.