### PR TITLE
Respect ci_kind in summary for the stats and all kinds

### DIFF
--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -183,8 +183,9 @@ def summary(
             summary=["mean"]
         )
         std_value = dataset.std(dim=sample_dims, skipna=skipna).expand_dims(summary=["sd"])
+        ci_fun = dataset.azstats.eti if ci_kind == "eti" else dataset.azstats.hdi
         ci = (
-            dataset.azstats.eti(prob=ci_prob, dim=sample_dims, skipna=skipna)
+            ci_fun(prob=ci_prob, dim=sample_dims, skipna=skipna)
             .rename({"ci_bound": "summary"})
             .assign_coords(summary=[f"{ci_kind}{ci_perc}_lb", f"{ci_kind}{ci_perc}_ub"])
         )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -268,6 +268,23 @@ def test_summary_ci_kind(datatree, ci_kind):
     assert f"{ci_kind}89_ub" in summary_df.columns
 
 
+@pytest.mark.parametrize("ci_kind", ["hdi", "eti"])
+def test_summary_ci_kind_values(datatree, ci_kind):
+    """The reported interval must be the one named in the column."""
+    summary_df = summary(datatree, ci_kind=ci_kind, ci_prob=0.89, var_names=["mu"], round_to="none")
+    posterior = datatree.posterior.ds[["mu"]]
+    expected = getattr(posterior.azstats, ci_kind)(prob=0.89, dim=["chain", "draw"])
+
+    np.testing.assert_allclose(
+        summary_df[f"{ci_kind}89_lb"].to_numpy(),
+        np.asarray(expected["mu"]).ravel()[0],
+    )
+    np.testing.assert_allclose(
+        summary_df[f"{ci_kind}89_ub"].to_numpy(),
+        np.asarray(expected["mu"]).ravel()[1],
+    )
+
+
 @pytest.mark.parametrize("round_to", [0, 2, 4, "none"])
 def test_summary_round_to(datatree, round_to):
     summary_df = summary(datatree, round_to=round_to, var_names=["mu"])


### PR DESCRIPTION
`summary` validates `ci_kind`, resolves it from `rcParams`, and uses it to label the interval columns — but the `stats` / `all` branch always calls `eti`:

```python
if ci_kind not in ("hdi", "eti", None):          # line 137
    raise ValueError("ci_kind must be either 'hdi' or 'eti'")
...
if ci_kind is None:                              # line 157
    ci_kind = rcParams["stats.ci_kind"]
...
ci = (
    dataset.azstats.eti(prob=ci_prob, dim=sample_dims, skipna=skipna)     # always eti
    .rename({"ci_bound": "summary"})
    .assign_coords(summary=[f"{ci_kind}{ci_perc}_lb", f"{ci_kind}{ci_perc}_ub"])
)
```

So `summary(ci_kind="hdi")` returns equal-tailed values under `hdi..._lb` / `hdi..._ub` headers. On a skewed posterior:

```
ci_kind="eti"    eti89_lb 0.217856    eti89_ub 6.712953
ci_kind="hdi"    hdi89_lb 0.217856    hdi89_ub 6.712953     <- same numbers

accessor reference:
    eti  [0.217856, 6.712953]
    hdi  [0.005735, 5.174913]
```

With this change the `hdi` row returns `[0.005735, 5.174913]`, matching the accessor.

Scope:

- `ci_kind="eti"` is the `rcParams` default and is unchanged.
- The `stats_median` branch also calls `eti`, but labels it `eti`, which matches the documented behaviour that `ci_kind` is forced to `eti` for the median kinds — so I left it alone.
- Because `ci_kind` is validated at the top and `None` is resolved before this point, the branch can only pick `hdi` for a genuine `"hdi"`.

`test_summary_ci_kind` asserts the column names only, which is why this passed CI. The added test compares the reported values against the corresponding accessor for both kinds; the `hdi` case fails on `main` and the `eti` case passes either way. `tests/test_summary.py` is 81 passed.
