### PR TITLE
test: update expected values in test_metrics_acc

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -201,8 +201,8 @@ def test_metrics(datatree, kind, round_to, expected_mean, expected_se):
 @pytest.mark.parametrize(
     "kind, round_to, expected_mean, expected_se",
     [
-        ("acc", 2, 0.86, 0.13),
-        ("acc_balanced", "2g", 0.83, 0.021),
+        ("acc", 2, 0.43, 0.19),
+        ("acc_balanced", "2g", 0.46, 0.039),
     ],
 )
 def test_metrics_acc(datatree_binary, kind, round_to, expected_mean, expected_se):


### PR DESCRIPTION
`test_metrics_acc` in `tests/test_metrics.py` has been failing on CI (first failure: https://github.com/arviz-devs/arviz-stats/actions/runs/28493302106/job/84478142260)  due to an unrelated upstream change in `arviz-base`.

`arviz-base`'s `datatree_binary()` test fixture (added in [arviz-devs/arviz-base#209](https://github.com/arviz-devs/arviz-base/pull/209)) draws a new `posterior` array from the shared RNG *before* the existing `posterior_predictive`/`observed_data` draws. This shifts all downstream values even though the seed is unchanged, invalidating the hardcoded expected values in `test_metrics_acc`.

This PR updates the expected values accordingly.

## Reproducing example

**On main:**
```bash
uv sync --extra xarray --extra test-xarray
uv pip install tox

# parent of breaking commit (pre-regression, 2026-06-30) - passes
uv run tox -e xarray --force-dep 'arviz-base @ git+https://github.com/arviz-devs/arviz-base@3c9fbdf522a8b5592529e55a2aeef3e4893421df' -- -k test_metrics_acc
```
```
collected 2577 items / 2575 deselected / 3 skipped / 2 selected

tests/test_metrics.py ..

=================================== 2 passed, 3 skipped, 2575 deselected in 3.92s ===================================
```

```bash
# breaking commit (PR #209) - fails
uv run tox -e xarray --force-dep 'arviz-base @ git+https://github.com/arviz-devs/arviz-base@85924c29d3e0d2726bff4bdc1222c180f100ba4c' -- -k test_metrics_acc
```
```
collected 2577 items / 2575 deselected / 3 skipped / 2 selected

tests/test_metrics.py FF

===================================================== FAILURES ======================================================
_________________________________________ test_metrics_acc[acc-2-0.86-0.13] _________________________________________

datatree_binary = <xarray.DataTree>
Group: /
├── Group: /posterior
│       Dimensions:  (chain: 4, draw: 100)
│       Coordinates:
│    ...:   1.3.0.dev0
            creation_library_language:  Python
            sample_dims:                ['chain', 'draw']
kind = 'acc', round_to = 2, expected_mean = 0.86, expected_se = 0.13

    @pytest.mark.parametrize(
        "kind, round_to, expected_mean, expected_se",
        [
            ("acc", 2, 0.86, 0.13),
            ("acc_balanced", "2g", 0.83, 0.021),
        ],
    )
    def test_metrics_acc(datatree_binary, kind, round_to, expected_mean, expected_se):
        result = metrics(datatree_binary, kind=kind, round_to=round_to)
>       assert_almost_equal(result.mean, expected_mean, decimal=4)
E       AssertionError:
E       Arrays are not almost equal to 4 decimals
E        ACTUAL: 0.43
E        DESIRED: 0.86

tests/test_metrics.py:210: AssertionError
___________________________________ test_metrics_acc[acc_balanced-2g-0.83-0.021] ____________________________________

datatree_binary = <xarray.DataTree>
Group: /
├── Group: /posterior
│       Dimensions:  (chain: 4, draw: 100)
│       Coordinates:
│    ...:   1.3.0.dev0
            creation_library_language:  Python
            sample_dims:                ['chain', 'draw']
kind = 'acc_balanced', round_to = '2g', expected_mean = 0.83, expected_se = 0.021

    @pytest.mark.parametrize(
        "kind, round_to, expected_mean, expected_se",
        [
            ("acc", 2, 0.86, 0.13),
            ("acc_balanced", "2g", 0.83, 0.021),
        ],
    )
    def test_metrics_acc(datatree_binary, kind, round_to, expected_mean, expected_se):
        result = metrics(datatree_binary, kind=kind, round_to=round_to)
>       assert_almost_equal(result.mean, expected_mean, decimal=4)
E       AssertionError:
E       Arrays are not almost equal to 4 decimals
E        ACTUAL: 0.46
E        DESIRED: 0.83

tests/test_metrics.py:210: AssertionError
============================================== short test summary info ==============================================
FAILED tests/test_metrics.py::test_metrics_acc[acc-2-0.86-0.13] - AssertionError:
FAILED tests/test_metrics.py::test_metrics_acc[acc_balanced-2g-0.83-0.021] - AssertionError:
=================================== 2 failed, 3 skipped, 2575 deselected in 4.20s ===================================
```

**On this PR:**
```bash
uv run tox -e xarray --force-dep 'arviz-base @ git+https://github.com/arviz-devs/arviz-base@85924c29d3e0d2726bff4bdc1222c180f100ba4c' -- -k test_metrics_acc
```
```
collected 2577 items / 2575 deselected / 3 skipped / 2 selected

tests/test_metrics.py ..

=================================== 2 passed, 3 skipped, 2575 deselected in 4.84s ===================================
```