### PR TITLE
Fix Kaplan–Meier estimates for integer event times

### DIFF
--- a/src/arviz_stats/survival.py
+++ b/src/arviz_stats/survival.py
@@ -61,7 +61,7 @@ def kaplan_meier(
 
         current_prob = 1.0
         unique_times = np.unique(sorted_times)
-        survival_probs = np.empty_like(unique_times)
+        survival_probs = np.empty_like(unique_times, dtype=float)
         for i, t in enumerate(unique_times):
             n_events = np.sum((sorted_times == t) & (sorted_status == 1))
             n_at_risk_t = np.sum(sorted_times >= t)

--- a/tests/test_survival.py
+++ b/tests/test_survival.py
@@ -251,6 +251,17 @@ def test_kaplan_meier_tied_events():
     assert np.all(np.diff(survival_probs) <= 0)
 
 
+def test_kaplan_meier_integer_times():
+    times = np.array([1, 1, 2, 3])
+    status = np.array([1, 0, 1, 0])
+    dt = azb.from_dict({"observed_data": {"times": times}, "constant_data": {"times": status}})
+
+    result = kaplan_meier(dt, var_names=["times"])
+    survival_probs = result["times"].values[1]
+
+    np.testing.assert_allclose(survival_probs, [0.75, 0.375, 0.375])
+
+
 def test_kaplan_meier_string_var_name():
     rng = np.random.default_rng(42)
     times = rng.exponential(10, 20)


### PR DESCRIPTION
When event times were integers, the array used to store Kaplan–Meier survival probabilities was also created as an integer array. So, for example:

```python
unique_times = np.array([1, 2, 3])
survival_probs = np.empty_like(unique_times)

survival_probs[:] = [0.75, 0.375, 0.375]
# array([0, 0, 0])
```

As a result, fractional survival probabilities were truncated to zero. 

This PR, creates the probability array with `dtype=float` to avoid this truncation to zero.