### PR TITLE
Fix `bayesian_r2` silently using Bernoulli pseudo-variance when scale is omitted.

### DIFF
--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1537,6 +1537,13 @@ class _DiagnosticsBase(_CoreBase):
             if circular:
                 raise ValueError("scale must be provided for circular response.")
 
+            warnings.warn(
+                "`scale` not provided; assuming a Bernoulli-like model and using the Tjur "
+                "pseudo-variance mean(mu_pred * (1 - mu_pred)). For continuous models pass the "
+                "modelled residual `scale`.",
+                UserWarning,
+                stacklevel=2,
+            )
             # Bernoulli-like models: use Tjur’s pseudo-variance
             scale = np.mean(mu_pred * (1 - mu_pred), axis=1)
         else:
@@ -1555,7 +1562,14 @@ class _DiagnosticsBase(_CoreBase):
             return 1 - scale
 
         var_y_est = np.var(mu_pred, axis=1, ddof=1)
-        return var_y_est / (var_y_est + scale)
+        r2 = var_y_est / (var_y_est + scale)
+        if np.any((r2 < 0) | (r2 > 1)):
+            raise ValueError(
+                "Computed R² outside [0, 1]. This usually means the Bernoulli "
+                "pseudo-variance fallback was applied to a non-probability `mu_pred`; "
+                "pass the modelled residual `scale` for continuous models."
+            )
+        return r2
 
     @staticmethod
     def _residual_r2(y_obs, mu_pred, circular):

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1566,9 +1566,10 @@ class _DiagnosticsBase(_CoreBase):
         r2 = var_y_est / (var_y_est + scale)
         if np.any((r2 < 0) | (r2 > 1)):
             raise ValueError(
-                "Computed R² outside [0, 1]. This usually means the Bernoulli "
-                "pseudo-variance fallback was applied to a non-probability `mu_pred`; "
-                "pass the modelled residual `scale` for continuous models."
+                "Computed R-squared outside [0, 1]. The Bernoulli pseudo-variance "
+                "`mean(mu_pred * (1 - mu_pred))` was used because `scale` was not provided, "
+                "but `mu_pred` are not probabilities in [0, 1]. Pass the modelled residual "
+                "`scale` for continuous models."
             )
         return r2
 

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1538,9 +1538,10 @@ class _DiagnosticsBase(_CoreBase):
                 raise ValueError("scale must be provided for circular response.")
 
             warnings.warn(
-                "`scale` not provided; assuming a Bernoulli-like model and using the Tjur "
-                "pseudo-variance mean(mu_pred * (1 - mu_pred)). For continuous models pass the "
-                "modelled residual `scale`.",
+                "`scale` was not provided, so a Bernoulli/binary model is assumed and the "
+                "pseudo-variance `mean(mu_pred * (1 - mu_pred))` is used as the residual "
+                "variance. This is only valid when `mu_pred` are probabilities in [0, 1]. "
+                "For continuous (e.g. Gaussian) models, pass the modelled residual `scale`.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/arviz_stats/metrics.py
+++ b/src/arviz_stats/metrics.py
@@ -107,9 +107,11 @@ def bayesian_r2(
 
     Examples
     --------
-    Calculate Bayesian :math:`R^2` for logistic regression:
+    Calculate Bayesian :math:`R^2` for logistic regression. ``scale`` is omitted, so the
+    Bernoulli pseudo-variance is used and a warning is emitted (expected here):
 
     .. ipython::
+        :okwarning:
 
         In [1]: from arviz_stats import bayesian_r2
            ...: from arviz_base import load_arviz_data

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -100,7 +100,6 @@ def test_residual_r2_invalid_shapes():
 
 
 def test_bayesian_r2_no_scale_warns():
-    # Bernoulli-appropriate mu_pred in [0, 1], scale omitted -> Tjur fallback + warning.
     rng = np.random.default_rng(0)
     mu_pred = rng.uniform(0.1, 0.9, size=(200, 40))
     with pytest.warns(UserWarning, match="Bernoulli"):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -107,6 +107,7 @@ def test_bayesian_r2_no_scale_warns():
     assert np.all((r2 >= 0) & (r2 <= 1))
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_bayesian_r2_continuous_no_scale_errors():
     rng = np.random.default_rng(0)
     mu_pred = rng.normal(0.0, 0.05, size=(200, 40))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -108,8 +108,6 @@ def test_bayesian_r2_no_scale_warns():
 
 
 def test_bayesian_r2_continuous_no_scale_errors():
-    # Continuous mu_pred (real-valued), scale omitted -> Bernoulli fallback yields R² outside
-    # [0, 1], which must raise instead of returning silently.
     rng = np.random.default_rng(0)
     mu_pred = rng.normal(0.0, 0.05, size=(200, 40))
     with pytest.raises(ValueError, match=r"outside \[0, 1\]"):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -99,6 +99,24 @@ def test_residual_r2_invalid_shapes():
         array_stats.residual_r2(y_true, y_pred)
 
 
+def test_bayesian_r2_no_scale_warns():
+    # Bernoulli-appropriate mu_pred in [0, 1], scale omitted -> Tjur fallback + warning.
+    rng = np.random.default_rng(0)
+    mu_pred = rng.uniform(0.1, 0.9, size=(200, 40))
+    with pytest.warns(UserWarning, match="Bernoulli"):
+        r2 = array_stats.bayesian_r2(mu_pred)
+    assert np.all((r2 >= 0) & (r2 <= 1))
+
+
+def test_bayesian_r2_continuous_no_scale_errors():
+    # Continuous mu_pred (real-valued), scale omitted -> Bernoulli fallback yields R² outside
+    # [0, 1], which must raise instead of returning silently.
+    rng = np.random.default_rng(0)
+    mu_pred = rng.normal(0.0, 0.05, size=(200, 40))
+    with pytest.raises(ValueError, match=r"outside \[0, 1\]"):
+        array_stats.bayesian_r2(mu_pred)
+
+
 def test_bayesian_r2_summary(datatree_regression):
     result = bayesian_r2(datatree_regression, pred_mean="mu", scale="sigma")
     assert isinstance(result, tuple)


### PR DESCRIPTION
Closes https://github.com/arviz-devs/arviz-stats/issues/388 


## Changes

- `_bayesian_r2` now emits a `UserWarning` whenever the Bernoulli pseudo-variance fallback is
  used (i.e. `scale` is not provided), pointing the user to pass the modelled residual `scale`
  for continuous models.
- The computed R² is range-checked; if any value falls outside [0, 1] a `ValueError` is raised.
  With a valid `scale >= 0` the ratio is mathematically always in [0, 1], so this only fires on
  the misused Bernoulli fallback and does not affect correct callers.
- Added two tests in `tests/test_metrics.py`: one asserting the warning (and result in [0, 1])
  for probability-valued `mu_pred`, one asserting the error for the continuous reproducer from
  the issue.

After this PR the same call raises `ValueError` `(scale omitted for a continuous model)`, and a
genuine Bernoulli use (probabilities in [0, 1], scale omitted) warns instead of failing.