### PR TITLE
Replace absolufy-imports with ruff TID and rename ruff hook to ruff-check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
     actions:
       patterns:
         - "*"
+- package-ecosystem: "pre-commit"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+  groups:
+    pre-commit:
+      patterns:
+        - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
       - name: Install dependencies

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,10 +9,10 @@ jobs:
     name: Update changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
-      - uses: rhysd/changelog-from-release/action@v3
+      - uses: rhysd/changelog-from-release/action@78b335bb7d059f35ad04c5428d50711726feee50 # v3.9.1
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,11 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
         with:
           # Prove that the packages were built in the context of this workflow.
           attest-build-provenance-github: true
@@ -39,11 +39,11 @@ jobs:
       id-token: write
     steps:
       - name: Download Distribution Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # The build-and-inspect-python-package action invokes upload-artifact.
           # These are the correct arguments from that action.
           name: Packages
           path: dist
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
         env:
           JOB: ${{ matrix.job }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           name: Python ${{ matrix.python-version }} ${{ matrix.job }}
           fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,17 +14,10 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.6
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix, --exit-non-zero-on-fix ]
     - id: ruff-format
       types_or: [ python, pyi ]
-
-- repo: https://github.com/MarcoGorelli/absolufy-imports
-  rev: v0.3.1
-  hooks:
-    - id: absolufy-imports
-      args: ["--application-directories", "src"]
-      files: ^src/arviz_stats/.+\.py$
 
 - repo: https://github.com/MarcoGorelli/madforhooks
   rev: 0.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
     exclude: ^tests/roaches\.nc\.xz$
@@ -12,7 +12,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.6
+  rev: 01a675ea018f2fb714478a5ffb83fcea8374bb06  # frozen: v0.15.21
   hooks:
     - id: ruff-check
       args: [ --fix, --exit-non-zero-on-fix ]
@@ -20,7 +20,7 @@ repos:
       types_or: [ python, pyi ]
 
 - repo: https://github.com/MarcoGorelli/madforhooks
-  rev: 0.4.1
+  rev: 543b5e414406c00edeb9e2204141713c4c8d2404  # frozen: 0.4.1
   hooks:
     - id: no-print-statements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ select = [
     "NPY", # numpy specific rules
     "UP",  # pyupgrade
     "I",  # isort
+    "TID",  # flake8-tidy-imports (relative imports)
     # "PL",  # Pylint
 ]
 ignore = [
@@ -97,10 +98,13 @@ ignore = [
 "src/arviz_stats/__init__.py" = ["I", "F401", "E402", "F403"]
 "src/arviz_stats/numba/*" = ["F841"]
 "src/arviz_stats/**/__init__.py" = ["I", "F401", "E402", "F403"]
-"tests/**/*" = ["D", "E402", "PLR2004", "NPY002"]
+"tests/**/*" = ["D", "E402", "PLR2004", "NPY002", "TID252"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [tool.ruff.format]
 docstring-code-format = false


### PR DESCRIPTION

- swap absolufy-imports for ruff's TID with ban-relative-imports

- rename the deprecated ruff hook id to ruff-check

- add pre-commit to dependabot so hook versions get bumped automatically