### PR TITLE
Add PyMC and Bambi support for `loo_subsample`

### DIFF
--- a/src/arviz_stats/loo/__init__.py
+++ b/src/arviz_stats/loo/__init__.py
@@ -7,6 +7,7 @@ from arviz_stats.loo.loo_influence import loo_influence
 from arviz_stats.loo.loo_score import loo_score
 from arviz_stats.loo.loo_pit import loo_pit
 from arviz_stats.loo.loo_subsample import loo_subsample, update_subsample
+from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
 from arviz_stats.loo.loo_moment_match import loo_moment_match
 from arviz_stats.loo.loo_moment_match_helper import mm_from_pymc
 from arviz_stats.loo.reloo import reloo

--- a/src/arviz_stats/loo/loo_helper.py
+++ b/src/arviz_stats/loo/loo_helper.py
@@ -568,20 +568,13 @@ def _prepare_subsample(
     n_data_points,
     n_samples,
     thin_factor=None,
+    model=None,
 ):
     """Prepare inputs for PSIS-LOO-CV with sub-sampling."""
     indices, subsample_size = _generate_subsample_indices(n_data_points, observations, seed)
 
-    if thin_factor is not None and log_lik_fn is not None:
-        from arviz_stats.manipulation import thin
-
-        data = data.copy(deep=True)
-        if hasattr(data, "posterior"):
-            thinned_posterior = thin(data.posterior, factor=thin_factor)
-            data["posterior"] = thinned_posterior
-
     if method == "lpd":
-        if log_lik_fn is None:
+        if log_lik_fn is None and model is None:
             lpd_approx_all = logsumexp(log_likelihood_da, dims=sample_dims, b=1 / n_samples)
         else:
             lpd_approx_all = _compute_loo_approximation(
@@ -591,6 +584,8 @@ def _prepare_subsample(
                 param_names=param_names,
                 method="lpd",
                 log=log,
+                model=model,
+                thin_factor=thin_factor,
             )
     else:  # method == "plpd"
         lpd_approx_all = _compute_loo_approximation(
@@ -600,6 +595,8 @@ def _prepare_subsample(
             param_names=param_names,
             method="plpd",
             log=log,
+            model=model,
+            thin_factor=thin_factor,
         )
 
     log_likelihood_sample = _select_obs_by_indices(log_likelihood_da, indices, obs_dims, "__obs__")
@@ -625,6 +622,7 @@ def _prepare_update_subsample(
     param_names,
     log,
     thin_factor=None,
+    model=None,
 ):
     """Prepare inputs for updating PSIS-LOO-CV with additional observations."""
     loo_inputs = _prepare_loo_inputs(data, var_name, thin_factor)
@@ -653,16 +651,8 @@ def _prepare_update_subsample(
         if len(overlap) > 0:
             raise ValueError(f"New indices {overlap} overlap with existing indices.")
 
-    if thin_factor is not None and log_lik_fn is not None:
-        from arviz_stats.manipulation import thin
-
-        data = data.copy(deep=True)
-        if hasattr(data, "posterior"):
-            thinned_posterior = thin(data.posterior, factor=thin_factor)
-            data["posterior"] = thinned_posterior
-
     if method == "lpd":
-        if log_lik_fn is None:
+        if log_lik_fn is None and model is None:
             lpd_approx_all = logsumexp(
                 log_likelihood, dims=loo_inputs.sample_dims, b=1 / loo_inputs.n_samples
             )
@@ -674,6 +664,8 @@ def _prepare_update_subsample(
                 param_names=param_names,
                 method="lpd",
                 log=log,
+                model=model,
+                thin_factor=thin_factor,
             )
     else:  # method == "plpd"
         lpd_approx_all = _compute_loo_approximation(
@@ -683,6 +675,8 @@ def _prepare_update_subsample(
             param_names=param_names,
             method="plpd",
             log=log,
+            model=model,
+            thin_factor=thin_factor,
         )
 
     log_likelihood_new_da = _select_obs_by_indices(
@@ -711,8 +705,38 @@ def _compute_loo_approximation(
     param_names=None,
     method="lpd",
     log=True,
+    model=None,
+    thin_factor=None,
 ):
     """Compute LOO approximation with LPD or PLPD method."""
+    if model is not None and log_lik_fn is not None:
+        warnings.warn(
+            "Both `model` and `log_lik_fn` were provided. The supplied `model` will be ignored.",
+            UserWarning,
+            stacklevel=4,
+        )
+    elif model is not None:
+        if not log:
+            raise ValueError("log must be True when log_lik_fn is auto-built from model.")
+        from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
+
+        # If model is Bambi's, re-center the intercept so it matches the PyMC value variable
+        re_center_intercept = getattr(model, "_re_center_intercept", None)
+        if re_center_intercept is not None:
+            data = re_center_intercept(data)
+            model = model.backend.model
+
+        log_lik_fn = ll_from_pymc(data, model=model, var_name=var_name)
+        param_names = None
+
+    if thin_factor is not None and log_lik_fn is not None:
+        from arviz_stats.manipulation import thin
+
+        data = data.copy(deep=True)
+        if hasattr(data, "posterior"):
+            thinned_posterior = thin(data.posterior, factor=thin_factor)
+            data["posterior"] = thinned_posterior
+
     if not hasattr(data, "observed_data"):
         raise ValueError("No observed_data group found in the data")
     if var_name not in data.observed_data:
@@ -730,7 +754,7 @@ def _compute_loo_approximation(
         return logsumexp(log_likelihood, dims=sample_dims, b=1 / n_samples)
 
     if log_lik_fn is None:
-        raise ValueError(f"log_lik_fn required for {method} method")
+        raise ValueError("log_lik_fn or model must be provided when method='plpd'")
     if not callable(log_lik_fn):
         raise TypeError("log_lik_fn must be a callable function.")
 

--- a/src/arviz_stats/loo/loo_moment_match_helper.py
+++ b/src/arviz_stats/loo/loo_moment_match_helper.py
@@ -3,6 +3,8 @@
 import numpy as np
 from xarray import DataArray
 
+from arviz_stats.loo.pymc_helper import _get_batched_func, _get_observed_rv
+
 __all__ = ["mm_from_pymc"]
 
 
@@ -143,57 +145,6 @@ def _validate_model(model):
         )
 
 
-def _get_observed_rv(model, idata, var_name):
-    """Identify the observed random variable to use for moment matching.
-
-    Parameters
-    ----------
-    model : Model
-        The PyMC model to check.
-    idata : DataTree
-        The DataTree object. If it contains an ``observed_data`` group,
-        ``var_name`` is validated against it. Otherwise, the group is optional.
-    var_name : str or None
-        The name of the observed variable to use. If None, the function will
-        attempt to infer the observed variable.
-
-    Returns
-    -------
-    observed_rv : RandomVariable
-        The observed random variable to use for moment matching.
-    var_name : str
-        The name of the observed variable.
-    """
-    observed = list(model.observed_RVs)
-
-    if (
-        var_name is not None
-        and hasattr(idata, "observed_data")
-        and var_name not in idata.observed_data
-    ):
-        raise ValueError(
-            f"`{var_name!r}` is not present in `idata.observed_data`. Make sure "
-            "the InferenceData contains the observed variable whose log-likelihood "
-            "is used for LOO."
-        )
-
-    if var_name is None:
-        if len(observed) != 1:
-            raise ValueError(
-                "The model has multiple observed random variables "
-                f"({[rv.name for rv in observed]}); please pass `var_name`."
-            )
-        return observed[0], observed[0].name
-
-    matches = [rv for rv in observed if rv.name == var_name]
-    if not matches:
-        raise ValueError(
-            f"`{var_name!r}` does not match any observed random variable in the model. "
-            f"Available: {[rv.name for rv in observed]}."
-        )
-    return matches[0], var_name
-
-
 def _get_upars_da(idata, model, initial_point, value_vars):
     """Compute unconstrained posterior draws.
 
@@ -300,44 +251,3 @@ def _get_upars_da(idata, model, initial_point, value_vars):
         ),
         n_params,
     )
-
-
-def _get_batched_func(inputs, outputs, initial_point, *, dtype="float64", on_unused_input="ignore"):
-    """Compile a batched function mapping ``(N, n_params)`` unconstrained draws to ``outputs``.
-
-    Parameters
-    ----------
-    inputs : list of PyTensor variables
-        Model value variables (unconstrained parameters), in column order.
-    outputs : list of PyTensor expressions
-        Expressions to evaluate (e.g. log posterior, elementwise log likelihood).
-    initial_point : dict
-        Model initial point; used to determine the shape of each value variable.
-
-    Returns
-    -------
-    func : callable
-        Function ``func(q) -> list`` where ``q`` has shape ``(N, n_params)``.
-    """
-    import pytensor
-    import pytensor.tensor as pt
-
-    block_inputs = []
-    block_slices = []
-    replace = {}
-    last = 0
-    for v in inputs:
-        shape = initial_point[v.name].shape
-        v_length = int(np.prod(shape, dtype=int)) if shape else 1
-        block = pt.matrix(f"upars_{v.name}", dtype=dtype)
-        block_inputs.append(block)
-        block_slices.append(slice(last, last + v_length))
-        replace[v] = block.reshape((block.shape[0], *tuple(shape)))
-        last += v_length
-    new_outputs = pytensor.graph.vectorize_graph(outputs, replace)
-    compiled = pytensor.function(block_inputs, new_outputs, on_unused_input=on_unused_input)
-
-    def func(q):
-        return compiled(*(np.ascontiguousarray(q[:, s]) for s in block_slices))
-
-    return func

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -37,6 +37,7 @@ def loo_subsample(
     param_names=None,
     log=True,
     log_jacobian=None,
+    model=None,
 ):
     r"""Compute PSIS-LOO-CV using sub-sampling.
 
@@ -90,7 +91,8 @@ def loo_subsample(
         Method used for approximating the pointwise log predictive density:
 
         - ``lpd``: Use standard log predictive density approximation (default)
-        - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``.
+        - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``
+          or a ``model`` from which one is built.
     thin: int or str, optional
         Thinning factor for posterior draws. Can be an integer to thin by that factor,
         "auto" to automatically determine thinning based on bulk and tail ESS, or None
@@ -118,6 +120,11 @@ def loo_subsample(
         original response scale :math:`y`. The value should be :math:`\log|\frac{dz}{dy}|`
         (the log absolute value of the derivative of the transformation). Must be a DataArray
         with dimensions matching the observation dimensions.
+    model : Model, optional
+        A model object. Currently supported models are PyMC and Bambi.
+        If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
+        so it does not have to be constructed manually. ``param_names`` is not needed in
+        this case.
 
     Returns
     -------
@@ -194,8 +201,23 @@ def loo_subsample(
 
     if method not in ["lpd", "plpd"]:
         raise ValueError("Method must be either 'lpd' or 'plpd'")
+
+    # Auto-build the log likelihood function from the model if provided
+    if model is not None and log_lik_fn is None:
+        if not log:
+            raise ValueError("log must be True when log_lik_fn is auto-built from model.")
+        from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
+
+        ## if model is Bambi's, re-center the intercept so it matches the PyMC value variable
+        re_center_intercept = getattr(model, "_re_center_intercept", None)
+        if re_center_intercept is not None:
+            data = re_center_intercept(data)
+            model = model.backend.model
+
+        log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
+
     if method == "plpd" and log_lik_fn is None:
-        raise ValueError("log_lik_fn must be provided when method='plpd'")
+        raise ValueError("log_lik_fn or model must be provided when method='plpd'")
 
     log_likelihood = loo_inputs.log_likelihood
     if reff is None:
@@ -372,6 +394,7 @@ def update_subsample(
     log_lik_fn=None,
     param_names=None,
     log=True,
+    model=None,
 ):
     """Update a sub-sampled PSIS-LOO-CV object with new observations.
 
@@ -416,7 +439,8 @@ def update_subsample(
         Method used for approximating the pointwise log predictive density:
 
         - ``lpd``: Use standard log predictive density approximation (default)
-        - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``.
+        - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``
+          or a ``model`` from which one is built.
     log_lik_fn : callable, optional
         Custom log-likelihood function. The signature must be ``log_lik_fn(observed, data)``
         where ``observed`` is a :class:`~xarray.DataArray` containing one or more observations
@@ -432,6 +456,11 @@ def update_subsample(
     log: bool, optional
         Whether the ``log_lik_fn`` returns log-likelihood (True) or likelihood (False).
         Default is True.
+    model : Model, optional
+        A model object. Currently supported models are PyMC and Bambi.
+        If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
+        so it does not have to be constructed manually. ``param_names`` is not needed in
+        this case.
 
     Returns
     -------
@@ -498,11 +527,27 @@ def update_subsample(
         raise ValueError("Original loo_subsample result must have pointwise=True")
     if method not in ["lpd", "plpd"]:
         raise ValueError("Method must be either 'lpd' or 'plpd'")
-    if method == "plpd" and log_lik_fn is None:
-        raise ValueError("log_lik_fn must be provided when method='plpd'")
 
     thin = getattr(loo_orig, "thin_factor", None)
     loo_inputs = _prepare_loo_inputs(data, var_name, thin)
+
+    # Auto-build the log likelihood function from the model if provided
+    if model is not None and log_lik_fn is None:
+        if not log:
+            raise ValueError("log must be True when log_lik_fn is auto-built from model.")
+        from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
+
+        ## if model is Bambi's, re-center the intercept so it matches the PyMC value variable
+        re_center_intercept = getattr(model, "_re_center_intercept", None)
+        if re_center_intercept is not None:
+            data = re_center_intercept(data)
+            model = model.backend.model
+
+        log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
+
+    if method == "plpd" and log_lik_fn is None:
+        raise ValueError("log_lik_fn or model must be provided when method='plpd'")
+
     update_data = _prepare_update_subsample(
         loo_orig, data, observations, var_name, seed, method, log_lik_fn, param_names, log, thin
     )

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -123,7 +123,7 @@ def loo_subsample(
     model : Model, optional
         A model object. Currently supported models are PyMC and Bambi.
         If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
-        so it does not have to be constructed manually. ``param_names`` is not needed in
+        so it does not have to be constructed manually. ``param_names`` is ignored in
         this case.
 
     Returns
@@ -202,6 +202,10 @@ def loo_subsample(
     if method not in ["lpd", "plpd"]:
         raise ValueError("Method must be either 'lpd' or 'plpd'")
 
+    log_likelihood = loo_inputs.log_likelihood
+    if reff is None:
+        reff = _get_r_eff(data, loo_inputs.n_samples)
+
     # Auto-build the log likelihood function from the model if provided
     if model is not None and log_lik_fn is None:
         if not log:
@@ -215,13 +219,10 @@ def loo_subsample(
             model = model.backend.model
 
         log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
+        param_names = None
 
     if method == "plpd" and log_lik_fn is None:
         raise ValueError("log_lik_fn or model must be provided when method='plpd'")
-
-    log_likelihood = loo_inputs.log_likelihood
-    if reff is None:
-        reff = _get_r_eff(data, loo_inputs.n_samples)
 
     jacobian_da = _check_log_jacobian(log_jacobian, loo_inputs.obs_dims)
 
@@ -459,7 +460,7 @@ def update_subsample(
     model : Model, optional
         A model object. Currently supported models are PyMC and Bambi.
         If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
-        so it does not have to be constructed manually. ``param_names`` is not needed in
+        so it does not have to be constructed manually. ``param_names`` is ignored in
         this case.
 
     Returns
@@ -531,6 +532,9 @@ def update_subsample(
     thin = getattr(loo_orig, "thin_factor", None)
     loo_inputs = _prepare_loo_inputs(data, var_name, thin)
 
+    if reff is None:
+        reff = _get_r_eff(data, loo_inputs.n_samples)
+
     # Auto-build the log likelihood function from the model if provided
     if model is not None and log_lik_fn is None:
         if not log:
@@ -544,6 +548,7 @@ def update_subsample(
             model = model.backend.model
 
         log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
+        param_names = None
 
     if method == "plpd" and log_lik_fn is None:
         raise ValueError("log_lik_fn or model must be provided when method='plpd'")
@@ -551,9 +556,6 @@ def update_subsample(
     update_data = _prepare_update_subsample(
         loo_orig, data, observations, var_name, seed, method, log_lik_fn, param_names, log, thin
     )
-
-    if reff is None:
-        reff = _get_r_eff(data, loo_inputs.n_samples)
 
     log_jacobian = getattr(loo_orig, "log_jacobian", None)
     jacobian_da = _check_log_jacobian(log_jacobian, loo_inputs.obs_dims)

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -126,7 +126,7 @@ def loo_subsample(
         A model object. Currently supported models are PyMC and Bambi.
         If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
         so it does not have to be constructed manually. ``param_names`` is ignored in
-        this case.
+        this case. If both are provided, ``log_lik_fn`` takes precedence and a warning is issued.
 
     Returns
     -------
@@ -208,24 +208,6 @@ def loo_subsample(
     if reff is None:
         reff = _get_r_eff(data, loo_inputs.n_samples)
 
-    # Auto-build the log likelihood function from the model if provided
-    if model is not None and log_lik_fn is None:
-        if not log:
-            raise ValueError("log must be True when log_lik_fn is auto-built from model.")
-        from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
-
-        ## if model is Bambi's, re-center the intercept so it matches the PyMC value variable
-        re_center_intercept = getattr(model, "_re_center_intercept", None)
-        if re_center_intercept is not None:
-            data = re_center_intercept(data)
-            model = model.backend.model
-
-        log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
-        param_names = None
-
-    if method == "plpd" and log_lik_fn is None:
-        raise ValueError("log_lik_fn or model must be provided when method='plpd'")
-
     jacobian_da = _check_log_jacobian(log_jacobian, loo_inputs.obs_dims)
 
     subsample_data = _prepare_subsample(
@@ -243,6 +225,7 @@ def loo_subsample(
         loo_inputs.n_data_points,
         loo_inputs.n_samples,
         thin,
+        model=model,
     )
 
     lpd_approx_all = subsample_data.lpd_approx_all
@@ -465,7 +448,7 @@ def update_subsample(
         A model object. Currently supported models are PyMC and Bambi.
         If provided and ``log_lik_fn`` is not, it will be used to auto-build ``log_lik_fn``,
         so it does not have to be constructed manually. ``param_names`` is ignored in
-        this case.
+        this case. If both are provided, ``log_lik_fn`` takes precedence and a warning is issued.
 
     Returns
     -------
@@ -539,26 +522,18 @@ def update_subsample(
     if reff is None:
         reff = _get_r_eff(data, loo_inputs.n_samples)
 
-    # Auto-build the log likelihood function from the model if provided
-    if model is not None and log_lik_fn is None:
-        if not log:
-            raise ValueError("log must be True when log_lik_fn is auto-built from model.")
-        from arviz_stats.loo.loo_subsample_helper import ll_from_pymc
-
-        ## if model is Bambi's, re-center the intercept so it matches the PyMC value variable
-        re_center_intercept = getattr(model, "_re_center_intercept", None)
-        if re_center_intercept is not None:
-            data = re_center_intercept(data)
-            model = model.backend.model
-
-        log_lik_fn = ll_from_pymc(data, model=model, var_name=loo_inputs.var_name)
-        param_names = None
-
-    if method == "plpd" and log_lik_fn is None:
-        raise ValueError("log_lik_fn or model must be provided when method='plpd'")
-
     update_data = _prepare_update_subsample(
-        loo_orig, data, observations, var_name, seed, method, log_lik_fn, param_names, log, thin
+        loo_orig,
+        data,
+        observations,
+        var_name,
+        seed,
+        method,
+        log_lik_fn,
+        param_names,
+        log,
+        thin,
+        model=model,
     )
 
     log_jacobian = getattr(loo_orig, "log_jacobian", None)

--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -90,7 +90,9 @@ def loo_subsample(
     method: str, optional
         Method used for approximating the pointwise log predictive density:
 
-        - ``lpd``: Use standard log predictive density approximation (default)
+        - ``lpd``: Use standard log predictive density approximation (default). The stored
+          log likelihood values are used unless ``log_lik_fn`` or ``model`` is provided,
+          in which case the approximation is recomputed from it.
         - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``
           or a ``model`` from which one is built.
     thin: int or str, optional
@@ -439,7 +441,9 @@ def update_subsample(
     method: str, optional
         Method used for approximating the pointwise log predictive density:
 
-        - ``lpd``: Use standard log predictive density approximation (default)
+        - ``lpd``: Use standard log predictive density approximation (default). The stored
+          log likelihood values are used unless ``log_lik_fn`` or ``model`` is provided,
+          in which case the approximation is recomputed from it.
         - ``plpd``: Use point log predictive density approximation which requires a ``log_lik_fn``
           or a ``model`` from which one is built.
     log_lik_fn : callable, optional

--- a/src/arviz_stats/loo/loo_subsample_helper.py
+++ b/src/arviz_stats/loo/loo_subsample_helper.py
@@ -1,0 +1,134 @@
+"""Helper functions for PSIS-LOO-CV sub-sampling."""
+
+import numpy as np
+from xarray import DataArray
+
+from arviz_stats.loo.loo_moment_match_helper import _get_batched_func, _get_observed_rv
+
+__all__ = ["ll_from_pymc"]
+
+
+def ll_from_pymc(
+    idata,
+    *,
+    model=None,
+    var_name=None,
+):
+    """Build a log-likelihood function for :func:`arviz_stats.loo_subsample` from a PyMC model.
+
+    :func:`arviz_stats.loo_subsample` and :func:`arviz_stats.update_subsample` accept a
+    ``log_lik_fn`` computing the pointwise log likelihood of the observed variable, which
+    is required for ``method="plpd"`` and optional for ``method="lpd"``. This helper
+    compiles that function directly from the PyMC model, so it does not have to be
+    constructed manually.
+
+    Parameters
+    ----------
+    idata : DataTree
+        InferenceData with ``posterior`` and ``observed_data`` groups. The posterior
+        group must contain the free random variables of the model.
+    model : Model
+        The PyMC model that produced the ``idata``.
+    var_name : str, optional
+        Name of the observed variable whose log-likelihood is used for LOO. Can be omitted
+        if the model has exactly one observed random variable.
+
+    Returns
+    -------
+    log_lik_fn : callable
+        ``log_lik_fn(observed, data) -> DataArray``. When ``data.posterior`` contains the
+        ``chain`` and ``draw`` dimensions, the result has dims ``(chain, draw, *obs_dims)``
+        holding the per-draw log likelihood of every observation, as required by
+        ``method="lpd"``. When ``data.posterior`` holds a point estimate without sample
+        dimensions, the result has the observation dimensions only, as required by
+        ``method="plpd"``.
+
+    See Also
+    --------
+    loo_subsample : PSIS-LOO-CV with sub-sampling.
+    update_subsample : Update a previously computed sub-sampled PSIS-LOO-CV.
+    """
+    from pymc.model import modelcontext
+    from pymc.model.transform.conditioning import remove_value_transforms
+
+    try:
+        model = modelcontext(model)
+    except TypeError as err:
+        raise ValueError("A PyMC model is required to build the log likelihood function.") from err
+
+    if model.discrete_value_vars:
+        raise NotImplementedError(
+            "Building a log likelihood function is not supported for models with discrete "
+            "random variables. "
+            f"Found discrete value variables: {[v.name for v in model.discrete_value_vars]}."
+        )
+
+    _, var_name = _get_observed_rv(model, idata, var_name)
+
+    # The posterior group stores draws in the constrained space, so compile the
+    # likelihood on the transform-removed model whose value variables live there too.
+    umodel = remove_value_transforms(model)
+    obs_rv = umodel[var_name]
+    free_rv_names = [rv.name for rv in umodel.free_RVs]
+    value_vars = [umodel.rvs_to_values[rv] for rv in umodel.free_RVs]
+    initial_point = dict(umodel.initial_point())
+    var_shapes = [initial_point[v.name].shape for v in value_vars]
+    named_dims = dict(umodel.named_vars_to_dims)
+
+    lik_func = _get_batched_func(
+        inputs=value_vars,
+        outputs=list(umodel.logp(vars=[obs_rv], sum=False)),
+        initial_point=initial_point,
+    )
+
+    if hasattr(idata, "observed_data") and var_name in idata.observed_data:
+        obs_ref = idata.observed_data[var_name]
+    else:
+        obs_ref = None
+
+    def log_lik_fn(observed, data):
+        posterior = getattr(data.posterior, "dataset", data.posterior)
+
+        missing = [name for name in free_rv_names if name not in posterior.data_vars]
+        if missing:
+            raise KeyError(
+                f"Posterior draws for free random variables {missing} were not found in "
+                f"`data.posterior`. Available variables: {list(posterior.data_vars)}."
+            )
+
+        has_sample_dims = all(dim in posterior.dims for dim in ("chain", "draw"))
+
+        sample_dims = ("chain", "draw") if has_sample_dims else ()
+        blocks = []
+        for name, shape in zip(free_rv_names, var_shapes):
+            alen = int(np.prod(shape, dtype=int)) if shape else 1
+            values = posterior[name]
+            rv_dims = named_dims.get(name)
+            if rv_dims is not None and all(
+                isinstance(dim, str) and dim in values.dims for dim in rv_dims
+            ):
+                values = values.transpose(*sample_dims, *rv_dims)
+            elif has_sample_dims:
+                values = values.transpose("chain", "draw", ...)
+            blocks.append(np.asarray(values.values, dtype="float64").reshape(-1, alen))
+        out = np.asarray(lik_func(np.concatenate(blocks, axis=1))[0])
+
+        target = obs_ref if obs_ref is not None else observed
+        if out.shape[1:] != target.shape:
+            raise ValueError(
+                f"The pointwise log likelihood of `{var_name}` has shape {out.shape[1:]}, "
+                f"which does not match the observed data shape {target.shape}. Models whose "
+                "likelihood reduces over observation dimensions are not supported."
+            )
+
+        coords = {dim: target[dim] for dim in target.dims if dim in target.coords}
+        if has_sample_dims:
+            vals = out.reshape(posterior.sizes["chain"], posterior.sizes["draw"], *target.shape)
+            if "chain" in posterior.coords:
+                coords["chain"] = posterior["chain"]
+            if "draw" in posterior.coords:
+                coords["draw"] = posterior["draw"]
+            return DataArray(vals, dims=("chain", "draw", *target.dims), coords=coords)
+        return DataArray(out.reshape(target.shape), dims=target.dims, coords=coords)
+
+    return log_lik_fn

--- a/src/arviz_stats/loo/loo_subsample_helper.py
+++ b/src/arviz_stats/loo/loo_subsample_helper.py
@@ -3,7 +3,7 @@
 import numpy as np
 from xarray import DataArray
 
-from arviz_stats.loo.loo_moment_match_helper import _get_batched_func, _get_observed_rv
+from arviz_stats.loo.pymc_helper import _get_batched_func, _get_observed_rv
 
 __all__ = ["ll_from_pymc"]
 

--- a/src/arviz_stats/loo/loo_subsample_helper.py
+++ b/src/arviz_stats/loo/loo_subsample_helper.py
@@ -20,7 +20,9 @@ def ll_from_pymc(
     ``log_lik_fn`` computing the pointwise log likelihood of the observed variable, which
     is required for ``method="plpd"`` and optional for ``method="lpd"``. This helper
     compiles that function directly from the PyMC model, so it does not have to be
-    constructed manually.
+    constructed manually. Bambi models are supported through the ``model`` argument of
+    those functions, which re-centers the posterior and passes the underlying PyMC
+    model to this helper automatically.
 
     Parameters
     ----------
@@ -30,8 +32,8 @@ def ll_from_pymc(
     model : Model
         The PyMC model that produced the ``idata``.
     var_name : str, optional
-        Name of the observed variable whose log-likelihood is used for LOO. Can be omitted
-        if the model has exactly one observed random variable.
+        Name of the observed variable whose log-likelihood is used for PSIS-LOO-CV.
+        Can be omitted if the model has exactly one observed random variable.
 
     Returns
     -------

--- a/src/arviz_stats/loo/pymc_helper.py
+++ b/src/arviz_stats/loo/pymc_helper.py
@@ -1,0 +1,95 @@
+"""Shared PyMC helper functions for PSIS-LOO-CV."""
+
+import numpy as np
+
+
+def _get_observed_rv(model, idata, var_name):
+    """Identify the observed random variable to use for PSIS-LOO-CV.
+
+    Parameters
+    ----------
+    model : Model
+        The PyMC model to check.
+    idata : DataTree
+        The DataTree object. If it contains an ``observed_data`` group,
+        ``var_name`` is validated against it. Otherwise, the group is optional.
+    var_name : str or None
+        The name of the observed variable to use. If None, the function will
+        attempt to infer the observed variable.
+
+    Returns
+    -------
+    observed_rv : RandomVariable
+        The observed random variable to use for PSIS-LOO-CV.
+    var_name : str
+        The name of the observed variable.
+    """
+    observed = list(model.observed_RVs)
+
+    if (
+        var_name is not None
+        and hasattr(idata, "observed_data")
+        and var_name not in idata.observed_data
+    ):
+        raise ValueError(
+            f"`{var_name!r}` is not present in `idata.observed_data`. Make sure "
+            "the InferenceData contains the observed variable whose log-likelihood "
+            "is used for LOO."
+        )
+
+    if var_name is None:
+        if len(observed) != 1:
+            raise ValueError(
+                "The model has multiple observed random variables "
+                f"({[rv.name for rv in observed]}); please pass `var_name`."
+            )
+        return observed[0], observed[0].name
+
+    matches = [rv for rv in observed if rv.name == var_name]
+    if not matches:
+        raise ValueError(
+            f"`{var_name!r}` does not match any observed random variable in the model. "
+            f"Available: {[rv.name for rv in observed]}."
+        )
+    return matches[0], var_name
+
+
+def _get_batched_func(inputs, outputs, initial_point, *, dtype="float64", on_unused_input="ignore"):
+    """Compile a batched function mapping ``(N, n_params)`` unconstrained draws to ``outputs``.
+
+    Parameters
+    ----------
+    inputs : list of PyTensor variables
+        Model value variables (unconstrained parameters), in column order.
+    outputs : list of PyTensor expressions
+        Expressions to evaluate (e.g. log posterior, elementwise log likelihood).
+    initial_point : dict
+        Model initial point; used to determine the shape of each value variable.
+
+    Returns
+    -------
+    func : callable
+        Function ``func(q) -> list`` where ``q`` has shape ``(N, n_params)``.
+    """
+    import pytensor
+    import pytensor.tensor as pt
+
+    block_inputs = []
+    block_slices = []
+    replace = {}
+    last = 0
+    for v in inputs:
+        shape = initial_point[v.name].shape
+        v_length = int(np.prod(shape, dtype=int)) if shape else 1
+        block = pt.matrix(f"upars_{v.name}", dtype=dtype)
+        block_inputs.append(block)
+        block_slices.append(slice(last, last + v_length))
+        replace[v] = block.reshape((block.shape[0], *tuple(shape)))
+        last += v_length
+    new_outputs = pytensor.graph.vectorize_graph(outputs, replace)
+    compiled = pytensor.function(block_inputs, new_outputs, on_unused_input=on_unused_input)
+
+    def func(q):
+        return compiled(*(np.ascontiguousarray(q[:, s]) for s in block_slices))
+
+    return func

--- a/tests/loo/test_loo_subsample.py
+++ b/tests/loo/test_loo_subsample.py
@@ -520,7 +520,7 @@ def test_loo_subsample_observations_exceeds_total(centered_eight_with_sigma):
 
 
 def test_loo_subsample_plpd_without_loglik(centered_eight_with_sigma):
-    with pytest.raises(ValueError, match="log_lik_fn must be provided when method='plpd'"):
+    with pytest.raises(ValueError, match="log_lik_fn or model must be provided when method='plpd'"):
         loo_subsample(
             centered_eight_with_sigma,
             observations=4,

--- a/tests/loo/test_loo_subsample_helpers.py
+++ b/tests/loo/test_loo_subsample_helpers.py
@@ -1,0 +1,285 @@
+"""Test sub-sampling helper functions for PyMC models."""
+
+# pylint: disable=no-self-use, redefined-outer-name
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.stats import norm
+
+from ..helpers import importorskip
+
+azb = importorskip("arviz_base")
+pm = importorskip("pymc")
+xr = importorskip("xarray")
+
+from arviz_stats import loo_subsample, update_subsample
+from arviz_stats.loo import ll_from_pymc
+
+
+def _build_normal_setup(*, n_chains=2, n_draws=60, n_obs=12, seed=0):
+    rng = np.random.default_rng(seed)
+    y_obs = rng.normal(1.0, 1.5, size=n_obs)
+    mu_draws = rng.normal(1.0, 0.2, size=(n_chains, n_draws))
+    sigma_draws = rng.lognormal(0.2, 0.15, size=(n_chains, n_draws))
+    log_lik = norm.logpdf(y_obs[None, None, :], mu_draws[..., None], sigma_draws[..., None])
+    idata = azb.from_dict(
+        {
+            "posterior": {"mu": mu_draws, "sigma": sigma_draws},
+            "log_likelihood": {"y": log_lik},
+            "observed_data": {"y": y_obs},
+        }
+    )
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 5)
+        sigma = pm.HalfNormal("sigma", 2.0)
+        pm.Normal("y", mu, sigma, observed=y_obs)
+    return idata, model, y_obs
+
+
+def _manual_ll_fn(observed, data):
+    mu = data.posterior["mu"]
+    sigma = data.posterior["sigma"]
+    return -0.5 * np.log(2 * np.pi * sigma**2) - 0.5 * ((observed - mu) / sigma) ** 2
+
+
+@pytest.fixture
+def normal_setup():
+    return _build_normal_setup()
+
+
+class TestSubsampleLogLikFunctions:
+    def test_lpd_dims_and_values(self, normal_setup):
+        idata, model, y_obs = normal_setup
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        observed = idata.observed_data["y"]
+        result = log_lik_fn(observed, idata)
+        assert isinstance(result, xr.DataArray)
+        assert result.dims == ("chain", "draw", "y_dim_0")
+        assert result.shape == (2, 60, y_obs.size)
+        mu_draws = idata.posterior["mu"].values
+        sigma_draws = idata.posterior["sigma"].values
+        expected = norm.logpdf(y_obs[None, None, :], mu_draws[..., None], sigma_draws[..., None])
+        assert_allclose(result.values, expected, rtol=1e-6)
+
+    def test_plpd_point_estimate_values(self, normal_setup):
+        idata, model, y_obs = normal_setup
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        observed = idata.observed_data["y"]
+        means = idata.posterior.dataset.mean(dim=["chain", "draw"])
+        data_point = idata.copy()
+        data_point.posterior = xr.Dataset(means.data_vars)
+        result = log_lik_fn(observed, data_point)
+        assert result.dims == ("y_dim_0",)
+        expected = norm.logpdf(y_obs, means["mu"].item(), means["sigma"].item())
+        assert_allclose(result.values, expected, rtol=1e-6)
+
+    def test_loo_subsample_plpd_model_matches_manual(self, normal_setup):
+        idata, model, _ = normal_setup
+        observations = np.array([0, 3, 7, 9])
+        loo_model = loo_subsample(
+            idata,
+            observations=observations,
+            var_name="y",
+            method="plpd",
+            model=model,
+            pointwise=True,
+        )
+        loo_manual = loo_subsample(
+            idata,
+            observations=observations,
+            var_name="y",
+            method="plpd",
+            log_lik_fn=_manual_ll_fn,
+            pointwise=True,
+        )
+        assert_allclose(loo_model.elpd, loo_manual.elpd, rtol=1e-6)
+        assert_allclose(loo_model.se, loo_manual.se, rtol=1e-6)
+        assert_allclose(
+            loo_model.elpd_i.values[observations],
+            loo_manual.elpd_i.values[observations],
+            rtol=1e-6,
+        )
+
+    def test_loo_subsample_lpd_model_recomputes_approximation(self, normal_setup):
+        idata, model, y_obs = normal_setup
+        ramp = xr.DataArray(np.linspace(0.0, 4.0, y_obs.size), dims="y_dim_0")
+        idata_bad = idata.copy()
+        idata_bad["log_likelihood"] = idata.log_likelihood.dataset + ramp
+        observations = np.array([1, 4, 6, 10])
+        kwargs = {"observations": observations, "var_name": "y", "method": "lpd", "pointwise": True}
+        loo_model = loo_subsample(idata_bad, model=model, **kwargs)
+        loo_manual = loo_subsample(idata_bad, log_lik_fn=_manual_ll_fn, **kwargs)
+        loo_default = loo_subsample(idata_bad, **kwargs)
+        assert_allclose(
+            loo_model.elpd_loo_approx.values, loo_manual.elpd_loo_approx.values, rtol=1e-6
+        )
+        assert not np.allclose(loo_model.elpd_loo_approx.values, loo_default.elpd_loo_approx.values)
+
+    def test_update_subsample_with_model(self, normal_setup):
+        idata, model, _ = normal_setup
+        initial = loo_subsample(
+            idata,
+            observations=np.array([0, 2, 5]),
+            var_name="y",
+            method="plpd",
+            model=model,
+            pointwise=True,
+        )
+        updated = update_subsample(
+            initial,
+            idata,
+            observations=np.array([1, 8]),
+            method="plpd",
+            model=model,
+        )
+        assert updated.subsample_size == 5
+        assert np.isfinite(updated.elpd)
+        assert np.isfinite(updated.se)
+        assert np.sum(~np.isnan(updated.pareto_k.values)) == 5
+
+    def test_update_subsample_lpd_model_matches_manual(self, normal_setup):
+        idata, model, _ = normal_setup
+        initial = loo_subsample(
+            idata,
+            observations=np.array([0, 2, 5]),
+            var_name="y",
+            method="lpd",
+            model=model,
+            pointwise=True,
+        )
+        updated_model = update_subsample(
+            initial, idata, observations=np.array([1, 8]), method="lpd", model=model
+        )
+        updated_manual = update_subsample(
+            initial, idata, observations=np.array([1, 8]), method="lpd", log_lik_fn=_manual_ll_fn
+        )
+        assert updated_model.subsample_size == 5
+        assert_allclose(updated_model.elpd, updated_manual.elpd, rtol=1e-6)
+        assert_allclose(updated_model.se, updated_manual.se, rtol=1e-6)
+
+    def test_loo_subsample_model_log_false_raises(self, normal_setup):
+        idata, model, _ = normal_setup
+        with pytest.raises(ValueError, match="log must be True"):
+            loo_subsample(
+                idata,
+                observations=4,
+                var_name="y",
+                method="plpd",
+                model=model,
+                log=False,
+            )
+
+    def test_update_subsample_model_log_false_raises(self, normal_setup):
+        idata, model, _ = normal_setup
+        initial = loo_subsample(
+            idata,
+            observations=np.array([0, 2, 5]),
+            var_name="y",
+            method="plpd",
+            model=model,
+            pointwise=True,
+        )
+        with pytest.raises(ValueError, match="log must be True"):
+            update_subsample(
+                initial, idata, observations=np.array([1, 8]), method="plpd", model=model, log=False
+            )
+
+    def test_update_subsample_plpd_without_loglik_or_model_raises(self, normal_setup):
+        idata, model, _ = normal_setup
+        initial = loo_subsample(
+            idata,
+            observations=np.array([0, 2, 5]),
+            var_name="y",
+            method="plpd",
+            model=model,
+            pointwise=True,
+        )
+        with pytest.raises(ValueError, match="log_lik_fn or model must be provided"):
+            update_subsample(initial, idata, observations=np.array([1, 8]), method="plpd")
+
+    def test_missing_posterior_var_raises(self, normal_setup):
+        idata, model, _ = normal_setup
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        observed = idata.observed_data["y"]
+        data_missing = idata.copy()
+        data_missing.posterior = xr.Dataset({"mu": idata.posterior.dataset["mu"]})
+        with pytest.raises(KeyError, match="sigma"):
+            log_lik_fn(observed, data_missing)
+
+    def test_missing_posterior_var_with_shadowing_coord_raises(self, normal_setup):
+        idata, model, _ = normal_setup
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        observed = idata.observed_data["y"]
+        data_shadow = idata.copy()
+        data_shadow.posterior = xr.Dataset({"mu": idata.posterior.dataset["mu"]}).assign_coords(
+            sigma=("sigma_dim", [1.0, 2.0])
+        )
+        with pytest.raises(KeyError, match="sigma"):
+            log_lik_fn(observed, data_shadow)
+
+    @pytest.mark.parametrize(
+        "rv_name, var_name, match",
+        [
+            ("y", "not_a_var", "is not present in `idata.observed_data`"),
+            ("y_renamed", "y", "does not match any observed random variable"),
+        ],
+    )
+    def test_invalid_var_name_raises(self, normal_setup, rv_name, var_name, match):
+        idata, _, y_obs = normal_setup
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0, 5)
+            pm.Normal(rv_name, mu, 1.0, observed=y_obs)
+        with pytest.raises(ValueError, match=match):
+            ll_from_pymc(idata, model=model, var_name=var_name)
+
+    def test_discrete_free_rv_raises(self, normal_setup):
+        idata, _, _ = normal_setup
+        with pm.Model() as model:
+            p = pm.Poisson("p", mu=2.0)
+            pm.Normal("y", p, 1.0, observed=[1.0, 2.0, 3.0])
+        with pytest.raises(NotImplementedError, match="discrete"):
+            ll_from_pymc(idata, model=model, var_name="y")
+
+    def test_named_dims_transposed_posterior(self):
+        rng = np.random.default_rng(0)
+        y_obs = rng.normal(size=(3, 4))
+        coords = {"g": ["a", "b", "c"], "t": list(range(4))}
+        with pm.Model(coords=coords) as model:
+            mu = pm.Normal("mu", 0, 5, dims=("g", "t"))
+            pm.Normal("y", mu, 1.0, dims=("g", "t"), observed=y_obs)
+        mu_draws = rng.normal(size=(2, 10, 3, 4))
+        log_lik = norm.logpdf(y_obs[None, None], mu_draws, 1.0)
+        idata = azb.from_dict(
+            {
+                "posterior": {"mu": mu_draws},
+                "log_likelihood": {"y": log_lik},
+                "observed_data": {"y": y_obs},
+            },
+            dims={"mu": ["g", "t"], "y": ["g", "t"]},
+            coords=coords,
+        )
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        result = log_lik_fn(idata.observed_data["y"], idata)
+        assert result.dims == ("chain", "draw", "g", "t")
+        assert_allclose(result.values, log_lik, rtol=1e-6)
+        idata_t = idata.copy()
+        idata_t["posterior"] = idata.posterior.dataset.transpose("chain", "draw", "t", "g")
+        result_t = log_lik_fn(idata_t.observed_data["y"], idata_t)
+        assert_allclose(result_t.values, log_lik, rtol=1e-6)
+
+    def test_reduced_likelihood_raises(self):
+        rng = np.random.default_rng(0)
+        y_obs = np.array([12, 8, 5])
+        with pm.Model() as model:
+            theta = pm.Dirichlet("theta", a=np.ones(3))
+            pm.Multinomial("y", n=int(y_obs.sum()), p=theta, observed=y_obs)
+        theta_draws = rng.dirichlet(np.ones(3), size=(2, 40))
+        idata = azb.from_dict(
+            {
+                "posterior": {"theta": theta_draws},
+                "observed_data": {"y": y_obs},
+            }
+        )
+        log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
+        with pytest.raises(ValueError, match="does not match the observed data shape"):
+            log_lik_fn(idata.observed_data["y"], idata)

--- a/tests/loo/test_loo_subsample_helpers.py
+++ b/tests/loo/test_loo_subsample_helpers.py
@@ -195,6 +195,35 @@ class TestSubsampleLogLikFunctions:
                 initial, idata, observations=np.array([1, 8]), method="plpd", model=model, log=False
             )
 
+    @pytest.mark.parametrize("update", [False, True])
+    def test_log_lik_fn_takes_precedence_over_model(self, normal_setup, update):
+        idata, _, _ = normal_setup
+        kwargs = {
+            "observations": np.array([1, 8]),
+            "method": "plpd",
+            "log_lik_fn": _manual_ll_fn,
+            "model": object(),
+        }
+        if update:
+            initial = loo_subsample(
+                idata,
+                observations=np.array([0, 2, 5]),
+                var_name="y",
+                method="plpd",
+                log_lik_fn=_manual_ll_fn,
+                pointwise=True,
+            )
+        else:
+            kwargs.update({"var_name": "y", "pointwise": True})
+
+        with pytest.warns(UserWarning, match="Both `model` and `log_lik_fn` were provided"):
+            if update:
+                result = update_subsample(initial, idata, **kwargs)
+            else:
+                result = loo_subsample(idata, **kwargs)
+
+        assert np.isfinite(result.elpd)
+
     def test_update_subsample_plpd_without_loglik_or_model_raises(self, normal_setup):
         idata, model, _ = normal_setup
         initial = loo_subsample(

--- a/tests/loo/test_loo_subsample_helpers.py
+++ b/tests/loo/test_loo_subsample_helpers.py
@@ -1,6 +1,8 @@
 """Test sub-sampling helper functions for PyMC models."""
 
 # pylint: disable=no-self-use, redefined-outer-name
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -14,6 +16,15 @@ xr = importorskip("xarray")
 
 from arviz_stats import loo_subsample, update_subsample
 from arviz_stats.loo import ll_from_pymc
+from arviz_stats.loo.loo_helper import _get_r_eff
+
+
+def _sort_mu_recenter(data):
+    data = data.copy(deep=True)
+    post = data.posterior.dataset
+    sorted_mu = np.sort(post["mu"].values, axis=1)
+    data["posterior"] = post.assign(mu=(("chain", "draw"), sorted_mu))
+    return data
 
 
 def _build_normal_setup(*, n_chains=2, n_draws=60, n_obs=12, seed=0):
@@ -283,3 +294,80 @@ class TestSubsampleLogLikFunctions:
         log_lik_fn = ll_from_pymc(idata, model=model, var_name="y")
         with pytest.raises(ValueError, match="does not match the observed data shape"):
             log_lik_fn(idata.observed_data["y"], idata)
+
+    @pytest.mark.parametrize("update", [False, True])
+    def test_reff_uses_original_posterior(self, update):
+        idata, model, _ = _build_normal_setup(n_draws=800)
+        fake = SimpleNamespace(
+            _re_center_intercept=_sort_mu_recenter, backend=SimpleNamespace(model=model)
+        )
+        n_samples = idata.posterior.sizes["chain"] * idata.posterior.sizes["draw"]
+        reff_orig = _get_r_eff(idata, n_samples)
+        if update:
+            initial = loo_subsample(
+                idata,
+                observations=np.array([0, 2, 5]),
+                var_name="y",
+                method="plpd",
+                model=fake,
+                reff=reff_orig,
+                pointwise=True,
+            )
+            res_auto = update_subsample(
+                initial, idata, observations=np.array([1, 8]), method="plpd", model=fake
+            )
+            res_explicit = update_subsample(
+                initial,
+                idata,
+                observations=np.array([1, 8]),
+                method="plpd",
+                model=fake,
+                reff=reff_orig,
+            )
+        else:
+            kwargs = {
+                "observations": np.array([0, 3, 7, 9]),
+                "var_name": "y",
+                "method": "plpd",
+                "pointwise": True,
+            }
+            res_auto = loo_subsample(idata, model=fake, **kwargs)
+            res_explicit = loo_subsample(idata, model=fake, reff=reff_orig, **kwargs)
+        assert_allclose(res_auto.elpd, res_explicit.elpd)
+        assert_allclose(res_auto.se, res_explicit.se)
+
+    @pytest.mark.parametrize("update", [False, True])
+    @pytest.mark.parametrize("method", ["lpd", "plpd"])
+    def test_param_names_ignored_with_model(self, normal_setup, update, method):
+        idata, model, _ = normal_setup
+        if update:
+            initial = loo_subsample(
+                idata,
+                observations=np.array([0, 2, 5]),
+                var_name="y",
+                method=method,
+                model=model,
+                pointwise=True,
+            )
+            res_with = update_subsample(
+                initial,
+                idata,
+                observations=np.array([1, 8]),
+                method=method,
+                model=model,
+                param_names=["mu"],
+            )
+            res_without = update_subsample(
+                initial, idata, observations=np.array([1, 8]), method=method, model=model
+            )
+        else:
+            kwargs = {
+                "observations": np.array([0, 3, 7, 9]),
+                "var_name": "y",
+                "method": method,
+                "pointwise": True,
+            }
+            res_with = loo_subsample(idata, model=model, param_names=["mu"], **kwargs)
+            res_without = loo_subsample(idata, model=model, **kwargs)
+        assert_allclose(res_with.elpd, res_without.elpd)
+        assert_allclose(res_with.se, res_without.se)


### PR DESCRIPTION
Adds a `model` arg to `loo_subsample` and `update_subsample` that auto-builds the pointwise log-likelihood function from a PyMC or Bambi model via a new `ll_from_pymc` helper, so `method="plpd"` no longer requires hand-writing a `log_lik_fn` (for `method="lpd"` the model is optional and recomputes the approximation instead of using the stored log-likelihood values). 

Also added `pymc_helper.py` which has both the moment matching and subsampling shared PyMC helpers. We will probably be adding more automatic PyMC extraction for other methods in the future so I figured we should just have a central place for this.