### PR TITLE
Fix custom limits for circular KDE

### DIFF
--- a/src/arviz_stats/base/density.py
+++ b/src/arviz_stats/base/density.py
@@ -643,7 +643,7 @@ class _DensityBase(_CoreBase):
 
         # Determine grid
         if custom_lims is not None:
-            custom_lims = self._check_custom_lims(custom_lims, x.min(), x.max())
+            custom_lims = self.check_custom_lims(custom_lims, x.min(), x.max())
             grid_min = custom_lims[0]
             grid_max = custom_lims[1]
             assert grid_min >= -np.pi, "Lower limit can't be smaller than -pi"

--- a/tests/base/test_density.py
+++ b/tests/base/test_density.py
@@ -405,6 +405,13 @@ class TestKDECircular:
         integral = np.sum(pdf * dx)
         assert_allclose(integral, 1.0, rtol=0.01)
 
+    def test_kde_circular_custom_lims(self, density, rng):
+        x = rng.uniform(-1, 1, size=100)
+        custom_lims = [-1.5, 1.5]
+        grid, _, _ = density.kde_circular(x, custom_lims=custom_lims)
+        assert grid.min() >= custom_lims[0]
+        assert grid.max() <= custom_lims[1]
+
     def test_kde_circular_cumulative(self, density, rng):
         x = rng.vonmises(0, 2, 100)
         _, pdf, _ = density.kde_circular(x, cumulative=True)


### PR DESCRIPTION
Fix circular KDE with `custom_lims` raising `AttributeError` by calling the correctly named validation method