### PR TITLE
Write the bandwidth into the kde gufunc output

### DIFF
--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -107,8 +107,8 @@ class NumbaArray(BaseArray):
             # pylint: disable=line-too-long, unused-argument
             @guvectorize(
                 [
-                    "void(float64[:],float64[:],boolean,UnicodeCharSeq(1),boolean,float64[:],float64[:],float64)",
-                    "void(float64[:],float64[:],boolean,float64,boolean,float64[:],float64[:],float64)",
+                    "void(float64[:],float64[:],boolean,UnicodeCharSeq(1),boolean,float64[:],float64[:],float64[:])",
+                    "void(float64[:],float64[:],boolean,float64,boolean,float64[:],float64[:],float64[:])",
                 ],
                 "(n),(m),(),(),()->(m),(m),()",
                 cache=True,
@@ -119,7 +119,7 @@ class NumbaArray(BaseArray):
             def kde_gufunc(a, grid_in, circular, bw, adaptive, grid, pdf, bw_out):
                 grid[:] = 0
                 pdf[:] = 0
-                bw_out = 0
+                bw_out[0] = 0
                 bw = {"t": "scott", "e": "experimental", "i": "isj", "s": "silverman"}.get(bw, bw)
                 grid_aux, pdf_aux, bw_aux = self.kde_linear(
                     a, bw=bw, adaptive=adaptive, grid_len=len(grid_in)
@@ -127,7 +127,7 @@ class NumbaArray(BaseArray):
                 for i in np.ndindex(grid.shape):
                     grid[i] = grid_aux[i]
                     pdf[i] = pdf_aux[i]
-                bw_out = bw_aux
+                bw_out[0] = bw_aux
 
             self._kde_ufunc = kde_gufunc
         return self._kde_ufunc

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -174,6 +174,17 @@ class TestNumbaArray:
         assert pdf.shape == (4, 256)
         assert bw.shape == (4,)
 
+    def test_kde_bw_matches_base(self, rng):
+        """The numba backend must return the same bandwidth as the base one."""
+        from arviz_stats.base.array import BaseArray
+
+        ary = rng.normal(size=(4, 100))
+        _, _, bw = NumbaArray().kde(ary, axis=-1, grid_len=256)  # pylint: disable=unpacking-non-sequence
+        _, _, expected_bw = BaseArray().kde(  # pylint: disable=unpacking-non-sequence
+            ary, axis=-1, grid_len=256
+        )
+        assert_allclose(bw, expected_bw)
+
     @pytest.mark.parametrize(
         "axis,expected_shape,expected_bw_shape",
         [


### PR DESCRIPTION
`kde_gufunc` writes its first two outputs into their buffers:

```python
grid[:] = 0
pdf[:] = 0
bw_out = 0
...
for i in np.ndindex(grid.shape):
    grid[i] = grid_aux[i]
    pdf[i] = pdf_aux[i]
bw_out = bw_aux
```

but `bw_out = bw_aux` only rebinds a local name, so the third output is never written. The bandwidth the ufunc returns is whatever the allocated array happened to hold:

```python
from arviz_stats.numba import array_stats as numba_stats
from arviz_stats.base import array_stats as base_stats

ary = rng.normal(size=(4, 500))
numba_stats.kde(ary, axis=-1)[2]
base_stats.kde(ary, axis=-1)[2]
```

```
numba bw : [-1.5994632609e+131 -5.9665110423e-097  8.7552390591e-151  1.5544144662e-095]
base  bw : [ 0.2994987638       0.2726243979       0.3016677283       0.3127839031]
```

It changes between runs, and it sometimes lands on a value that looks reasonable — through the accessor, with `rcParams["stats.module"] = "numba"`, it came out as exactly `0.0` against `0.21009862` from the base backend — so a wrong bandwidth will not always be obvious. `grid` and `pdf` are computed correctly; only `bw` is affected.

One detail worth flagging for review: writing `bw_out[0]` requires the output to be typed as an array. With the signatures unchanged, `bw_out[...] = bw_aux` raises

```
SystemError: <class 'slice'> returned a result with an exception set
```

because object mode hands the kernel a Python float for a scalar-typed output. So the two type signatures declare `float64[:]` for that argument; the layout signature `"(n),(m),(),(),()->(m),(m),()"` is unchanged. `bw_out[0] = 0` keeps the initialisation parallel with `grid[:] = 0` / `pdf[:] = 0`.

After the change the numba backend matches the base backend exactly, and is stable across runs.

Added `test_kde_bw_matches_base`. The existing `test_kde_basic` and `test_kde_axis` only assert `bw.shape`, never its value, which is why this went unnoticed. The new test fails on `main` and passes here; the full suite is `2720 passed, 4 skipped` both before and after.
