### PR TITLE
Monte Carlo calibrate uniformity_test p-values (#419)

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -778,7 +778,11 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             Method to use for the uniformity test.
             Valid options are pot_c (default), prit_c and piet_c.
         **kwargs
-            Additional keyword arguments.
+            Additional keyword arguments passed to the test function.
+            ``n_simulations`` (default 1000) sets how many null replications
+            are used to Monte Carlo calibrate the p-value (simulated once and
+            cached per sample size); pass 0 for the uncalibrated analytic
+            p-value, which is anti-conservative at conventional levels.
 
         Returns
         -------

--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -14,6 +14,8 @@ from scipy.stats import binom, hypergeom
 
 from arviz_stats.base.core import _CoreBase
 
+_UNIFORMITY_NULL_CACHE = {}
+
 
 class _DensityBase(_CoreBase):
     """Class with numpy+scipy only density related functions."""
@@ -843,8 +845,47 @@ class _DensityBase(_CoreBase):
 
         return (values / n) + ((harmonic_n - 1) / n) * (values - mean_others)
 
-    def _pot_c(self, ary):
-        """Pointwise Order-based Test with Cauchy combination (Beta-based tests)."""
+    def _calibrate_uniformity_pvalue(self, test_func, p_value, n, n_simulations):
+        """Calibrate an analytic Cauchy-combination p-value against the simulated null.
+
+        The Cauchy combination treats the combined statistic as standard
+        Cauchy, which is only guaranteed in the far tail; the combined terms
+        here (order statistics of one sample) are strongly dependent, so at
+        conventional levels the analytic p-value is anti-conservative
+        (roughly twice the nominal rejection rate at alpha = 0.05). The null
+        is fully known -- n i.i.d. uniforms -- so the analytic p-value is
+        re-ranked against ``n_simulations`` null p-values simulated through
+        the identical test, cached per (test, n, n_simulations) with a fixed
+        seed. Below the Monte Carlo resolution ``1 / (n_simulations + 1)``
+        the analytic value is kept: that is the far-tail regime where the
+        Cauchy combination is valid, and it preserves the gradation of
+        extreme p-values.
+        """
+        key = (test_func.__name__, n, n_simulations)
+        null = _UNIFORMITY_NULL_CACHE.get(key)
+        if null is None:
+            rng = np.random.default_rng(214)
+            null = np.empty(n_simulations)
+            for i in range(n_simulations):
+                try:
+                    null[i] = test_func(rng.uniform(size=n), n_simulations=0)[0]
+                except ValueError:
+                    # truncated combination with no pointwise p below 0.5
+                    null[i] = 0.5
+            null.sort()
+            _UNIFORMITY_NULL_CACHE[key] = null
+        n_at_or_below = int(np.searchsorted(null, p_value, side="right"))
+        if n_at_or_below == 0:
+            return min(p_value, 1.0 / (1.0 + n_simulations))
+        return (1.0 + n_at_or_below) / (1.0 + n_simulations)
+
+    def _pot_c(self, ary, n_simulations=1000):
+        """Pointwise Order-based Test with Cauchy combination (Beta-based tests).
+
+        The analytic p-value is Monte Carlo calibrated against the simulated
+        null (see ``_calibrate_uniformity_pvalue``); pass ``n_simulations=0``
+        for the uncalibrated analytic value.
+        """
         ary = ary[np.isfinite(ary)]
         n = len(ary)
 
@@ -860,6 +901,8 @@ class _DensityBase(_CoreBase):
         ps = 2 * np.minimum(probs, 1 - probs)
         cauchy_vals = np.tan((0.5 - ps) * np.pi)
         p_value = self._cauchy_combination(ps, cauchy_vals, truncate=True)
+        if n_simulations:
+            p_value = self._calibrate_uniformity_pvalue(self._pot_c, p_value, n, n_simulations)
 
         shapley_vals = self._shapley_mean(cauchy_vals)
 
@@ -868,8 +911,13 @@ class _DensityBase(_CoreBase):
 
         return p_value, shapley_vals, shapley_unsorted
 
-    def _prit_c(self, ary):
-        """Pointwise Rank-based Individual Test with Cauchy combination (Binomial-based tests)."""
+    def _prit_c(self, ary, n_simulations=1000):
+        """Pointwise Rank-based Individual Test with Cauchy combination (Binomial-based tests).
+
+        The analytic p-value is Monte Carlo calibrated against the simulated
+        null (see ``_calibrate_uniformity_pvalue``); pass ``n_simulations=0``
+        for the uncalibrated analytic value.
+        """
         ary = ary[np.isfinite(ary)]
         n = len(ary)
 
@@ -888,6 +936,8 @@ class _DensityBase(_CoreBase):
 
         cauchy_vals = np.tan((0.5 - ps) * np.pi)
         p_value = self._cauchy_combination(ps, cauchy_vals, truncate=True)
+        if n_simulations:
+            p_value = self._calibrate_uniformity_pvalue(self._prit_c, p_value, n, n_simulations)
         shapley_vals = self._shapley_mean(cauchy_vals)
 
         shapley_unsorted = np.empty_like(shapley_vals)
@@ -895,8 +945,13 @@ class _DensityBase(_CoreBase):
 
         return p_value, shapley_vals, shapley_unsorted
 
-    def _piet_c(self, ary):
-        """Pointwise Inverse-CDF Evaluation Tests Combination (Exp(1)-based tests)."""
+    def _piet_c(self, ary, n_simulations=1000):
+        """Pointwise Inverse-CDF Evaluation Tests Combination (Exp(1)-based tests).
+
+        The analytic p-value is Monte Carlo calibrated against the simulated
+        null (see ``_calibrate_uniformity_pvalue``); pass ``n_simulations=0``
+        for the uncalibrated analytic value.
+        """
         ary = ary[np.isfinite(ary)]
         n = len(ary)
 
@@ -909,6 +964,8 @@ class _DensityBase(_CoreBase):
         ps = 2 * np.minimum(pe, 1 - pe)
         cauchy_vals = np.tan((0.5 - ps) * np.pi)
         p_value = self._cauchy_combination(ps, cauchy_vals, truncate=False)
+        if n_simulations:
+            p_value = self._calibrate_uniformity_pvalue(self._piet_c, p_value, n, n_simulations)
         shapley_vals = self._shapley_mean(cauchy_vals)
 
         shapley_unsorted = np.empty_like(shapley_vals)

--- a/tests/test_uniformity.py
+++ b/tests/test_uniformity.py
@@ -95,7 +95,9 @@ class TestUniformityTestPotC:
         ps = 2*min(cdf, 1-cdf) = [0.38, 0.02] (both < 0.5 for truncation)
         """
         x = np.array([0.1, 0.9])
-        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(x, method="pot_c")
+        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(
+            x, method="pot_c", n_simulations=0
+        )
 
         x_sorted = np.sort(x)
         n = len(x)
@@ -148,7 +150,9 @@ class TestUniformityTestPritC:
         Test binomial probabilities to ensure some ps < 0.5 for truncation.
         """
         x = np.array([0.1, 0.9])
-        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(x, method="prit_c")
+        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(
+            x, method="prit_c", n_simulations=0
+        )
 
         x_sorted = np.sort(x)
         len_x = len(x_sorted)
@@ -192,7 +196,9 @@ class TestUniformityTestPietC:
     def test_basic_values(self):
         """pe = expon.cdf(-log(x)), ps = 2*min(pe, 1-pe), then Cauchy combination."""
         x = np.array([0.1, 0.25, 0.5, 0.75, 0.9])
-        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(x, method="piet_c")
+        p_value, shapley, shapley_unsorted = array_stats.uniformity_test(
+            x, method="piet_c", n_simulations=0
+        )
 
         pe = expon.cdf(-np.log(x))
         ps = 2 * np.minimum(pe, 1 - pe)
@@ -275,7 +281,7 @@ class TestUniformityTestGeneral:
     def test_all_pointwise_ps_above_half(self, method):
         """An evenly spaced grid makes every pointwise p-value >= 0.5."""
         grid = (np.arange(300) + 0.5) / 300
-        p_value, *_ = array_stats.uniformity_test(grid, method=method)
+        p_value, *_ = array_stats.uniformity_test(grid, method=method, n_simulations=0)
         assert_allclose(p_value, 0.5, atol=1e-10)
 
     @pytest.mark.parametrize("method", ["pot_c", "prit_c"])
@@ -283,7 +289,7 @@ class TestUniformityTestGeneral:
         """One all-ps-above-half row must not abort a batched call."""
         rng = np.random.default_rng(0)
         x = np.vstack([rng.uniform(size=(3, 300)), (np.arange(300) + 0.5) / 300])
-        p_value, *_ = array_stats.uniformity_test(x, axis=-1, method=method)
+        p_value, *_ = array_stats.uniformity_test(x, axis=-1, method=method, n_simulations=0)
         assert p_value.shape == (4,)
         assert_allclose(p_value[-1], 0.5, atol=1e-10)
 
@@ -295,6 +301,33 @@ class TestUniformityTestGeneral:
         p_values, *_ = array_stats.uniformity_test(x, axis=-1, method=method)
         attained_size = np.mean(p_values < 0.05)
         assert 0.03 < attained_size < 0.08
+
+
+class TestUniformityCalibration:
+    """Monte Carlo calibration of the Cauchy-combination p-values (see #419)."""
+
+    @pytest.mark.parametrize("method", ["pot_c", "prit_c", "piet_c"])
+    def test_null_rejection_rate_larger_n(self, method):
+        """Attained size stays near nominal at sample sizes where the analytic
+        p-value rejects roughly twice the nominal rate."""
+        rng = np.random.default_rng(42)
+        x = rng.uniform(size=(2_000, 400))
+        p_values, *_ = array_stats.uniformity_test(x, axis=-1, method=method)
+        attained_size = np.mean(p_values < 0.05)
+        assert 0.03 < attained_size < 0.07
+
+    def test_far_tail_gradation_kept(self):
+        """Extreme evidence keeps the analytic value below the MC resolution."""
+        rng = np.random.default_rng(0)
+        p_value, *_ = array_stats.uniformity_test(rng.beta(0.5, 0.5, size=500))
+        assert p_value < 1e-6
+
+    def test_opt_out_returns_analytic(self):
+        rng = np.random.default_rng(3)
+        x = rng.uniform(size=100)
+        p_calibrated, *_ = array_stats.uniformity_test(x)
+        p_analytic, *_ = array_stats.uniformity_test(x, n_simulations=0)
+        assert p_calibrated != p_analytic
 
 
 class TestMchainUniformity:


### PR DESCRIPTION
Closes #419.

The Cauchy combination is only guaranteed in the far tail, and the pointwise terms it combines here are strongly dependent. As a result the analytic p-value rejects about twice the nominal rate at alpha = 0.05 (measurements in #419).

Since the null is fully known, `pot_c`, `prit_c` and `piet_c` now re-rank their analytic p-value against 1000 simulated null p-values, computed once and cached per test and sample size.

* Attained size is now close to nominal. A new test checks it for all three methods.
* Extreme p-values keep the analytic value, so far tail gradation is preserved.
* `n_simulations=0` gives the previous behavior. Shapley contributions are unchanged.
* `_mtc_c` is left for a follow-up.

Draft to discuss the default behavior and the number of simulations.