### PR TITLE
Make pred_mean and scale required in bayesian_r2

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -849,7 +849,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             **kwargs,
         )
 
-    def bayesian_r2(self, mu_pred, scale=None, scale_kind="sd", circular=False):
+    def bayesian_r2(self, mu_pred, scale, scale_kind="sd", circular=False):
         """Compute Bayesian R² for regression models."""
         r2_ufunc = make_ufunc(
             self._bayesian_r2,

--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1537,15 +1537,6 @@ class _DiagnosticsBase(_CoreBase):
             if circular:
                 raise ValueError("scale must be provided for circular response.")
 
-            warnings.warn(
-                "`scale` was not provided, so a Bernoulli/binary model is assumed and the "
-                "pseudo-variance `mean(mu_pred * (1 - mu_pred))` is used as the residual "
-                "variance. This is only valid when `mu_pred` are probabilities in [0, 1]. "
-                "For continuous (e.g. Gaussian) models, pass the modelled residual `scale`.",
-                UserWarning,
-                stacklevel=2,
-            )
-            # Bernoulli-like models: use Tjur’s pseudo-variance
             scale = np.mean(mu_pred * (1 - mu_pred), axis=1)
         else:
             if scale_kind not in ("sd", "var"):
@@ -1567,9 +1558,9 @@ class _DiagnosticsBase(_CoreBase):
         if np.any((r2 < 0) | (r2 > 1)):
             raise ValueError(
                 "Computed R-squared outside [0, 1]. The Bernoulli pseudo-variance "
-                "`mean(mu_pred * (1 - mu_pred))` was used because `scale` was not provided, "
-                "but `mu_pred` are not probabilities in [0, 1]. Pass the modelled residual "
-                "`scale` for continuous models."
+                "`mean(mu_pred * (1 - mu_pred))` was used because `scale=None`, but `mu_pred` "
+                "are not probabilities in [0, 1]. Pass the modelled residual `scale` for "
+                "continuous models."
             )
         return r2
 

--- a/src/arviz_stats/metrics.py
+++ b/src/arviz_stats/metrics.py
@@ -13,8 +13,8 @@ from arviz_stats.base.stats_utils import round_num
 
 def bayesian_r2(
     data,
-    pred_mean=None,
-    scale=None,
+    pred_mean,
+    scale,
     scale_kind="sd",
     summary=True,
     group="posterior",
@@ -57,10 +57,10 @@ def bayesian_r2(
         Input data. It should contain the posterior and posterior_predictive groups.
     pred_mean : str
         Name of the variable representing the predicted mean.
-    scale : str, optional
+    scale : str or None
         Name of the variable representing the modeled variance (or pseudo-variance).
-        It can be omitted for binary classification problems, in which case the pseudo-variance
-        is computed internally.
+        Pass ``None`` explicitly for binary classification problems, in which case the
+        Bernoulli pseudo-variance is computed internally. This argument is required.
     scale_kind : str
         Whether the variable referenced by `scale` is a standard deviation ("sd")
         or variance ("var"). Defaults to "sd".
@@ -107,16 +107,15 @@ def bayesian_r2(
 
     Examples
     --------
-    Calculate Bayesian :math:`R^2` for logistic regression. ``scale`` is omitted, so the
-    Bernoulli pseudo-variance is used and a warning is emitted (expected here):
+    Calculate Bayesian :math:`R^2` for logistic regression. Pass ``scale=None`` to use the
+    Bernoulli pseudo-variance:
 
     .. ipython::
-        :okwarning:
 
         In [1]: from arviz_stats import bayesian_r2
            ...: from arviz_base import load_arviz_data
            ...: data = load_arviz_data('anes')
-           ...: bayesian_r2(data, pred_mean="p")
+           ...: bayesian_r2(data, pred_mean="p", scale=None)
 
     Calculate Bayesian :math:`R^2` for circular regression. The posterior has
     the concentration parameter ``kappa`` (from the VonMises distribution).

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -99,20 +99,18 @@ def test_residual_r2_invalid_shapes():
         array_stats.residual_r2(y_true, y_pred)
 
 
-def test_bayesian_r2_no_scale_warns():
+def test_bayesian_r2_binary_scale_none():
     rng = np.random.default_rng(0)
     mu_pred = rng.uniform(0.1, 0.9, size=(200, 40))
-    with pytest.warns(UserWarning, match="Bernoulli"):
-        r2 = array_stats.bayesian_r2(mu_pred)
+    r2 = array_stats.bayesian_r2(mu_pred, None)
     assert np.all((r2 >= 0) & (r2 <= 1))
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_bayesian_r2_continuous_no_scale_errors():
+def test_bayesian_r2_continuous_scale_none_errors():
     rng = np.random.default_rng(0)
     mu_pred = rng.normal(0.0, 0.05, size=(200, 40))
     with pytest.raises(ValueError, match=r"outside \[0, 1\]"):
-        array_stats.bayesian_r2(mu_pred)
+        array_stats.bayesian_r2(mu_pred, None)
 
 
 def test_bayesian_r2_summary(datatree_regression):


### PR DESCRIPTION
## Description

Follow-up to #389. That PR emitted a `UserWarning` when `scale` was omitted in `bayesian_r2`
(silently taking the Bernoulli pseudo-variance path). Review feedback noted that `scale=None`
meaning "binary/Bernoulli model" is valid and documented, so warning on it is undesirable. The
actual problem is that `scale` *defaults* to `None`, so a user who has not read the docstring
gets the binary path (and wrong results) for a continuous model without asking for it.

This implements the proposed option: make `pred_mean` and `scale` **required** parameters. The
binary path becomes opt-in via an explicit `scale=None`.

Also drops the `scale=None` default on the array-level `array_stats.bayesian_r2` `(src/arviz_stats/base/array.py)` so scale is required there too, keeping the lower-level API consistent with the public function.


Closes https://github.com/arviz-devs/arviz-stats/issues/390