### PR TITLE
chore: add livedocs tox environment matching arviz-base

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -116,7 +116,6 @@ extras =
     numba
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
-    
 
 [testenv:livedocs]
 description = Build live preview of HTML docs with automatic updates
@@ -126,8 +125,6 @@ extras =
     xarray
 commands =
     sphinx-autobuild -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
-
-
 
 [testenv:cleandocs]
 description = Clean HTML doc build outputs

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
 isolated_build = True
 isolated_build_env = build
 labels =
-    dev = check, cleandocs, docs, viewdocs, full, minimal, xarray, nightlies
+    dev = check, cleandocs, docs, livedocs, viewdocs, full, minimal, xarray, nightlies
 
 [gh-actions]
 python =
@@ -120,9 +120,7 @@ commands =
 [testenv:livedocs]
 description = Build live preview of HTML docs with automatic updates
 base = docs
-extras =
-    doc
-    xarray
+deps = sphinx-autobuild
 commands =
     sphinx-autobuild -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
 

--- a/tox.ini
+++ b/tox.ini
@@ -116,6 +116,18 @@ extras =
     numba
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
+    
+
+[testenv:livedocs]
+description = Build live preview of HTML docs with automatic updates
+base = docs
+extras =
+    doc
+    xarray
+commands =
+    sphinx-autobuild -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -v -bhtml
+
+
 
 [testenv:cleandocs]
 description = Clean HTML doc build outputs


### PR DESCRIPTION
## Summary
Part of DevOps standardization across the ArviZ ecosystem.

## What does this add?
Adds a `livedocs` tox environment to arviz-stats matching the 
one already present in arviz-base. This allows contributors to 
build a live preview of HTML docs with automatic updates during 
development.

## Why?
arviz-base already has this environment but arviz-stats was 
missing it. This is part of ongoing effort to standardize 
development tooling across all ArviZ repositories.

## Related
- arviz-base reference: https://github.com/arviz-devs/arviz-base/blob/main/tox.ini
- GSoC 2025/2026 DevOps standardization project