### PR TITLE
Fix reloo k threshold

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -128,18 +128,11 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             func_kwargs.update(kwargs)
         else:
             extra_kwargs = list(kwargs.keys())
-            if "hdi_prob" in kwargs:
-                raise TypeError(
-                    "hdi got an unexpected keyword argument: 'hdi_prob'. "
-                    "The 'hdi_prob' argument was renamed to 'prob' in arviz-stats 1.0. "
-                    "Use 'prob' instead (e.g. prob=0.95). "
-                    "See the migration guide: "
-                    "https://python.arviz.org/en/stable/user_guide/migration_guide.html"
-                )
             if len(extra_kwargs) == 1:
                 raise TypeError(f"hdi got an unexpected keyword argument: '{extra_kwargs[0]}'")
             if len(extra_kwargs) > 1:
                 raise TypeError(f"hdi got unexpected keyword arguments: {extra_kwargs}")
+
         if method == "multimodal_sample":
             func_kwargs["from_sample"] = True
 

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -128,11 +128,18 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             func_kwargs.update(kwargs)
         else:
             extra_kwargs = list(kwargs.keys())
+            if "hdi_prob" in kwargs:
+                raise TypeError(
+                    "hdi got an unexpected keyword argument: 'hdi_prob'. "
+                    "The 'hdi_prob' argument was renamed to 'prob' in arviz-stats 1.0. "
+                    "Use 'prob' instead (e.g. prob=0.95). "
+                    "See the migration guide: "
+                    "https://python.arviz.org/en/stable/user_guide/migration_guide.html"
+                )
             if len(extra_kwargs) == 1:
                 raise TypeError(f"hdi got an unexpected keyword argument: '{extra_kwargs[0]}'")
             if len(extra_kwargs) > 1:
                 raise TypeError(f"hdi got unexpected keyword arguments: {extra_kwargs}")
-
         if method == "multimodal_sample":
             func_kwargs["from_sample"] = True
 

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -98,8 +98,8 @@ def reloo(
     confirm that the number of values above the threshold is small enough. Otherwise,
     prohibitive computation time may be needed to perform all required refits.
 
-    As an extreme case, artificially assigning all ``pareto_k`` values to something
-    larger than the threshold would make ``reloo`` perform the whole exact LOO-CV.
+    As an extreme case, setting ``k_threshold=-np.inf`` will flag every observation and
+    make ``reloo`` perform the whole exact LOO-CV, requiring one refit per observation.
     This is not generally recommended nor intended, however, if needed, this function can
     be used to achieve the result.
 

--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -20,7 +20,7 @@ def reloo(
     loo_orig=None,
     var_name=None,
     log_weights=None,
-    k_threshold=-np.inf,
+    k_threshold=None,
     pointwise=None,
 ):
     r"""Recalculate exact Leave-One-Out cross validation refitting where the approximation fails.


### PR DESCRIPTION
Fixes #398

**What changed:**
Changed the default value of `k_threshold` from `-np.inf` to `None` in `reloo.py` to match the documentation, as requested in the issue.