### PR TITLE
chore: add --hook-stage manual to pre-commit run matching arviz-base

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ deps =
 skip_install = true
 commands =
     pre-commit install
-    pre-commit run --all-files --show-diff-on-failure
+    pre-commit run --all-files --show-diff-on-failure --hook-stage manual
     python -m build
 
 [testenv:docs]


### PR DESCRIPTION
## Summary
Part of DevOps standardization across the ArviZ ecosystem.

## What does this change?
Adds `--hook-stage manual` flag to pre-commit run command in 
tox check environment, matching the configuration already 
present in arviz-base.

## Why?
arviz-base uses `--hook-stage manual` but arviz-stats was 
missing this flag. This ensures manual-stage hooks are also 
run during CI checks, improving consistency across repos.

## Related
- arviz-base reference: https://github.com/arviz-devs/arviz-base/blob/main/tox.ini
- GSoC DevOps standardization project