### PR TITLE
REF: better handling of custom folds and multi-dim likelihoods in `loo_kfold()`

### DIFF
--- a/src/arviz_stats/loo/helper_loo_kfold.py
+++ b/src/arviz_stats/loo/helper_loo_kfold.py
@@ -63,6 +63,12 @@ def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_
     sample_dims = ["chain", "draw"]
 
     obs_dims = [dim for dim in log_likelihood.dims if dim not in sample_dims]
+    if len(obs_dims) > 1:
+        raise NotImplementedError(
+            "loo_kfold only supports a single observation dimension in the log likelihood, "
+            f"but found {len(obs_dims)}: {obs_dims}. Stack the observation dimensions into a "
+            "single dimension before calling loo_kfold."
+        )
     n_data_points = int(np.prod([log_likelihood.sizes[dim] for dim in obs_dims]))
     n_samples = int(np.prod([log_likelihood.sizes[dim] for dim in sample_dims]))
 
@@ -70,7 +76,9 @@ def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_
 
     if folds is not None:
         folds = _validate_array_length(folds, n_data_points, "folds")
-        k = len(np.unique(folds))
+        _, folds = np.unique(folds, return_inverse=True)
+        folds = np.reshape(folds, -1) + 1
+        k = _validate_k_value(len(np.unique(folds)), n_data_points)
     elif stratify_by is not None:
         stratify_by = _validate_array_length(stratify_by, n_data_points, "stratify_by")
         folds = _kfold_split_stratified(k=k, x=stratify_by)

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -232,7 +232,7 @@ def loo_kfold(
         good_k=None,
         elpd_i=kfold_results.elpd_i if pointwise else None,
         pareto_k=None,
-        n_folds=k,
+        n_folds=kfold_inputs.k,
     )
 
     if save_fits:

--- a/tests/loo/test_loo_kfold.py
+++ b/tests/loo/test_loo_kfold.py
@@ -265,3 +265,39 @@ def test_loo_kfold_grouped_ngroups_not_multiple_of_k(centered_eight, fresh_wrapp
     assert fresh_wrapper.fit_count == 2
     assert np.isfinite(result.elpd)
     assert result.elpd_i.size == 8
+
+
+def test_loo_kfold_custom_folds_zero_indexed(centered_eight, fresh_wrapper):
+    result = loo_kfold(
+        data=centered_eight, wrapper=fresh_wrapper, folds=[0, 0, 1, 1, 2, 2, 3, 3], pointwise=True
+    )
+    assert result.n_folds == 4
+    assert fresh_wrapper.fit_count == 4
+    assert result.elpd_i.size == 8
+    assert np.all(np.isfinite(result.elpd_i.values))
+
+
+def test_loo_kfold_custom_folds_noncontiguous_labels(centered_eight, fresh_wrapper):
+    result = loo_kfold(
+        data=centered_eight, wrapper=fresh_wrapper, folds=[10, 10, 20, 20, 30, 30, 40, 40]
+    )
+    assert result.n_folds == 4
+    assert fresh_wrapper.fit_count == 4
+
+
+def test_loo_kfold_custom_folds_single_value_raises(centered_eight, fresh_wrapper):
+    with pytest.raises(ValueError, match="k must be greater than 1"):
+        loo_kfold(data=centered_eight, wrapper=fresh_wrapper, folds=[1, 1, 1, 1, 1, 1, 1, 1])
+
+
+def test_loo_kfold_multiple_obs_dims_raises(fresh_wrapper):
+    rng = np.random.default_rng(0)
+    idata = azb.from_dict(
+        {
+            "posterior": {"mu": rng.normal(size=(2, 50))},
+            "log_likelihood": {"obs": rng.normal(size=(2, 50, 3, 2))},
+        },
+        dims={"obs": ["g", "h"]},
+    )
+    with pytest.raises(NotImplementedError, match="single observation dimension"):
+        loo_kfold(data=idata, wrapper=fresh_wrapper, k=2)


### PR DESCRIPTION
This makes `loo_kfold's` handling of user-provided folds more robust. Previously `_prepare_kfold_inputs` assumed the assignments were already labeled `1..k`, but the fold loop pulls test indices by iterating `range(1, k + 1)`, so any other labeling silently failed. 

Also relabels incoming folds to a contiguous `1..k` and validates with `_validate_k_value`, so arbitrary labelings work and a single fold value now raises a clear error. It also fixes `n_folds` to report the actual fold count instead of the `k` argument, and guards against multi-dimensional log-likelihoods that were previously flattened and split without aligning the fold arrays.