### PR TITLE
Fix rounding of `subsampling_dse` in `compare()`

### DIFF
--- a/src/arviz_stats/loo/compare.py
+++ b/src/arviz_stats/loo/compare.py
@@ -69,7 +69,8 @@ def compare(
 
         * ``elpd`` and ``elpd_diff`` are rounded based on ``se`` and ``dse`` respectively,
             using the same rule as ``summary`` stat/se pairs.
-        * ``se`` and ``dse`` are rounded based on ``rcParams["stats.round_to"]``.
+        * ``se``, ``dse`` and ``subsampling_dse`` are rounded based on
+          ``rcParams["stats.round_to"]``.
         * ``p`` is rounded to 1 decimal place.
         * ``weight`` uses precision based on the largest weight, showing approximately 2
           significant digits for that maximum value.
@@ -380,6 +381,8 @@ def compare(
     else:
         if round_to not in ("None", "none"):
             cols_to_round = ["elpd", "p", "elpd_diff", "weight", "se", "dse", prob_direction]
+            if "subsampling_dse" in result.columns:
+                cols_to_round.append("subsampling_dse")
             result[cols_to_round] = result[cols_to_round].map(lambda x: round_num(x, round_val))
 
     model_order = list(ics.index)
@@ -722,6 +725,11 @@ def _round_compare(result, round_val, prob_direction):
 
             decimal_places = get_decimal_places_from_se(se_val)
             result.loc[idx, stat_col] = round_num(stat_val, decimal_places)
+
+    if "subsampling_dse" in result.columns:
+        result["subsampling_dse"] = result["subsampling_dse"].apply(
+            lambda x: round_num(x, round_val)
+        )
 
     if "p" in result.columns:
         result["p"] = result["p"].apply(lambda x: round_num(x, 1))

--- a/tests/loo/test_compare.py
+++ b/tests/loo/test_compare.py
@@ -206,9 +206,10 @@ def test_compare_subsampled(centered_eight_with_sigma, centered_eight):
     assert np.isfinite(comparison_updated["subsampling_dse"].values).all()
 
     with pytest.warns(UserWarning, match="Different subsamples used in 'model_a' and 'model_b'"):
-        comparison_diff_subsample = compare({"model_a": loo_sub1, "model_b": loo_sub3})
+        comparison_diff_subsample = compare({"model_a": loo_sub1, "model_b": loo_sub3}, round_to=1)
     assert "subsampling_dse" in comparison_diff_subsample.columns
     assert np.isfinite(comparison_diff_subsample["subsampling_dse"].values).all()
+    assert_allclose(comparison_diff_subsample["subsampling_dse"].to_numpy(), [0.0, 0.4])
 
     comparison_regular = compare({"model1": loo_full, "model2": loo_full})
     assert "subsampling_dse" not in comparison_regular.columns
@@ -511,6 +512,7 @@ def test_round_auto():
             "rank": [0, 1, 2],
             "elpd_diff": [0.0, -0.031, -1.5],
             "dse": [0.0, 0.061, 0.0],
+            "subsampling_dse": [0.0, 0.369184, 0.072078],
             "p_worse": [0.9123, 0.9123, 0.0001],
             "diag_diff": ["", "", "N < 100"],
             "diag_elpd": ["", "", ""],
@@ -526,6 +528,7 @@ def test_round_auto():
 
     assert_allclose(result["elpd_diff"].to_numpy(), np.array([0.0, 0.0, -2]))
     assert_allclose(result["dse"].to_numpy(), np.array([0.0, 0.06, 0.0]))
+    assert_allclose(result["subsampling_dse"].to_numpy(), np.array([0.0, 0.37, 0.07]))
     assert_allclose(result["p_worse"].to_numpy(), np.array([0.91, 0.91, 0.0]))
     assert (result["diag_diff"] == ["", "", "N < 100"]).all()
     assert (result["diag_elpd"] == ["", "", ""]).all()


### PR DESCRIPTION
Fixes rounding of `subsampling_dse` in `compare()`. `subsampling_dse` now respects both explicit `round_to` values and automatic rounding, consistent with `se` and `dse`.