### PR TITLE
Fix `p_loo` calculation in sub-sampled PSIS-LOO-CV

### DIFF
--- a/src/arviz_stats/loo/loo_subsample.py
+++ b/src/arviz_stats/loo/loo_subsample.py
@@ -235,6 +235,11 @@ def loo_subsample(
     lpd_approx_sample = _select_obs_by_indices(
         lpd_approx_all, subsample_data.indices, loo_inputs.obs_dims, "__obs__"
     )
+    lpd_sample = logsumexp(
+        subsample_data.log_likelihood_sample,
+        dims=loo_inputs.sample_dims,
+        b=1 / loo_inputs.n_samples,
+    )
 
     sample_ds = xr.Dataset({loo_inputs.var_name: subsample_data.log_likelihood_sample})
 
@@ -285,6 +290,7 @@ def loo_subsample(
             jacobian_da, subsample_data.indices, loo_inputs.obs_dims, "__obs__"
         )
         elpd_loo_i = elpd_loo_i + jacobian_sample
+        lpd_sample = lpd_sample + jacobian_sample
 
     warn_mg, good_k = _warn_pareto_k(pareto_k_sample_da, loo_inputs.n_samples)
 
@@ -296,7 +302,7 @@ def loo_subsample(
 
     # Calculate p_loo using SRS estimation directly on the p_loo values
     # from the subsample
-    p_loo_sample = lpd_approx_sample - elpd_loo_i
+    p_loo_sample = lpd_sample - elpd_loo_i
     p_loo, _, _ = p_loo_sample.azstats.srs_estimator(
         n_data_points=loo_inputs.n_data_points,
     )
@@ -607,6 +613,7 @@ def update_subsample(
     combined_pareto_k_da = xr.concat(
         [update_data.old_pareto_k, pareto_k_new_da], dim=update_data.concat_dim
     )
+    combined_indices = np.concatenate((update_data.old_indices, update_data.new_indices))
 
     good_k = loo_orig.good_k
     warn_mg, _ = _warn_pareto_k(combined_pareto_k_da, loo_inputs.n_samples)
@@ -623,12 +630,25 @@ def update_subsample(
 
     # Calculate p_loo using SRS estimation directly on the p_loo values
     # from the subsample
-    p_loo_sample = lpd_approx_sample_da - combined_elpd_i_da
+    log_likelihood_sample_da = _select_obs_by_indices(
+        loo_inputs.log_likelihood, combined_indices, loo_inputs.obs_dims, "__obs__"
+    )
+    lpd_sample_da = logsumexp(
+        log_likelihood_sample_da,
+        dims=loo_inputs.sample_dims,
+        b=1 / loo_inputs.n_samples,
+    )
+    if jacobian_da is not None:
+        jacobian_sample_da = _select_obs_by_indices(
+            jacobian_da, combined_indices, loo_inputs.obs_dims, "__obs__"
+        )
+        lpd_sample_da = lpd_sample_da + jacobian_sample_da
+
+    p_loo_sample = lpd_sample_da - combined_elpd_i_da
     p_loo, _, _ = p_loo_sample.azstats.srs_estimator(
         n_data_points=loo_inputs.n_data_points,
     )
 
-    combined_indices = np.concatenate((update_data.old_indices, update_data.new_indices))
     elpd_i_full, pareto_k_full = _prepare_full_arrays(
         combined_elpd_i_da,
         combined_pareto_k_da,

--- a/tests/loo/test_loo_subsample.py
+++ b/tests/loo/test_loo_subsample.py
@@ -11,7 +11,7 @@ azb = importorskip("arviz_base")
 xr = importorskip("xarray")
 sp = importorskip("scipy")
 
-from arviz_stats import loo_subsample, update_subsample
+from arviz_stats import loo, loo_subsample, update_subsample
 from arviz_stats.utils import ELPDData
 
 
@@ -221,8 +221,6 @@ def test_log_weights_storage_subsample(centered_eight_with_sigma):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_log_weights_input_formats_subsample(centered_eight_with_sigma):
-    from arviz_stats import loo
-
     loo_result = loo(centered_eight_with_sigma, pointwise=True)
     loo_sub_elpddata = loo_subsample(
         centered_eight_with_sigma,
@@ -307,26 +305,26 @@ def test_update_subsample_size_increases(centered_eight_with_sigma):
     assert initial.subsample_size == 2
 
 
-def test_loo_subsample_methods_differ(centered_eight_with_sigma):
+def test_loo_subsample_p_loo_independent_of_approximation(centered_eight_with_sigma):
+    observations = np.array([1, 3, 5])
     result_lpd = loo_subsample(
         centered_eight_with_sigma,
-        observations=4,
+        observations=observations,
         method="lpd",
         var_name="obs",
-        seed=42,
         pointwise=True,
     )
     result_plpd = loo_subsample(
         centered_eight_with_sigma,
-        observations=4,
+        observations=observations,
         method="plpd",
         var_name="obs",
         log_lik_fn=log_lik_fn_subsample,
         param_names=["theta"],
-        seed=42,
         pointwise=True,
     )
     assert result_lpd.elpd != result_plpd.elpd
+    assert_allclose(result_lpd.p, result_plpd.p)
 
 
 def test_loo_subsample_observations_as_array(centered_eight_with_sigma):
@@ -451,9 +449,21 @@ def test_loo_subsample_all_observations(centered_eight_with_sigma):
         seed=42,
         pointwise=True,
     )
+    result_plpd = loo_subsample(
+        centered_eight_with_sigma,
+        observations=np.arange(n_obs),
+        var_name="obs",
+        method="plpd",
+        log_lik_fn=log_lik_fn_subsample,
+        param_names=["theta"],
+        pointwise=True,
+    )
+    result_full = loo(centered_eight_with_sigma, var_name="obs")
+
     assert result.subsample_size == n_obs
     assert np.sum(~np.isnan(result.elpd_i.values)) == n_obs
     assert result.subsampling_se == 0.0
+    assert_allclose(result_plpd.p, result_full.p)
 
 
 def test_loo_subsample_seed_reproducibility(centered_eight_with_sigma):
@@ -589,29 +599,45 @@ def test_update_subsample_observations_zero(centered_eight_with_sigma):
     assert updated.subsample_size == initial.subsample_size
 
 
-def test_update_subsample_plpd_method(centered_eight_with_sigma):
-    initial = loo_subsample(
+def test_update_subsample_p_loo_independent_of_approximation(centered_eight_with_sigma):
+    initial_observations = np.array([0, 2, 4])
+    new_observations = np.array([1, 3])
+    initial_lpd = loo_subsample(
         centered_eight_with_sigma,
-        observations=3,
+        observations=initial_observations,
+        var_name="obs",
+        method="lpd",
+        pointwise=True,
+    )
+    initial_plpd = loo_subsample(
+        centered_eight_with_sigma,
+        observations=initial_observations,
         var_name="obs",
         method="plpd",
         log_lik_fn=log_lik_fn_subsample,
         param_names=["theta"],
-        seed=42,
+        pointwise=True,
     )
-    updated = update_subsample(
-        initial,
+    updated_lpd = update_subsample(
+        initial_lpd,
         centered_eight_with_sigma,
-        observations=2,
+        observations=new_observations,
+        var_name="obs",
+        method="lpd",
+    )
+    updated_plpd = update_subsample(
+        initial_plpd,
+        centered_eight_with_sigma,
+        observations=new_observations,
         var_name="obs",
         method="plpd",
         log_lik_fn=log_lik_fn_subsample,
         param_names=["theta"],
-        seed=43,
     )
-    assert updated.subsample_size == 5
-    assert isinstance(updated, ELPDData)
-    assert np.isfinite(updated.elpd)
+    assert updated_plpd.subsample_size == 5
+    assert isinstance(updated_plpd, ELPDData)
+    assert np.isfinite(updated_plpd.elpd)
+    assert_allclose(updated_lpd.p, updated_plpd.p)
 
 
 def test_update_subsample_without_pointwise_raises(centered_eight_with_sigma):
@@ -720,6 +746,7 @@ def test_loo_subsample_jacobian(centered_eight_with_sigma, method):
     loo_with_jac = loo_subsample(centered_eight, **loo_kwargs, log_jacobian=log_jacobian)
 
     assert loo_with_jac.elpd != loo_no_jac.elpd
+    assert_allclose(loo_with_jac.p, loo_no_jac.p)
     assert loo_with_jac.elpd_i is not None
     assert loo_no_jac.elpd_i is not None
 
@@ -745,7 +772,8 @@ def test_loo_subsample_jacobian(centered_eight_with_sigma, method):
     assert loo_no_pointwise.elpd != loo_no_jac.elpd
 
 
-def test_update_subsample_jacobian(centered_eight_with_sigma):
+@pytest.mark.parametrize("method", ["lpd", "plpd"])
+def test_update_subsample_jacobian(centered_eight_with_sigma, method):
     centered_eight = centered_eight_with_sigma
 
     y_obs = centered_eight.observed_data["obs"].values
@@ -757,8 +785,18 @@ def test_update_subsample_jacobian(centered_eight_with_sigma):
         coords={"school": centered_eight.observed_data["obs"].coords["school"]},
     )
 
+    method_log_lik_fn = log_lik_fn_subsample if method == "plpd" else None
+    method_param_names = ["theta"] if method == "plpd" else None
+
     initial_loo_no_jac = loo_subsample(
-        centered_eight, observations=3, var_name="obs", pointwise=True, seed=42
+        centered_eight,
+        observations=3,
+        var_name="obs",
+        pointwise=True,
+        method=method,
+        log_lik_fn=method_log_lik_fn,
+        param_names=method_param_names,
+        seed=42,
     )
 
     initial_loo_with_jac = loo_subsample(
@@ -766,19 +804,37 @@ def test_update_subsample_jacobian(centered_eight_with_sigma):
         observations=3,
         var_name="obs",
         pointwise=True,
+        method=method,
+        log_lik_fn=method_log_lik_fn,
+        param_names=method_param_names,
         seed=42,
         log_jacobian=log_jacobian,
     )
 
     updated_no_jac = update_subsample(
-        initial_loo_no_jac, centered_eight, observations=2, var_name="obs", seed=43
+        initial_loo_no_jac,
+        centered_eight,
+        observations=2,
+        var_name="obs",
+        method=method,
+        log_lik_fn=method_log_lik_fn,
+        param_names=method_param_names,
+        seed=43,
     )
 
     updated_with_jac = update_subsample(
-        initial_loo_with_jac, centered_eight, observations=2, var_name="obs", seed=43
+        initial_loo_with_jac,
+        centered_eight,
+        observations=2,
+        var_name="obs",
+        method=method,
+        log_lik_fn=method_log_lik_fn,
+        param_names=method_param_names,
+        seed=43,
     )
 
     assert updated_with_jac.elpd != updated_no_jac.elpd
+    assert_allclose(updated_with_jac.p, updated_no_jac.p)
     assert updated_with_jac.subsample_size == 5
     assert updated_no_jac.subsample_size == 5
     assert updated_with_jac.elpd_i is not None


### PR DESCRIPTION
Fixes `p_loo` computation in `loo_subsample()` and `update_subsample()`.

Previously, `method="plpd"` used PLPD when calculating `p_loo`, but PLPD should only be used for the subsampled ELPD estimate. `p_loo` should always use ordinary LPD from the posterior log-likelihood draws. This matches the `loo` package, which [computes pointwise `p_loo` from ordinary LPD](https://github.com/stan-dev/loo/blob/v2.10.1/R/loo.R#L427-L438) and then [uses those pointwise values in the subsampling estimator](https://github.com/stan-dev/loo/blob/v2.10.1/R/loo_subsample.R#L1153-L1164).

The differences in `p_loo` using PLPD vs LPD are pretty minor, but we should be using the correct formulation regardless.

---
Reminder to myself to rerun the subsampling EABM chapter for this to correct the `p_loo` values https://github.com/arviz-devs/EABM/pull/222.