### PR TITLE
Honour circular in the numba kde

### DIFF
--- a/src/arviz_stats/numba/array.py
+++ b/src/arviz_stats/numba/array.py
@@ -120,10 +120,19 @@ class NumbaArray(BaseArray):
                 grid[:] = 0
                 pdf[:] = 0
                 bw_out[0] = 0
-                bw = {"t": "scott", "e": "experimental", "i": "isj", "s": "silverman"}.get(bw, bw)
-                grid_aux, pdf_aux, bw_aux = self.kde_linear(
-                    a, bw=bw, adaptive=adaptive, grid_len=len(grid_in)
-                )
+                bw = {
+                    "t": "scott",
+                    "e": "experimental",
+                    "i": "isj",
+                    "s": "silverman",
+                    "y": "taylor",
+                }.get(bw, bw)
+                if circular:
+                    grid_aux, pdf_aux, bw_aux = self.kde_circular(a, bw=bw, grid_len=len(grid_in))
+                else:
+                    grid_aux, pdf_aux, bw_aux = self.kde_linear(
+                        a, bw=bw, adaptive=adaptive, grid_len=len(grid_in)
+                    )
                 for i in np.ndindex(grid.shape):
                     grid[i] = grid_aux[i]
                     pdf[i] = pdf_aux[i]
@@ -161,8 +170,14 @@ class NumbaArray(BaseArray):
             kwargs["axes"] = [(-1,), (0,), (), (), ()]
         else:
             ary = ary.ravel()
-        bw = kwargs.get("bw", "experimental")
-        bw = {"scott": "t", "experimental": "e", "isj": "i", "silverman": "s"}.get(bw, bw)
+        bw = kwargs.get("bw", "taylor" if circular else "experimental")
+        bw = {
+            "scott": "t",
+            "experimental": "e",
+            "isj": "i",
+            "silverman": "s",
+            "taylor": "y",
+        }.get(bw, bw)
         adaptive = kwargs.get("adaptive", False)
 
         return self.kde_ufunc(ary, np.empty(grid_len), circular, bw, adaptive)

--- a/tests/numba/test_array.py
+++ b/tests/numba/test_array.py
@@ -207,6 +207,28 @@ class TestNumbaArray:
         assert pdf.shape == expected_shape
         assert bw.shape == expected_bw_shape
 
+    def test_kde_circular_matches_base(self, rng):
+        """The numba backend must honour ``circular``, like the base one does."""
+        from arviz_stats.base.array import BaseArray
+
+        ary = rng.vonmises(0.0, 2.0, size=(4, 100))
+
+        grid, pdf, bw = NumbaArray().kde(  # pylint: disable=unpacking-non-sequence
+            ary, axis=-1, circular=True, grid_len=256
+        )
+        e_grid, e_pdf, e_bw = BaseArray().kde(  # pylint: disable=unpacking-non-sequence
+            ary, axis=-1, circular=True, grid_len=256
+        )
+        assert_allclose(grid, e_grid)
+        assert_allclose(pdf, e_pdf)
+        assert_allclose(bw, e_bw)
+
+        # and the circular estimate must not silently be the linear one
+        _, linear_pdf, _ = NumbaArray().kde(  # pylint: disable=unpacking-non-sequence
+            ary, axis=-1, circular=False, grid_len=256
+        )
+        assert not np.allclose(pdf, linear_pdf)
+
     def test_kde_ufunc_caching(self):
         array_stats = NumbaArray()
         assert array_stats._kde_ufunc is None


### PR DESCRIPTION
### What this fixes

`NumbaArray.kde` accepts `circular`, documents it ("Whether the data is circular (e.g., angles)"), and passes it into the guvectorized kernel — but the kernel never reads it and always calls `kde_linear`:

```python
def kde_gufunc(a, grid_in, circular, bw, adaptive, grid, pdf, bw_out):
    ...
    grid_aux, pdf_aux, bw_aux = self.kde_linear(
        a, bw=bw, adaptive=adaptive, grid_len=len(grid_in)
    )
```

The base backend dispatches on the flag in `_kde`, so the two backends disagree: switching to numba for speed silently turns a circular KDE into a linear one.

### Evidence

Angles clustered either side of the -pi/+pi wrap point, where the two estimators differ most:

| backend | `circular=True` bw | `circular=False` bw | flag has an effect |
|---|---|---|---|
| base | 83.7330 (Taylor) | 0.3910 | yes |
| numba (before) | 0.3910 | 0.3910 | **no — output byte-identical** |
| numba (after) | 83.7330 | 0.3910 | yes |

After the change the numba backend matches the base backend exactly on grid, pdf and bandwidth, for `circular=True` and for every bandwidth rule on the linear path (`scott`, `silverman`, `isj`, `experimental`).

### Notes on the change

- `kde_circular` defaults to `"taylor"`, so the default bandwidth rule now follows the flag the way the base backend's does.
- Bandwidth names cross the ufunc boundary as single characters (`UnicodeCharSeq(1)`), so `"taylor"` needed a code of its own — `"t"` was already taken by `"scott"`.
- `adaptive` is forwarded only on the linear path, since `kde_circular` does not accept it. The linear path is otherwise untouched.
- `circular="degrees"` still raises `TypeError` here, exactly as it did before: the kernel signature types the flag as `boolean`, so the string cannot cross it. That is a loud failure rather than a wrong number, so I have left it out of this change rather than widen the scope — happy to follow up separately if you'd like it supported.

### Testing

Added `test_kde_circular_matches_base`, following the existing `test_kde_bw_matches_base` pattern: it asserts grid, pdf and bandwidth match the base backend, and that the circular estimate is not silently the linear one.

- without the fix: fails, 1024/1024 elements mismatched
- with the fix: passes
- `tests/numba` and `tests/base`: 1720 passed, 2 skipped
