### PR TITLE
Fix NaN in `loo_score` CRPS and simplify score calculations

### DIFF
--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -492,12 +492,11 @@ class _DiagnosticsBase(_CoreBase):
         y_obs = np.asarray(y_obs).flat[0]
         abs_error = np.abs(ary - y_obs)
 
-        log_den = logsumexp(log_weights)
-        loo_weighted_abs_error = np.exp(logsumexp(log_weights, b=abs_error) - log_den)
-        loo_weighted_mean_prediction = np.exp(logsumexp(log_weights, b=ary) - log_den)
-
         weights = np.exp(log_weights - log_weights.max())
         weights /= np.sum(weights)
+
+        loo_weighted_abs_error = np.sum(weights * abs_error)
+        loo_weighted_mean_prediction = np.sum(weights * ary)
 
         idx = np.argsort(ary, kind="mergesort")
         values_sorted = ary[idx]

--- a/src/arviz_stats/loo/loo_score.py
+++ b/src/arviz_stats/loo/loo_score.py
@@ -23,38 +23,47 @@ def loo_score(
     log_weights=None,
     pareto_k=None,
 ):
-    r"""Compute PWM-based CRPS/SCRPS with PSIS-LOO-CV weights.
+    r"""Compute CRPS or SCRPS with PSIS-LOO-CV weights.
 
-    Implements the probability-weighted-moment (PWM) identity for the continuous ranked
-    probability score (CRPS) with Pareto-smoothed importance sampling leave-one-out (PSIS-LOO-CV)
-    weights, but returns its negative as a maximization score (larger is better). This assumes
-    that the PSIS-LOO-CV approximation is working well.
+    Computes the continuous ranked probability score (CRPS) or its scale-invariant variant
+    (SCRPS) using Pareto-smoothed importance sampling leave-one-out (PSIS-LOO-CV) weights, and
+    returns its negative as a maximization score (larger is better). This assumes that the
+    PSIS-LOO-CV approximation is working well.
 
-    Specifically, the PWM identity used here is
+    Writing :math:`E_{\text{loo}}` for the PSIS-LOO-CV weighted expectation over
+    posterior-predictive draws :math:`X` (with :math:`X'` an independent copy), the CRPS is
 
     .. math::
 
         \operatorname{CRPS}_{\text{loo}}(F, y)
         = E_{\text{loo}}\left[|X - y|\right]
-        + E_{\text{loo}}[X]
-        - 2\cdot E_{\text{loo}} \left[X\,F_{\text{mid}}(X) \right],
+        - \frac{1}{2}\, E_{\text{loo}}\left[|X - X'|\right],
 
-    where :math:`F_{\text{mid}}` is the midpoint CDF estimator defined as
-    :math:`F_{\text{mid}}(x_{(i)}) := F^-_{(i)} + w_{(i)}/2`. This midpoint formulation
-    provides improved accuracy for weighted samples compared to the left-continuous CDF.
+    and the SCRPS is
 
-    The PWM identity is described in [3]_, traditional CRPS and SCRPS are described in
-    [1]_ and [2]_, and the PSIS-LOO-CV method is described in [4]_ and [5]_.
+    .. math::
+
+        S_{\text{SCRPS}}(F, y)
+        = -\frac{E_{\text{loo}}\left[|X - y|\right]}{E_{\text{loo}}\left[|X - X'|\right]}
+        - \frac{1}{2}\log E_{\text{loo}}\left[|X - X'|\right].
+
+    Both are evaluated with the probability-weighted-moment (PWM) estimator of [3]_, which
+    computes them exactly in :math:`\mathcal{O}(S \log S)` from a single set of draws.
+    Traditional CRPS and SCRPS are described in [1]_ and [2]_, and the PSIS-LOO-CV method in
+    [4]_ and [5]_.
 
     Parameters
     ----------
     data : DataTree or InferenceData
         Input data. It should contain the ``posterior_predictive``, ``observed_data`` and
-        ``log_likelihood`` groups.
+        ``log_likelihood`` groups. A ``posterior`` group is also required when
+        ``log_weights`` and ``pareto_k`` are not provided, as it is used to compute the
+        relative efficiency of the importance sampling estimate.
     var_name : str, optional
-        The name of the variable in the log_likelihood group to use. If None, the first
-        variable in ``observed_data`` is used and assumed to match ``log_likelihood`` and
-        ``posterior_predictive`` names.
+        The name of the variable in the log_likelihood group to use. If None, the only
+        variable in the ``log_likelihood`` group is used (an error is raised if there are
+        several) and assumed to match the ``observed_data`` and ``posterior_predictive``
+        names.
     kind : str, default "crps"
         The kind of score to compute. Available options are:
 
@@ -64,8 +73,8 @@ def loo_score(
         If True, include per-observation score values in the return object.
     round_to : int or str, optional
         If integer, number of decimal places to round the result. If string of the
-        form '2g' number of significant digits to round the result. Defaults to '2g'.
-        Use None to return raw numbers.
+        form '2g' number of significant digits to round the result. Defaults to None,
+        which returns raw numbers.
     log_weights : DataArray, optional
         Pre-computed smoothed log weights from PSIS. Must be provided together with pareto_k.
         If not provided, PSIS will be computed internally.
@@ -96,66 +105,6 @@ def loo_score(
 
         In [2]: loo_score(dt, kind="scrps")
 
-    Notes
-    -----
-    For a single observation with posterior-predictive draws :math:`x_1, \ldots, x_S`
-    and PSIS-LOO-CV weights :math:`w_i \propto \exp(\ell_i)` normalized so that
-    :math:`\sum_{i=1}^S w_i = 1`, define the PSIS-LOO-CV expectation as
-
-    .. math::
-
-        E_{\text{loo}}[g(X)] := \sum_{i=1}^S w_i\, g(x_i).
-
-    For weighted samples, we use the midpoint CDF estimator rather than the left-continuous CDF.
-    Given sorted values :math:`x_{(1)} \leq \cdots \leq x_{(S)}` with corresponding weights
-    :math:`w_{(i)}`, define the left-cumulative weight :math:`F^-_{(i)} = \sum_{j<i} w_{(j)}`
-    and the midpoint CDF as
-
-    .. math::
-
-        F_{\text{mid}}(x_{(i)}) := F^-_{(i)} + \frac{w_{(i)}}{2}.
-
-    The first probability-weighted moment using the midpoint CDF is
-    :math:`b_1 := \sum_{i=1}^S w_{(i)}\, x_{(i)}\, F_{\text{mid}}(x_{(i)})`.
-    With this, the nonnegative CRPS under PSIS-LOO-CV is
-
-    .. math::
-
-        \operatorname{CRPS}_{\text{loo}}(F, y)
-        = E_{\text{loo}}\left[\,|X-y|\,\right]
-        + E_{\text{loo}}[X] - 2\,b_1.
-
-    For the scale term for the SCRPS, we use the PSIS-LOO-CV weighted Gini mean difference given by
-    :math:`\Delta_{\text{loo}} := E_{\text{loo}}\left[\,|X - X'|\,\right]`.
-    This admits the PWM representation given by
-
-    .. math::
-
-        \Delta_{\text{loo}} =
-        2\,E_{\text{loo}}\left[\,X\,\left(2F_{\text{loo}}(X') - 1\right)\,\right].
-
-    A finite-sample weighted order-statistic version of this is used in the function and is given by
-
-    .. math::
-
-        \Delta_{\text{loo}} =
-        2 \sum_{i=1}^S w_{(i)}\, x_{(i)} \left\{\,2 F^-_{(i)} + w_{(i)} - 1\,\right\},
-
-    where :math:`x_{(i)}` are the values sorted increasingly, :math:`w_{(i)}` are the
-    corresponding normalized weights, and :math:`F^-_{(i)} = \sum_{j<i} w_{(j)}`.
-
-    The locally scale-invariant score returned for ``kind="scrps"`` is
-
-    .. math::
-
-        S_{\text{SCRPS}}(F, y)
-        = -\frac{E_{\text{loo}}\left[\,|X-y|\,\right]}{\Delta_{\text{loo}}}
-        - \frac{1}{2}\log \Delta_{\text{loo}}.
-
-    When PSIS weights are highly variable (large Pareto :math:`k`), Monte-Carlo noise can
-    increase. This function surfaces PSIS-LOO-CV diagnostics via ``pareto_k`` and warns when
-    tail behavior suggests unreliability.
-
     References
     ----------
 
@@ -178,6 +127,8 @@ def loo_score(
     """
     if kind not in {"crps", "scrps"}:
         raise ValueError(f"kind must be either 'crps' or 'scrps'. Got {kind}")
+    if (log_weights is None) != (pareto_k is None):
+        raise ValueError("log_weights and pareto_k must be provided together.")
 
     data = convert_to_datatree(data)
 
@@ -187,7 +138,6 @@ def loo_score(
     n_samples = loo_inputs.n_samples
     sample_dims = loo_inputs.sample_dims
     obs_dims = loo_inputs.obs_dims
-    r_eff = _get_r_eff(data, n_samples)
 
     y_pred = extract(
         data,
@@ -200,16 +150,16 @@ def loo_score(
 
     _validate_crps_input(y_pred, y_obs, log_likelihood, sample_dims=sample_dims, obs_dims=obs_dims)
 
-    if log_weights is not None and pareto_k is not None:
+    if log_weights is not None:
         pointwise_scores, pareto_k_out = y_pred.azstats.loo_score(
             y_obs=y_obs,
             log_weights=log_weights,
             pareto_k=pareto_k,
             kind=kind,
-            r_eff=r_eff,
             sample_dims=sample_dims,
         )
     else:
+        r_eff = _get_r_eff(data, n_samples)
         log_ratios = -log_likelihood
         pointwise_scores, pareto_k_out = y_pred.azstats.loo_score(
             y_obs=y_obs, log_ratios=log_ratios, kind=kind, r_eff=r_eff, sample_dims=sample_dims

--- a/src/arviz_stats/loo/loo_score.py
+++ b/src/arviz_stats/loo/loo_score.py
@@ -26,31 +26,10 @@ def loo_score(
     r"""Compute CRPS or SCRPS with PSIS-LOO-CV weights.
 
     Computes the continuous ranked probability score (CRPS) or its scale-invariant variant
-    (SCRPS) using Pareto-smoothed importance sampling leave-one-out (PSIS-LOO-CV) weights, and
-    returns its negative as a maximization score (larger is better). This assumes that the
-    PSIS-LOO-CV approximation is working well.
-
-    Writing :math:`E_{\text{loo}}` for the PSIS-LOO-CV weighted expectation over
-    posterior-predictive draws :math:`X` (with :math:`X'` an independent copy), the CRPS is
-
-    .. math::
-
-        \operatorname{CRPS}_{\text{loo}}(F, y)
-        = E_{\text{loo}}\left[|X - y|\right]
-        - \frac{1}{2}\, E_{\text{loo}}\left[|X - X'|\right],
-
-    and the SCRPS is
-
-    .. math::
-
-        S_{\text{SCRPS}}(F, y)
-        = -\frac{E_{\text{loo}}\left[|X - y|\right]}{E_{\text{loo}}\left[|X - X'|\right]}
-        - \frac{1}{2}\log E_{\text{loo}}\left[|X - X'|\right].
-
-    Both are evaluated with the probability-weighted-moment (PWM) estimator of [3]_, which
-    computes them exactly in :math:`\mathcal{O}(S \log S)` from a single set of draws.
-    Traditional CRPS and SCRPS are described in [1]_ and [2]_, and the PSIS-LOO-CV method in
-    [4]_ and [5]_.
+    (SCRPS) using Pareto-smoothed importance sampling leave-one-out (PSIS-LOO-CV) weights.
+    Both are returned as maximization scores where larger is better. The CRPS is negated
+    to match this convention, which the SCRPS already satisfies by definition. This assumes
+    that the PSIS-LOO-CV approximation is working well.
 
     Parameters
     ----------

--- a/tests/loo/test_loo_score.py
+++ b/tests/loo/test_loo_score.py
@@ -1,17 +1,29 @@
 """Test score functions for PSIS-LOO-CV."""
 
-# pylint: disable=redefined-outer-name, unused-argument
+# pylint: disable=redefined-outer-name, unused-argument, protected-access
 import pytest
 
 from ..helpers import importorskip
 
 np = importorskip("numpy")
 azb = importorskip("arviz_base")
+xr = importorskip("xarray")
 
 from numpy.testing import assert_almost_equal
 
 from arviz_stats import loo_score
+from arviz_stats.base import array_stats
 from arviz_stats.loo.loo_helper import _get_r_eff, _prepare_loo_inputs
+
+
+def _brute_force_score(values, log_weights, y_obs, kind):
+    weights = np.exp(log_weights - log_weights.max())
+    weights /= weights.sum()
+    e_abs = np.sum(weights * np.abs(values - y_obs))
+    delta = np.sum(weights[:, None] * weights[None, :] * np.abs(values[:, None] - values[None, :]))
+    if kind == "crps":
+        return -(e_abs - 0.5 * delta)
+    return -e_abs / delta - 0.5 * np.log(delta)
 
 
 def test_loo_score_invalid_kind(centered_eight):
@@ -184,3 +196,147 @@ def test_loo_score_precomputed_weights(centered_eight, kind):
         result_precomputed.pointwise.values, result_auto.pointwise.values, decimal=10
     )
     assert_almost_equal(result_precomputed.pareto_k.values, result_auto.pareto_k.values, decimal=10)
+
+
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+@pytest.mark.parametrize("center", [-100.0, -5.0, 0.0, 5.0])
+def test_loo_score_kernel_matches_brute_force(kind, center):
+    rng = np.random.default_rng(42)
+    values = rng.normal(center, 2.0, size=500)
+    log_weights = rng.normal(0, 1.5, size=500)
+    y_obs = center + 0.5
+
+    result = array_stats._loo_score(values, y_obs, log_weights, kind)
+    expected = _brute_force_score(values, log_weights, y_obs, kind)
+
+    assert_almost_equal(result, expected, decimal=12)
+
+
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_kernel_discrete_ties(kind):
+    rng = np.random.default_rng(42)
+    values = rng.poisson(3, size=400).astype(float)
+    log_weights = rng.normal(0, 1.0, size=400)
+
+    result = array_stats._loo_score(values, 2.0, log_weights, kind)
+    expected = _brute_force_score(values, log_weights, 2.0, kind)
+
+    assert_almost_equal(result, expected, decimal=12)
+
+
+def test_loo_score_kernel_small_samples():
+    result = array_stats._loo_score(np.array([2.0]), 3.0, np.array([0.0]), "crps")
+    assert_almost_equal(result, -1.0, decimal=14)
+
+    values = np.array([1.0, 3.0])
+    log_weights = np.zeros(2)
+    result = array_stats._loo_score(values, 2.0, log_weights, "crps")
+    expected = _brute_force_score(values, log_weights, 2.0, "crps")
+    assert_almost_equal(result, expected, decimal=14)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_shift_invariance(kind):
+    rng = np.random.default_rng(42)
+    mu = rng.normal(size=(2, 50))
+    y_pred = rng.normal(size=(2, 50, 5))
+    log_lik = rng.normal(size=(2, 50, 5))
+    y = rng.normal(size=5)
+    shift = -50.0
+
+    dt = azb.from_dict(
+        {
+            "posterior": {"mu": mu},
+            "posterior_predictive": {"y": y_pred},
+            "log_likelihood": {"y": log_lik},
+            "observed_data": {"y": y},
+        }
+    )
+    dt_shifted = azb.from_dict(
+        {
+            "posterior": {"mu": mu},
+            "posterior_predictive": {"y": y_pred + shift},
+            "log_likelihood": {"y": log_lik},
+            "observed_data": {"y": y + shift},
+        }
+    )
+
+    result = loo_score(dt, kind=kind, pointwise=True)
+    result_shifted = loo_score(dt_shifted, kind=kind, pointwise=True)
+
+    assert np.all(np.isfinite(result.pointwise.values))
+    assert_almost_equal(result_shifted.pointwise.values, result.pointwise.values, decimal=10)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_negative_data(kind):
+    rng = np.random.default_rng(42)
+    mu = rng.normal(-5, 0.1, size=(4, 100))
+    y = rng.normal(-5, 1, size=6)
+    y_pred = rng.normal(mu[..., None], 1.0, size=(4, 100, 6))
+    log_lik = -0.5 * (y[None, None, :] - mu[..., None]) ** 2 - 0.5 * np.log(2 * np.pi)
+
+    dt = azb.from_dict(
+        {
+            "posterior": {"mu": mu},
+            "posterior_predictive": {"y": y_pred},
+            "log_likelihood": {"y": log_lik},
+            "observed_data": {"y": y},
+        }
+    )
+
+    result = loo_score(dt, kind=kind, pointwise=True)
+
+    assert np.isfinite(result.mean)
+    assert np.isfinite(result.se)
+    assert np.all(np.isfinite(result.pointwise.values))
+    if kind == "crps":
+        assert np.all(result.pointwise.values <= 0)
+
+
+def test_loo_score_lone_precomputed_arg_raises(centered_eight):
+    loo_inputs = _prepare_loo_inputs(centered_eight, None)
+    log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
+        dim=["chain", "draw"],
+        r_eff=_get_r_eff(centered_eight, loo_inputs.n_samples),
+    )
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        loo_score(centered_eight, log_weights=log_weights)
+    with pytest.raises(ValueError, match="must be provided together"):
+        loo_score(centered_eight, pareto_k=pareto_k)
+
+
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_precomputed_weights_used(centered_eight, kind):
+    result_auto = loo_score(centered_eight, kind=kind, pointwise=True)
+
+    uniform_log_weights = xr.zeros_like(centered_eight.log_likelihood["obs"])
+    flat_pareto_k = xr.zeros_like(centered_eight.observed_data["obs"])
+    result_uniform = loo_score(
+        centered_eight,
+        kind=kind,
+        pointwise=True,
+        log_weights=uniform_log_weights,
+        pareto_k=flat_pareto_k,
+    )
+
+    assert not np.allclose(result_uniform.pointwise.values, result_auto.pointwise.values)
+
+
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_precomputed_no_posterior(centered_eight, kind):
+    loo_inputs = _prepare_loo_inputs(centered_eight, None)
+    log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
+        dim=["chain", "draw"],
+        r_eff=_get_r_eff(centered_eight, loo_inputs.n_samples),
+    )
+    dt_no_posterior = centered_eight.drop_nodes("posterior")
+
+    result = loo_score(dt_no_posterior, kind=kind, log_weights=log_weights, pareto_k=pareto_k)
+    result_full = loo_score(centered_eight, kind=kind, log_weights=log_weights, pareto_k=pareto_k)
+
+    assert_almost_equal(result.mean, result_full.mean, decimal=10)
+    assert_almost_equal(result.se, result_full.se, decimal=10)

--- a/tests/loo/test_loo_score.py
+++ b/tests/loo/test_loo_score.py
@@ -13,6 +13,7 @@ from numpy.testing import assert_almost_equal
 
 from arviz_stats import loo_score
 from arviz_stats.base import array_stats
+from arviz_stats.base.stats_utils import round_num
 from arviz_stats.loo.loo_helper import _get_r_eff, _prepare_loo_inputs
 
 
@@ -36,21 +37,6 @@ def test_loo_score_invalid_var_name(centered_eight):
         loo_score(centered_eight, var_name="nonexistent")
 
 
-@pytest.mark.parametrize("kind", ["crps", "scrps"])
-def test_loo_score_basic(centered_eight, kind):
-    result = loo_score(centered_eight, kind=kind)
-
-    assert hasattr(result, "mean")
-    assert hasattr(result, "se")
-    assert np.isfinite(result.mean)
-    assert np.isfinite(result.se)
-    assert result.se >= 0
-
-    if kind == "crps":
-        assert result.mean <= 0
-
-
-@pytest.mark.parametrize("kind", ["crps", "scrps"])
 @pytest.mark.parametrize(
     "scenario, pattern",
     [
@@ -59,7 +45,7 @@ def test_loo_score_basic(centered_eight, kind):
         ("loglik_sample_dim_mismatch", "Size mismatch in sample dimension 'draw'"),
     ],
 )
-def test_loo_score_validation_errors(centered_eight, kind, scenario, pattern):
+def test_loo_score_validation_errors(centered_eight, scenario, pattern):
     broken = centered_eight.copy()
 
     if scenario == "missing_sample_dim":
@@ -70,42 +56,36 @@ def test_loo_score_validation_errors(centered_eight, kind, scenario, pattern):
         broken.log_likelihood["obs"] = broken.log_likelihood["obs"].isel(draw=slice(0, -1))
 
     with pytest.raises(ValueError, match=pattern):
-        loo_score(broken, kind=kind)
+        loo_score(broken)
 
 
+@pytest.mark.parametrize("pointwise", [False, True])
 @pytest.mark.parametrize("kind", ["crps", "scrps"])
-def test_loo_score_pointwise(centered_eight, kind):
-    result = loo_score(centered_eight, kind=kind, pointwise=True)
+def test_loo_score_pointwise(centered_eight, kind, pointwise):
+    result = loo_score(centered_eight, kind=kind, pointwise=pointwise)
 
-    assert hasattr(result, "mean")
-    assert hasattr(result, "se")
-    assert hasattr(result, "pointwise")
-    assert hasattr(result, "pareto_k")
+    assert type(result).__name__ == kind.upper()
     assert np.isfinite(result.mean)
     assert np.isfinite(result.se)
-    assert result.pointwise.shape == (8,)
-    assert np.all(np.isfinite(result.pointwise.values))
-    assert result.pareto_k.shape == (8,)
-    assert np.all(np.isfinite(result.pareto_k.values))
-
+    assert result.se >= 0
     if kind == "crps":
-        assert np.all(result.pointwise.values <= 0)
+        assert result.mean <= 0
 
-
-def test_loo_score_namedtuple_names(centered_eight):
-    crps_result = loo_score(centered_eight, kind="crps")
-    scrps_result = loo_score(centered_eight, kind="scrps")
-
-    assert type(crps_result).__name__ == "CRPS"
-    assert type(scrps_result).__name__ == "SCRPS"
-
-
-def test_loo_score_crps_vs_scrps(centered_eight):
-    crps_result = loo_score(centered_eight, kind="crps")
-    scrps_result = loo_score(centered_eight, kind="scrps")
-
-    assert crps_result.mean != scrps_result.mean
-    assert crps_result.se != scrps_result.se
+    if pointwise:
+        assert result.pointwise.shape == (8,)
+        assert np.all(np.isfinite(result.pointwise.values))
+        assert result.pareto_k.shape == (8,)
+        assert np.all(np.isfinite(result.pareto_k.values))
+        assert_almost_equal(result.mean, result.pointwise.values.mean(), decimal=14)
+        assert_almost_equal(
+            result.se,
+            result.pointwise.values.std(ddof=0) / result.pointwise.size**0.5,
+            decimal=14,
+        )
+        if kind == "crps":
+            assert np.all(result.pointwise.values <= 0)
+    else:
+        assert result._fields == ("mean", "se")
 
 
 def test_loo_score_explicit_var_name(centered_eight):
@@ -116,19 +96,13 @@ def test_loo_score_explicit_var_name(centered_eight):
     assert_almost_equal(result_explicit.se, result_auto.se, decimal=10)
 
 
-@pytest.mark.parametrize("round_to", [2, 3, "2g", "3g", None])
+@pytest.mark.parametrize("round_to", [2, "2g"])
 def test_loo_score_round_to(centered_eight, round_to):
+    base = loo_score(centered_eight, kind="crps")
     result = loo_score(centered_eight, kind="crps", round_to=round_to)
 
-    assert hasattr(result, "mean")
-    assert hasattr(result, "se")
-
-    if round_to is None:
-        assert isinstance(result.mean, float)
-        assert isinstance(result.se, float)
-    else:
-        assert isinstance(result.mean, int | float | str)
-        assert isinstance(result.se, int | float | str)
+    assert result.mean == round_num(base.mean, round_to)
+    assert result.se == round_num(base.se, round_to)
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -144,50 +118,32 @@ def test_loo_score_multidimensional():
         }
     )
 
-    result = loo_score(multi_dim_data, kind="crps")
+    result = loo_score(multi_dim_data, kind="crps", pointwise=True)
 
-    assert hasattr(result, "mean")
-    assert hasattr(result, "se")
     assert np.isfinite(result.mean)
     assert np.isfinite(result.se)
+    assert result.pointwise.shape == (3, 4)
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_loo_score_pointwise_shape_multidim():
-    rng = np.random.default_rng(42)
-
-    multi_var_data = azb.from_dict(
-        {
-            "posterior": {"mu": rng.normal(size=(2, 50))},
-            "posterior_predictive": {"y": rng.normal(size=(2, 50, 5))},
-            "log_likelihood": {"y": rng.normal(size=(2, 50, 5))},
-            "observed_data": {"y": rng.normal(size=5)},
-        }
-    )
-
-    result = loo_score(multi_var_data, kind="crps", pointwise=True)
-
-    assert result.pointwise.shape == (5,)
-
-
-@pytest.mark.parametrize("kind", ["crps", "scrps"])
-def test_loo_score_precomputed_weights(centered_eight, kind):
-    result_auto = loo_score(centered_eight, kind=kind, pointwise=True)
-
+@pytest.fixture
+def psis_weights(centered_eight):
     loo_inputs = _prepare_loo_inputs(centered_eight, None)
-    log_likelihood = loo_inputs.log_likelihood
-
-    log_weights_computed, pareto_k_computed = log_likelihood.azstats.psislw(
+    return loo_inputs.log_likelihood.azstats.psislw(
         dim=["chain", "draw"],
         r_eff=_get_r_eff(centered_eight, loo_inputs.n_samples),
     )
 
+
+def test_loo_score_precomputed_weights(centered_eight, psis_weights):
+    result_auto = loo_score(centered_eight, kind="crps", pointwise=True)
+    log_weights, pareto_k = psis_weights
+
     result_precomputed = loo_score(
         centered_eight,
-        kind=kind,
+        kind="crps",
         pointwise=True,
-        log_weights=log_weights_computed,
-        pareto_k=pareto_k_computed,
+        log_weights=log_weights,
+        pareto_k=pareto_k,
     )
 
     assert_almost_equal(result_precomputed.mean, result_auto.mean, decimal=10)
@@ -199,7 +155,7 @@ def test_loo_score_precomputed_weights(centered_eight, kind):
 
 
 @pytest.mark.parametrize("kind", ["crps", "scrps"])
-@pytest.mark.parametrize("center", [-100.0, -5.0, 0.0, 5.0])
+@pytest.mark.parametrize("center", [-100.0, 0.0])
 def test_loo_score_kernel_matches_brute_force(kind, center):
     rng = np.random.default_rng(42)
     values = rng.normal(center, 2.0, size=500)
@@ -209,6 +165,19 @@ def test_loo_score_kernel_matches_brute_force(kind, center):
     result = array_stats._loo_score(values, y_obs, log_weights, kind)
     expected = _brute_force_score(values, log_weights, y_obs, kind)
 
+    assert_almost_equal(result, expected, decimal=12)
+
+
+@pytest.mark.parametrize("kind", ["crps", "scrps"])
+def test_loo_score_kernel_extreme_weights(kind):
+    rng = np.random.default_rng(42)
+    values = rng.normal(0.0, 2.0, size=300)
+    log_weights = rng.normal(0.0, 1.0, size=300) + 800.0
+
+    result = array_stats._loo_score(values, 0.5, log_weights, kind)
+    expected = _brute_force_score(values, log_weights, 0.5, kind)
+
+    assert np.isfinite(result)
     assert_almost_equal(result, expected, decimal=12)
 
 
@@ -278,39 +247,9 @@ def test_loo_score_shift_invariance(kind):
     assert_almost_equal(result_shifted.pointwise.values, result.pointwise.values, decimal=10)
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
-@pytest.mark.parametrize("kind", ["crps", "scrps"])
-def test_loo_score_negative_data(kind):
-    rng = np.random.default_rng(42)
-    mu = rng.normal(-5, 0.1, size=(4, 100))
-    y = rng.normal(-5, 1, size=6)
-    y_pred = rng.normal(mu[..., None], 1.0, size=(4, 100, 6))
-    log_lik = -0.5 * (y[None, None, :] - mu[..., None]) ** 2 - 0.5 * np.log(2 * np.pi)
-
-    dt = azb.from_dict(
-        {
-            "posterior": {"mu": mu},
-            "posterior_predictive": {"y": y_pred},
-            "log_likelihood": {"y": log_lik},
-            "observed_data": {"y": y},
-        }
-    )
-
-    result = loo_score(dt, kind=kind, pointwise=True)
-
-    assert np.isfinite(result.mean)
-    assert np.isfinite(result.se)
-    assert np.all(np.isfinite(result.pointwise.values))
-    if kind == "crps":
-        assert np.all(result.pointwise.values <= 0)
-
-
 def test_loo_score_lone_precomputed_arg_raises(centered_eight):
-    loo_inputs = _prepare_loo_inputs(centered_eight, None)
-    log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
-        dim=["chain", "draw"],
-        r_eff=_get_r_eff(centered_eight, loo_inputs.n_samples),
-    )
+    log_weights = xr.zeros_like(centered_eight.log_likelihood["obs"])
+    pareto_k = xr.zeros_like(centered_eight.observed_data["obs"])
 
     with pytest.raises(ValueError, match="must be provided together"):
         loo_score(centered_eight, log_weights=log_weights)
@@ -348,17 +287,12 @@ def test_loo_score_precomputed_weights_used(centered_eight, kind):
     np.testing.assert_allclose(result_uniform.pointwise.values, expected, rtol=1e-10)
 
 
-@pytest.mark.parametrize("kind", ["crps", "scrps"])
-def test_loo_score_precomputed_no_posterior(centered_eight, kind):
-    loo_inputs = _prepare_loo_inputs(centered_eight, None)
-    log_weights, pareto_k = loo_inputs.log_likelihood.azstats.psislw(
-        dim=["chain", "draw"],
-        r_eff=_get_r_eff(centered_eight, loo_inputs.n_samples),
-    )
+def test_loo_score_precomputed_no_posterior(centered_eight, psis_weights):
+    log_weights, pareto_k = psis_weights
     dt_no_posterior = centered_eight.drop_nodes("posterior")
 
-    result = loo_score(dt_no_posterior, kind=kind, log_weights=log_weights, pareto_k=pareto_k)
-    result_full = loo_score(centered_eight, kind=kind, log_weights=log_weights, pareto_k=pareto_k)
+    result = loo_score(dt_no_posterior, kind="crps", log_weights=log_weights, pareto_k=pareto_k)
+    result_full = loo_score(centered_eight, kind="crps", log_weights=log_weights, pareto_k=pareto_k)
 
     assert_almost_equal(result.mean, result_full.mean, decimal=10)
     assert_almost_equal(result.se, result_full.se, decimal=10)

--- a/tests/loo/test_loo_score.py
+++ b/tests/loo/test_loo_score.py
@@ -234,6 +234,15 @@ def test_loo_score_kernel_small_samples():
     expected = _brute_force_score(values, log_weights, 2.0, "crps")
     assert_almost_equal(result, expected, decimal=14)
 
+    result = array_stats._loo_score(values, 2.0, log_weights, "scrps")
+    assert_almost_equal(result, -1.0, decimal=14)
+
+    values = np.array([1.0, 5.0])
+    result = array_stats._loo_score(values, 2.0, log_weights, "crps")
+    assert_almost_equal(result, -1.0, decimal=14)
+    result = array_stats._loo_score(values, 2.0, log_weights, "scrps")
+    assert_almost_equal(result, -1.0 - 0.5 * np.log(2.0), decimal=14)
+
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("kind", ["crps", "scrps"])
@@ -324,6 +333,19 @@ def test_loo_score_precomputed_weights_used(centered_eight, kind):
     )
 
     assert not np.allclose(result_uniform.pointwise.values, result_auto.pointwise.values)
+
+    y_pred = centered_eight.posterior_predictive["obs"].stack(sample=("chain", "draw"))
+    y_obs = centered_eight.observed_data["obs"]
+    expected = [
+        _brute_force_score(
+            y_pred.sel(school=school).values,
+            np.zeros(y_pred.sizes["sample"]),
+            y_obs.sel(school=school).item(),
+            kind,
+        )
+        for school in y_obs["school"].values
+    ]
+    np.testing.assert_allclose(result_uniform.pointwise.values, expected, rtol=1e-10)
 
 
 @pytest.mark.parametrize("kind", ["crps", "scrps"])


### PR DESCRIPTION
Fixes `loo_score` silently returning NaN CRPS for models with negative LOO-weighted mean predictions by replacing the `logsumexp`-based expectations with direct weighted sums. Now only computes the `reff` when weights are computed internally, so precomputed `log_weights`/`pareto_k` no longer require a posterior group.