### PR TITLE
Fix truncated Cauchy combination: restore correct denominator (#409)

### DIFF
--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -985,14 +985,16 @@ class _DensityBase(_CoreBase):
         return p_value, b_shapley_vals, w_shapley_vals
 
     def _cauchy_combination(self, ps, cauchy_vals, truncate):
-        """Combine p-values using the Cauchy combination method."""
+        """Combine p-values using the Cauchy combination method.
+
+        With ``truncate=True`` this is the truncated Cauchy combination test:
+        terms with p >= 0.5 are zeroed out but the denominator remains the
+        total number of terms, following Eq. (24) of Tesso and Vehtari (2026),
+        https://arxiv.org/abs/2603.02928. An input with no p-values below 0.5
+        therefore yields a statistic of 0 and a p-value of 0.5.
+        """
         if truncate:
-            idx = ps < 0.5
-            if not np.any(idx):
-                raise ValueError(
-                    "Cannot compute truncated Cauchy combination test. No p-values below 0.5 found."
-                )
-            cauchy_mean = np.mean(cauchy_vals[idx])
+            cauchy_mean = np.mean(np.where(ps < 0.5, cauchy_vals, 0.0))
         else:
             cauchy_mean = np.mean(cauchy_vals)
         return 0.5 - np.arctan(cauchy_mean) / np.pi

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -290,8 +290,7 @@ class TestUniformityTestGeneral:
 
     @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
     def test_attained_size_under_null(self, method):
-        """Guard against the denominator regression (see #409).
-        """
+        """Guard against the denominator regression (see #409)."""
         rng = np.random.default_rng(42)
         x = rng.uniform(size=(10_000, 100))
         p_values, *_ = array_stats.uniformity_test(x, axis=-1, method=method)

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -13,12 +13,7 @@ def _cauchy_combination(ps, truncate=True):
     ps = np.asarray(ps, dtype=float)
     cauchy_vals = np.tan((0.5 - ps) * np.pi)
     if truncate:
-        idx = ps < 0.5
-        if not np.any(idx):
-            raise ValueError(
-                "Cannot compute truncated Cauchy combination test. No p-values below 0.5 found."
-            )
-        cauchy_vals = cauchy_vals[idx]
+        cauchy_vals = np.where(ps < 0.5, cauchy_vals, 0.0)
     mean_val = np.mean(cauchy_vals)
     return 0.5 - np.arctan(mean_val) / np.pi
 
@@ -68,19 +63,21 @@ class TestCauchyCombination:
         assert 0 <= result <= 1
 
     def test_truncated(self):
+        """Truncation zeroes terms with p >= 0.5 but keeps the denominator at n (Eq. 24)."""
         ps = np.array([0.1, 0.2, 0.3, 0.4, 0.7, 0.8])
         cauchy_vals = np.tan((0.5 - ps) * np.pi)
         idx = ps < 0.5
-        truncated_mean = np.mean(cauchy_vals[idx])
+        truncated_mean = np.sum(cauchy_vals[idx]) / len(ps)
         expected_trunc = 0.5 - np.arctan(truncated_mean) / np.pi
         result = _cauchy_combination(ps, truncate=True)
         assert_allclose(result, expected_trunc, atol=1e-10)
         assert 0 <= result <= 1
 
-    def test_truncated_no_values_below_half_raises(self):
+    def test_truncated_no_values_below_half_returns_half(self):
+        """All terms zeroed gives a statistic of 0, i.e. p = 0.5, not an error."""
         ps = np.array([0.5, 0.7, 0.8, 0.9])
-        with pytest.raises(ValueError, match="No p-values below 0.5 found"):
-            _cauchy_combination(ps, truncate=True)
+        result = _cauchy_combination(ps, truncate=True)
+        assert_allclose(result, 0.5, atol=1e-10)
 
     def test_compute_cauchy_transform(self):
         """tan((0.5 - x) * pi) at known points."""
@@ -273,6 +270,45 @@ class TestUniformityTestGeneral:
         assert p_value.shape == (2, 3)
         assert shapley.shape == (2, 3, 80)
         assert shapley_unsorted.shape == (2, 3, 80)
+
+    @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
+    def test_all_pointwise_ps_above_half(self, method):
+        """An evenly spaced grid makes every pointwise p-value >= 0.5.
+
+        The truncated statistic is then an empty sum, i.e. 0, so the
+        combined p-value is exactly 0.5 (no evidence against uniformity)
+        and the call must not raise.
+        """
+        grid = (np.arange(300) + 0.5) / 300
+        p_value, *_ = array_stats.uniformity_test(grid, method=method)
+        assert_allclose(p_value, 0.5, atol=1e-10)
+
+    @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
+    def test_batched_with_grid_column(self, method):
+        """One all-ps-above-half row must not abort a batched call."""
+        rng = np.random.default_rng(0)
+        x = np.vstack([rng.uniform(size=(3, 300)), (np.arange(300) + 0.5) / 300])
+        p_value, *_ = array_stats.uniformity_test(x, axis=-1, method=method)
+        assert p_value.shape == (4,)
+        assert_allclose(p_value[-1], 0.5, atol=1e-10)
+
+    @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
+    def test_attained_size_under_null(self, method):
+        """Guard against the denominator regression (see #409).
+
+        On i.i.d. uniform input the rejection rate at alpha = 0.05 is
+        ~0.05-0.07 with the Eq. 24 denominator, but ~0.08-0.10 when the
+        truncated sum is divided by the retained count instead of n. The
+        bounds deliberately allow the method-inherent inflation above
+        0.05 (see the endnote of #409) and sit ~5 Monte-Carlo standard
+        errors from both the correct and the regressed values, so the
+        test stays safe even if the numpy Generator bit-stream changes.
+        """
+        rng = np.random.default_rng(42)
+        x = rng.uniform(size=(10_000, 100))
+        p_values, *_ = array_stats.uniformity_test(x, axis=-1, method=method)
+        attained_size = np.mean(p_values < 0.05)
+        assert 0.03 < attained_size < 0.08
 
 
 class TestMchainUniformity:

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -274,10 +274,6 @@ class TestUniformityTestGeneral:
     @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
     def test_all_pointwise_ps_above_half(self, method):
         """An evenly spaced grid makes every pointwise p-value >= 0.5.
-
-        The truncated statistic is then an empty sum, i.e. 0, so the
-        combined p-value is exactly 0.5 (no evidence against uniformity)
-        and the call must not raise.
         """
         grid = (np.arange(300) + 0.5) / 300
         p_value, *_ = array_stats.uniformity_test(grid, method=method)

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -273,8 +273,7 @@ class TestUniformityTestGeneral:
 
     @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
     def test_all_pointwise_ps_above_half(self, method):
-        """An evenly spaced grid makes every pointwise p-value >= 0.5.
-        """
+        """An evenly spaced grid makes every pointwise p-value >= 0.5."""
         grid = (np.arange(300) + 0.5) / 300
         p_value, *_ = array_stats.uniformity_test(grid, method=method)
         assert_allclose(p_value, 0.5, atol=1e-10)

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -295,14 +295,6 @@ class TestUniformityTestGeneral:
     @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
     def test_attained_size_under_null(self, method):
         """Guard against the denominator regression (see #409).
-
-        On i.i.d. uniform input the rejection rate at alpha = 0.05 is
-        ~0.05-0.07 with the Eq. 24 denominator, but ~0.08-0.10 when the
-        truncated sum is divided by the retained count instead of n. The
-        bounds deliberately allow the method-inherent inflation above
-        0.05 (see the endnote of #409) and sit ~5 Monte-Carlo standard
-        errors from both the correct and the regressed values, so the
-        test stays safe even if the numpy Generator bit-stream changes.
         """
         rng = np.random.default_rng(42)
         x = rng.uniform(size=(10_000, 100))


### PR DESCRIPTION
The refactor in #352 changed the truncated Cauchy combination from a masked mean (truncated sum divided by the total number of terms, as in Eq. 24 of arXiv:2603.02928) to a mean over the retained subset, roughly doubling the statistic and inflating the rejection rate of pot_c and prit_c under the null. It also made the no-retained-terms case (every pointwise p >= 0.5) undefined, guarded by a ValueError that a single too-uniform column could trigger, aborting whole batched calls.

Restore the Eq. 24 semantics via `np.where` (avoiding the inf * 0 hazard of the original mask multiplication), so the empty-truncation case is simply a statistic of 0 (p = 0.5) and the error case disappears. Update the test helper and expectations accordingly, and add regression guards: grid input returns 0.5 instead of raising, one such column no longer aborts a batched call, and the attained size under the null stays below the regressed level.