### PR TITLE
Correct the BaseArray summary statistic docstrings

### DIFF
--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -981,16 +981,16 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the mean.
-        axis : int, sequence of int or None, default -1
-            Axis or axes along which to compute the mean.
+        axis : int, sequence of int or None, default None
+            Axis or axes along which to compute the mean. If None, reduce over all axes.
 
         Returns
         -------
@@ -1012,16 +1012,16 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the median.
-        axis : int, sequence of int or None, default -1
-            Axis or axes along which to compute the median.
+        axis : int, sequence of int or None, default None
+            Axis or axes along which to compute the median. If None, reduce over all axes.
 
         Returns
         -------
@@ -1043,16 +1043,16 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the mode.
-        axis : int, sequence of int or None, default -1
-            Axis or axes along which to compute the mode.
+        axis : int, sequence of int or None, default None
+            Axis or axes along which to compute the mode. If None, reduce over all axes.
 
         Returns
         -------
@@ -1074,16 +1074,17 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the standard deviation.
-        axis : int, sequence of int or None, default -1
+        axis : int, sequence of int or None, default None
             Axis or axes along which to compute the standard deviation.
+            If None, reduce over all axes.
 
         Returns
         -------
@@ -1105,16 +1106,16 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the variance.
-        axis : int, sequence of int or None, default -1
-            Axis or axes along which to compute the variance.
+        axis : int, sequence of int or None, default None
+            Axis or axes along which to compute the variance. If None, reduce over all axes.
 
         Returns
         -------
@@ -1136,16 +1137,17 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the mean absolute deviation.
-        axis : int, sequence of int or None, default -1
+        axis : int, sequence of int or None, default None
             Axis or axes along which to compute the mean absolute deviation.
+            If None, reduce over all axes.
 
         Returns
         -------
@@ -1167,18 +1169,19 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
 
         Parameters
         ----------
-        values : array-like
+        ary : array-like
             Input array.
         quantiles : tuple of float, default (0.25, 0.75)
             Quantiles to compute the interquartile range.
         round_to : int or str, optional
             If integer, number of decimal places to round the result. If string of the
-            form '2g' number of significant digits to round the result. Defaults to '2g'.
-            Use None to return raw numbers.
+            form '2g' number of significant digits to round the result. Defaults to
+            None, which returns raw numbers.
         skipna : bool, default False
             Whether to ignore NaN values when computing the interquantile range.
-        axis : int, sequence of int or None, default -1
+        axis : int, sequence of int or None, default None
             Axis or axes along which to compute the interquantile range.
+            If None, reduce over all axes.
 
         Returns
         -------


### PR DESCRIPTION
### What this fixes

The docstrings for the `BaseArray` summary statistics — `mean`, `median`, `mode`, `std`, `var`, `mad` and `iqr` — disagree with their signatures in three ways:

| documented | actual signature |
|---|---|
| `values : array-like` | the parameter is `ary` |
| `round_to` — "Defaults to `'2g'`" | `round_to=None`, result comes back unrounded |
| `axis : ... default -1` | `axis=None`, which `process_ary_axes` expands to every axis |

The `axis` one is the one that actually misleads. With a `(2, 3, 4)` array:

```python
>>> array_stats.mean(ary)            # documented as axis=-1
array(11.5)                          # shape ()
>>> array_stats.mean(ary, axis=-1)
                                     # shape (2, 3)
```

A reader following the docstring would expect a per-row reduction and instead gets a single scalar over the whole array.

And for `round_to`:

```python
>>> array_stats.mean(np.array([1.23456789, 2.0]))
array(1.61728395)                    # documented as if '2g' were the default
>>> array_stats.mean(np.array([1.23456789, 2.0]), round_to='2g')
array(1.6)
```

### Scope

Docs only — no behaviour is changed. `axis=None` meaning "all axes" matches numpy's own convention and is clearly deliberate, so the code is left as it is and the documentation is corrected to match.

Worth noting explicitly: the other nine `axis : ... default -1` docstrings in this module (`hdi`, `psislw`, `power_scale_lw`, `compute_ranks`, `get_bins`, `histogram`, `kde`, `ecdf`, `uniformity_test`) are **correct** — those functions really do default to `-1`. Only the seven summary statistics above are touched. I verified all 17 `axis` docstrings in the module against their signatures afterwards; there are no remaining mismatches in either direction.

`loo_pit` was also checked and needs nothing: its `pit_values` is a return name, not a parameter.

### Testing

- `tests/base`: 1627 passed, 2 skipped
- `ruff check` and `ruff format --check` clean
