### PR TITLE
doc: fix typos, grammar, and deprecated links in README and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This is mostly aimed at advanced users or libraries that want to use ArviZ to co
 The latest development version can be installed from the main branch using pip:
 
 ```
-pip install git+git://github.com/arviz-devs/arviz-stats.git
+pip install git+https://github.com/arviz-devs/arviz-stats.git
 ```
 
 Another option is to clone the repository and install using git and setuptools:

--- a/src/arviz_stats/sampling_diagnostics.py
+++ b/src/arviz_stats/sampling_diagnostics.py
@@ -356,7 +356,7 @@ def rhat_nested(
         Dictionary of dimension/index names to coordinate values defining a subset
         of the data for which to perform the computation.
     superchain_ids : list
-        Lisf ot length ``chains`` specifying which superchain each chain belongs to.
+        List of length ``chains`` specifying which superchain each chain belongs to.
         There should be equal numbers of chains in each superchain. All chains within
         the same superchain are assumed to have been initialized at the same point.
     chain_axis, draw_axis : int, optional
@@ -365,8 +365,8 @@ def rhat_nested(
 
     See Also
     --------
-    arviz.rhat : Calculate estimate of the effective sample size (ess).
-    arviz.ess : Calculate Markov Chain Standard Error statistic.
+    rhat : Compute split R-hat convergence diagnostic
+    ess : Estimate the effective sample size (ess).
     plot_forest : Forest plot to compare HDI intervals from a number of distributions.
 
     References
@@ -713,7 +713,7 @@ def diagnose(
 
     Examples
     --------
-    Get diagnostics printted to stdout:
+    Get diagnostics printed to stdout:
 
     .. ipython::
 
@@ -879,7 +879,7 @@ def diagnose(
     if bad_ess_params:
         has_errors = True
         messages.append(
-            f"The following parameters has fewer than {ess_min_ratio:.3f} effective draws per "
+            f"The following parameters have fewer than {ess_min_ratio:.3f} effective draws per "
             f"transition:\n  {', '.join(bad_ess_params)}\n"
             "Such low values indicate that the effective sample size estimators may be "
             "biased high and actual performance may be substantially lower than quoted."
@@ -905,7 +905,7 @@ def diagnose(
         if below_minimum_params:
             has_errors = True
             messages.append(
-                f"The following parameters has fewer than {ess_threshold} effective samples:\n"
+                f"The following parameters have fewer than {ess_threshold} effective samples:\n"
                 f"  {', '.join(below_minimum_params)}\n"
                 "This suggests that the sampler may not have fully explored the posterior "
                 "distribution for this parameter.\nConsider reparameterizing the model or "
@@ -950,7 +950,7 @@ def diagnose(
     if bad_rhat_params:
         has_errors = True
         messages.append(
-            f"The following parameters has R-hat values greater than {rhat_max:.2f}:\n"
+            f"The following parameters have R-hat values greater than {rhat_max:.2f}:\n"
             f"  {', '.join(bad_rhat_params)}\n"
             "Such high values indicate incomplete mixing and biased estimation.\n"
             "You should consider regularizing your model with additional prior information or "


### PR DESCRIPTION
### Description
This PR addresses and resolves multiple documentation discrepancies, typographical errors, and terminal console output grammatical mismatches across the repository to improve clarity and maintain accurate mathematical references.

### Changes Made
1. **`src/arviz_stats/sampling_diagnostics.py`**:
   * **Core Logic Fix**: Rectified the `See Also` references for `rhat_nested`. The previous docstring inaccurately claimed that `arviz.rhat` calculates the effective sample size (`ess`) and that `arviz.ess` calculates the Markov Chain Standard Error (`mcse`). Updated them to map to their mathematically correct local convergence diagnostic definitions (`rhat` and `ess`).
   * **Typo Corrections**: Fixed `Lisf ot length` to `List of length` in the `rhat_nested` parameters, and `printted` to `printed` in the `diagnose` function examples.
   * **Console Output Grammar**: Corrected subject-verb agreement mismatches (`parameters has` ➡️ `parameters have`) within the terminal warning strings printed to standard output during model convergence checks.

2. **`README.md`**:
   * Updated the deprecated `git://` protocol link to `https://` for cloning the repository, ensuring standard modern security practices for users installing the development build.

### Checklist
- [x] Code adheres to the project style guidelines.
- [x] Changes purely target documentation and terminal outputs; no public API architectural breakages.