### PR TITLE
FEAT: enhance k-fold cross-validation with random seed and pointwise handling

### DIFF
--- a/src/arviz_stats/loo/helper_loo_kfold.py
+++ b/src/arviz_stats/loo/helper_loo_kfold.py
@@ -43,7 +43,7 @@ KfoldInputs = namedtuple(
 )
 
 
-def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_by):
+def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_by, seed=None):
     """Prepare inputs for k-fold cross-validation."""
     data = convert_to_datatree(data)
 
@@ -79,14 +79,16 @@ def _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_
         _, folds = np.unique(folds, return_inverse=True)
         folds = np.reshape(folds, -1) + 1
         k = _validate_k_value(len(np.unique(folds)), n_data_points)
-    elif stratify_by is not None:
-        stratify_by = _validate_array_length(stratify_by, n_data_points, "stratify_by")
-        folds = _kfold_split_stratified(k=k, x=stratify_by)
-    elif group_by is not None:
-        group_by = _validate_array_length(group_by, n_data_points, "group_by")
-        folds = _kfold_split_grouped(k=k, x=group_by)
     else:
-        folds = _kfold_split_random(k=k, n=n_data_points)
+        rng = np.random.default_rng(seed)
+        if stratify_by is not None:
+            stratify_by = _validate_array_length(stratify_by, n_data_points, "stratify_by")
+            folds = _kfold_split_stratified(k=k, x=stratify_by, rng=rng)
+        elif group_by is not None:
+            group_by = _validate_array_length(group_by, n_data_points, "group_by")
+            folds = _kfold_split_grouped(k=k, x=group_by, rng=rng)
+        else:
+            folds = _kfold_split_random(k=k, n=n_data_points, rng=rng)
 
     return KfoldInputs(
         log_likelihood=log_likelihood,
@@ -117,20 +119,30 @@ def _compute_kfold_results(kfold_inputs, wrapper, save_fits):
         idata_k = wrapper.get_inference_data(fitted_model)
         log_lik_k = wrapper.log_likelihood__i(test_data, idata_k)
 
-        if "chain" in log_lik_k.dims and "draw" in log_lik_k.dims:
-            sample_dims_k = ["chain", "draw"]
-        else:
-            sample_dims_k = [dim for dim in log_lik_k.dims if dim not in kfold_inputs.obs_dims]
+        n_test = len(test_idx)
+        obs_dim_k = next(
+            (
+                dim
+                for dim in reversed(log_lik_k.dims)
+                if dim not in kfold_inputs.sample_dims and log_lik_k.sizes[dim] == n_test
+            ),
+            None,
+        )
 
+        if obs_dim_k is None and n_test > 1:
+            raise ValueError(
+                f"The log likelihood returned by log_likelihood__i for fold {fold_num} has "
+                f"sizes {dict(log_lik_k.sizes)}. Expected a dimension other than "
+                f"{kfold_inputs.sample_dims} with size {n_test} "
+                "(one entry per test observation)."
+            )
+
+        sample_dims_k = [dim for dim in log_lik_k.dims if dim != obs_dim_k]
         n_samples_k = int(np.prod([log_lik_k.sizes[dim] for dim in sample_dims_k]))
         elpd_k = logsumexp(log_lik_k, dims=sample_dims_k, b=1 / n_samples_k)
-        elpd_values = elpd_k.values if hasattr(elpd_k, "values") else elpd_k
 
-        if np.isscalar(elpd_values):
-            elpd_unordered.append((test_idx[0], float(elpd_values)))
-        else:
-            for i, idx in enumerate(test_idx):
-                elpd_unordered.append((idx, float(elpd_values[i])))
+        for idx, value in zip(test_idx, np.atleast_1d(elpd_k.values), strict=True):
+            elpd_unordered.append((idx, float(value)))
 
         if save_fits:
             fold_results[fold_num] = {"fit": idata_k, "test_indices": test_idx}
@@ -160,7 +172,7 @@ def _compute_kfold_results(kfold_inputs, wrapper, save_fits):
     )
 
 
-def _kfold_split_random(k=10, n=None):
+def _kfold_split_random(k=10, n=None, rng=None):
     """Split the data into K groups of equal size (or roughly equal size)."""
     if n is None:
         raise ValueError("n must be provided")
@@ -179,12 +191,12 @@ def _kfold_split_random(k=10, n=None):
         folds[start:end] = i + 1
         start = end
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(rng)
     perm = rng.permutation(n)
     return folds[perm]
 
 
-def _kfold_split_stratified(k=10, x=None):
+def _kfold_split_stratified(k=10, x=None, rng=None):
     """Split observations into k groups ensuring relative category frequencies are preserved."""
     if x is None:
         raise ValueError("x must be provided")
@@ -200,7 +212,7 @@ def _kfold_split_stratified(k=10, x=None):
     n = len(x)
     xids = []
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(rng)
     for level in range(n_lev):
         idx = np.where(x_int == level)[0]
         if len(idx) > 1:
@@ -215,7 +227,7 @@ def _kfold_split_stratified(k=10, x=None):
     return bins
 
 
-def _kfold_split_grouped(k=10, x=None):
+def _kfold_split_grouped(k=10, x=None, rng=None):
     """Split observations ensuring all observations from the same group stay together."""
     if x is None:
         raise ValueError("x must be provided")
@@ -233,7 +245,7 @@ def _kfold_split_grouped(k=10, x=None):
     if n_levels == k:
         return level_of_obs
 
-    fold_of_level = _kfold_split_random(k=k, n=n_levels)
+    fold_of_level = _kfold_split_random(k=k, n=n_levels, rng=rng)
     return fold_of_level[level_of_obs - 1]
 
 

--- a/src/arviz_stats/loo/loo_kfold.py
+++ b/src/arviz_stats/loo/loo_kfold.py
@@ -21,6 +21,7 @@ def loo_kfold(
     stratify_by=None,
     group_by=None,
     save_fits=False,
+    seed=271,
 ):
     """Perform exact K-fold cross-validation.
 
@@ -63,6 +64,10 @@ def loo_kfold(
         `stratify_by`.
     save_fits : bool, default=False
         If True, store the fitted models and fold indices in the returned object.
+    seed : int, default=271
+        Seed for the random fold assignment used by the random, stratified and grouped
+        splitting strategies, making repeated calls reproducible. Pass ``None`` to draw
+        a different split on every call. Ignored when `folds` is provided explicitly.
 
     Returns
     -------
@@ -212,7 +217,9 @@ def loo_kfold(
     """
     pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
 
-    kfold_inputs = _prepare_kfold_inputs(data, var_name, wrapper, k, folds, stratify_by, group_by)
+    kfold_inputs = _prepare_kfold_inputs(
+        data, var_name, wrapper, k, folds, stratify_by, group_by, seed
+    )
     kfold_results = _compute_kfold_results(kfold_inputs, wrapper, save_fits)
 
     combined_results = _combine_fold_elpds([kfold_results.elpds], kfold_inputs.n_data_points)

--- a/src/arviz_stats/loo/wrapper.py
+++ b/src/arviz_stats/loo/wrapper.py
@@ -152,7 +152,10 @@ class SamplingWrapper:
         -------
         log_likelihood: xr.Dataarray
             Log likelihood of ``excluded_obs`` evaluated at each of the posterior samples
-            stored in ``idata__i``.
+            stored in ``idata__i``. When more than one observation is excluded, the returned
+            array must keep a dimension with one entry per excluded observation, in the same
+            order as the requested indices. All other dimensions (e.g. ``chain`` and ``draw``)
+            are treated as sample dimensions and reduced over.
         """
         if self.log_lik_fun is None:
             raise NotImplementedError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,6 +394,76 @@ def fresh_wrapper(mock_wrapper):
 
 
 @pytest.fixture
+def dim_style_wrapper(centered_eight):
+    from arviz_stats.loo.wrapper import SamplingWrapper
+
+    sp = importorskip("scipy")
+    xr = importorskip("xarray")
+    azb = importorskip("arviz_base")
+
+    class DimStyleWrapper(SamplingWrapper):
+        def __init__(self, idata, ll_style):
+            super().__init__(model=None, idata_orig=idata)
+            self.ll_style = ll_style
+            self.y_obs = idata.observed_data["obs"].values
+            self.sigma = np.array([15, 10, 16, 11, 9, 11, 10, 18])
+            self.rng = np.random.default_rng(42)
+
+        def sel_observations(self, idx):
+            all_indices = np.arange(len(self.y_obs))
+            train_indices = np.setdiff1d(all_indices, idx)
+            train_data = {
+                "y": self.y_obs[train_indices],
+                "sigma": self.sigma[train_indices],
+                "indices": train_indices,
+            }
+            test_data = {
+                "y": self.y_obs[idx],
+                "sigma": self.sigma[idx],
+                "indices": np.asarray(idx),
+            }
+            return train_data, test_data
+
+        def sample(self, modified_observed_data):
+            n_samples = 500
+            train_y = modified_observed_data["y"]
+            mu = self.rng.normal(np.mean(train_y), 5, n_samples)
+            tau = np.abs(self.rng.normal(10, 2, n_samples))
+            return {"mu": mu, "tau": tau}
+
+        def get_inference_data(self, fitted_model):
+            posterior = {
+                "mu": fitted_model["mu"].reshape(1, -1),
+                "tau": fitted_model["tau"].reshape(1, -1),
+            }
+            return azb.from_dict({"posterior": posterior})
+
+        def log_likelihood__i(self, excluded_obs, idata__i):
+            test_y = excluded_obs["y"]
+            test_sigma = excluded_obs["sigma"]
+            mu = idata__i.posterior["mu"].values.flatten()
+            tau = idata__i.posterior["tau"].values.flatten()
+            var_total = tau[:, np.newaxis] ** 2 + test_sigma**2
+            log_lik = sp.stats.norm.logpdf(test_y, loc=mu[:, np.newaxis], scale=np.sqrt(var_total))
+            if self.ll_style == "no_obs_dim":
+                return xr.DataArray(log_lik[:, 0][np.newaxis, :], dims=["chain", "draw"])
+            if self.ll_style == "flat_sample":
+                return xr.DataArray(log_lik, dims=["sample", "obs"])
+            if self.ll_style == "summed":
+                return xr.DataArray(log_lik.sum(axis=1)[np.newaxis, :], dims=["chain", "draw"])
+            return xr.DataArray(
+                log_lik.T[np.newaxis, :, :],
+                dims=["chain", "school", "draw"],
+                coords={"school": excluded_obs["indices"]},
+            )
+
+    def make(ll_style):
+        return DimStyleWrapper(centered_eight, ll_style)
+
+    return make
+
+
+@pytest.fixture
 def mock_wrapper_reloo(non_centered_eight):
     from arviz_stats.loo.wrapper import SamplingWrapper
 

--- a/tests/loo/test_helper_kfold.py
+++ b/tests/loo/test_helper_kfold.py
@@ -526,3 +526,17 @@ def test_kfold_split_grouped_balanced_fold_sizes(n_levels, k):
     group_folds = folds[unique_indices]
     _, fold_counts = np.unique(group_folds, return_counts=True)
     assert fold_counts.max() - fold_counts.min() <= 1
+
+
+@pytest.mark.parametrize(
+    "split_func,kwargs",
+    [
+        (_kfold_split_random, {"n": 20}),
+        (_kfold_split_stratified, {"x": np.tile([0, 1], 10)}),
+        (_kfold_split_grouped, {"x": np.repeat(np.arange(10), 2)}),
+    ],
+)
+def test_kfold_split_rng_reproducible(split_func, kwargs):
+    folds_1 = split_func(k=4, rng=np.random.default_rng(3), **kwargs)
+    folds_2 = split_func(k=4, rng=np.random.default_rng(3), **kwargs)
+    np.testing.assert_array_equal(folds_1, folds_2)

--- a/tests/loo/test_loo_kfold.py
+++ b/tests/loo/test_loo_kfold.py
@@ -301,3 +301,42 @@ def test_loo_kfold_multiple_obs_dims_raises(fresh_wrapper):
     )
     with pytest.raises(NotImplementedError, match="single observation dimension"):
         loo_kfold(data=idata, wrapper=fresh_wrapper, k=2)
+
+
+@pytest.mark.parametrize(
+    "ll_style,folds",
+    [
+        ("flat_sample", [1, 1, 2, 2, 3, 3, 4, 4]),
+        ("no_obs_dim", [1, 2, 3, 4, 5, 6, 7, 8]),
+    ],
+)
+def test_loo_kfold_wrapper_dim_styles_match_canonical(
+    centered_eight, dim_style_wrapper, ll_style, folds
+):
+    result = loo_kfold(
+        data=centered_eight, wrapper=dim_style_wrapper(ll_style), folds=folds, pointwise=True
+    )
+    reference = loo_kfold(
+        data=centered_eight, wrapper=dim_style_wrapper("canonical"), folds=folds, pointwise=True
+    )
+    assert np.all(np.isfinite(result.elpd_i.values))
+    assert_almost_equal(result.elpd_i.values, reference.elpd_i.values, decimal=8)
+    assert_almost_equal(result.elpd, reference.elpd, decimal=8)
+
+
+def test_loo_kfold_wrapper_reduced_loglik_raises(centered_eight, dim_style_wrapper):
+    with pytest.raises(ValueError, match="one entry per test observation"):
+        loo_kfold(data=centered_eight, wrapper=dim_style_wrapper("summed"), k=4)
+
+
+@pytest.mark.parametrize("seed", ["default", 7])
+def test_loo_kfold_seed_reproducible(centered_eight, dim_style_wrapper, seed):
+    kwargs = {} if seed == "default" else {"seed": seed}
+    result_1 = loo_kfold(
+        data=centered_eight, wrapper=dim_style_wrapper("canonical"), k=4, pointwise=True, **kwargs
+    )
+    result_2 = loo_kfold(
+        data=centered_eight, wrapper=dim_style_wrapper("canonical"), k=4, pointwise=True, **kwargs
+    )
+    assert_almost_equal(result_1.elpd, result_2.elpd, decimal=12)
+    assert_almost_equal(result_1.elpd_i.values, result_2.elpd_i.values, decimal=12)


### PR DESCRIPTION
This makes `loo_kfold` robust to the shape of the log likelihood returned by the wrapper, and makes fold assignment reproducible. 

Previously, a wrapper that returned its per-fold log likelihood without an observation dimension, or with a differently named one, had that dimension reduced away crashing with an `IndexError`. The observation dimension is now identified by size, with a clear `ValueError` when none matches. Additionally, `loo_kfold` now takes a seed argument.