### PR TITLE
chore: add contributing/generated to cleandocs matching arviz-base

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,7 +122,7 @@ description = Clean HTML doc build outputs
 skip_install = true
 allowlist_externals = rm
 commands =
-    rm -r "{toxworkdir}/docs_out" "{toxworkdir}/docs_doctree" "{toxworkdir}/jupyter_execute" docs/source/api/generated
+    rm -r "{toxworkdir}/docs_out" "{toxworkdir}/docs_doctree" "{toxworkdir}/jupyter_execute" docs/source/api/generated docs/source/contributing/generated
 
 [testenv:viewdocs]
 description = View HTML docs with the default browser


### PR DESCRIPTION
## Summary
Part of DevOps standardization across the ArviZ ecosystem.

## What does this change?
Adds `docs/source/contributing/generated` to the list of 
directories cleaned by the `cleandocs` tox environment, 
matching the configuration already present in arviz-base.

## Why?
arviz-base cleans `docs/source/contributing/generated` in 
its cleandocs environment but arviz-stats was missing this 
directory. This ensures a complete cleanup of all generated 
documentation files when running `tox -e cleandocs`.

## Related
- arviz-base reference: https://github.com/arviz-devs/arviz-base/blob/main/tox.ini
- GSoC DevOps standardization project