### PR TITLE
Fix covariance and split steps in `loo_moment_match`

### DIFF
--- a/src/arviz_stats/loo/loo_helper.py
+++ b/src/arviz_stats/loo/loo_helper.py
@@ -423,7 +423,7 @@ def _shift_and_cov(upars, lwi):
     shift_vec = mean_weighted - mean_original
 
     cov_original = np.cov(upars_values, rowvar=False, ddof=1)
-    cov_weighted = np.cov(upars_values, rowvar=False, aweights=weights, ddof=0)
+    cov_weighted = np.cov(upars_values, rowvar=False, aweights=weights, ddof=1)
 
     mapping_mat = np.eye(upars_values.shape[1])
     try:
@@ -439,7 +439,7 @@ def _shift_and_cov(upars, lwi):
         chol_weighted = np.linalg.cholesky(cov_weighted)
         chol_original = np.linalg.cholesky(cov_original)
 
-        mapping_mat = chol_weighted.T @ np.linalg.inv(chol_original.T)
+        mapping_mat = chol_weighted @ np.linalg.inv(chol_original)
 
     except np.linalg.LinAlgError as e:
         warnings.warn(

--- a/src/arviz_stats/loo/loo_moment_match.py
+++ b/src/arviz_stats/loo/loo_moment_match.py
@@ -496,7 +496,7 @@ def _split_moment_match(
 
     # Inverse Transformation
     upars_trans = upars_trans + (xr.DataArray(total_shift, dims=param_dim) + mean_original)
-    upars_trans_inv = upars_stacked - (xr.DataArray(total_shift, dims=param_dim) + mean_original)
+    upars_trans_inv = upars_stacked - mean_original
 
     if cov and dim > 0:
         try:
@@ -665,7 +665,8 @@ def _loo_moment_match_i(
     var_name,
 ):
     """Compute moment matching for a single observation."""
-    log_liki = _get_log_likelihood_i(log_likelihood, i, obs_dims).squeeze(drop=True)
+    log_liki = _get_log_likelihood_i(log_likelihood, i, obs_dims)
+    log_liki = log_liki.squeeze([dim for dim in obs_dims if dim in log_liki.dims], drop=True)
 
     if isinstance(r_eff, xr.DataArray):
         reff_i = _get_r_eff_i(r_eff, i, obs_dims)
@@ -690,7 +691,8 @@ def _loo_moment_match_i(
             log_lik_i=log_liki,
             var_name=var_name,
         )
-        lwi = log_weights_i.squeeze(drop=True).transpose(*sample_dims).astype(np.float64)
+        squeeze_dims = [dim for dim in obs_dims if dim in log_weights_i.dims]
+        lwi = log_weights_i.squeeze(squeeze_dims, drop=True).transpose(*sample_dims)
     else:
         log_ratio_i_init = -log_liki
         lwi, ki = _wrap__psislw(log_ratio_i_init, sample_dims, reff_i)
@@ -710,11 +712,10 @@ def _loo_moment_match_i(
         if iterind == max_iters:
             warnings.warn(
                 f"Maximum number of moment matching iterations ({max_iters}) reached "
-                f"for observation {i}. Final Pareto k is {ki:.2f}.",
+                f"for observation {i}. Increasing max_iters may improve accuracy.",
                 UserWarning,
                 stacklevel=2,
             )
-            break
 
         # Try Mean Shift
         try:

--- a/tests/loo/test_loo_helper.py
+++ b/tests/loo/test_loo_helper.py
@@ -57,6 +57,26 @@ def log_lik_fn_subsample(obs_da, datatree):
     return sp.stats.norm.logpdf(obs_da, loc=theta, scale=sigma)
 
 
+def split_log_prob_fn(calls):
+    def log_prob_upars_fn(upars_in):
+        calls.append(upars_in)
+        return -0.5 * (upars_in**2).sum(dim="param")
+
+    return log_prob_upars_fn
+
+
+def split_log_lik_i_fn(upars_in, _idx):
+    return -0.5 * upars_in.isel(param=0) ** 2
+
+
+def stack_draw_major(upars):
+    return upars.stack(__sample__=["draw", "chain"]).transpose("__sample__", "param").values
+
+
+def forward_transform(values, mean_original, total_scaling, total_mapping):
+    return ((values - mean_original) * total_scaling) @ total_mapping.T + mean_original
+
+
 def test_get_r_eff(centered_eight):
     n_samples = centered_eight.posterior.chain.size * centered_eight.posterior.draw.size
     r_eff = _get_r_eff(centered_eight, n_samples)
@@ -525,6 +545,33 @@ def test_shift_and_cov():
     assert result.mapping.shape == (param_size, param_size)
 
 
+def test_shift_and_cov_matches_weighted_moments():
+    rng = np.random.default_rng(42)
+    chain_size, draw_size, param_size = 2, 500, 3
+    upars = xr.DataArray(
+        rng.normal(size=(chain_size, draw_size, param_size)),
+        dims=["chain", "draw", "param"],
+    )
+    log_weights = rng.normal(size=(chain_size, draw_size))
+    lwi = xr.DataArray(
+        log_weights - np.log(np.sum(np.exp(log_weights))),
+        dims=["chain", "draw"],
+    )
+
+    result = _shift_and_cov(upars, lwi)
+
+    sample_dims = ["chain", "draw"]
+    upars_values = upars.stack(__sample__=sample_dims).transpose("__sample__", "param").values
+    new_values = result.upars.stack(__sample__=sample_dims).transpose("__sample__", "param").values
+    weights = np.exp(lwi.stack(__sample__=sample_dims).values)
+    mean_weighted = weights @ upars_values
+    centered = upars_values - mean_weighted
+    cov_weighted = (weights[:, None] * centered).T @ centered / (1 - np.sum(weights**2))
+
+    assert_allclose(new_values.mean(axis=0), mean_weighted)
+    assert_allclose(np.cov(new_values, rowvar=False, ddof=1), cov_weighted)
+
+
 @pytest.mark.parametrize("cov", [True, False])
 def test_split_moment_match(cov, centered_eight):
     rng = np.random.default_rng(42)
@@ -590,6 +637,76 @@ def test_split_moment_match(cov, centered_eight):
     assert result.lwi.shape == (chain_size, draw_size)
     assert result.lwfi.shape == (chain_size, draw_size)
     assert result.log_liki.shape == (chain_size, draw_size)
+
+
+def test_split_moment_match_shift_inverse():
+    rng = np.random.default_rng(42)
+    chain_size, draw_size, param_size = 2, 100, 3
+    upars = xr.DataArray(
+        rng.normal(size=(chain_size, draw_size, param_size)),
+        dims=["chain", "draw", "param"],
+    )
+    total_shift = rng.normal(size=param_size)
+    log_prob_calls = []
+
+    _split_moment_match(
+        upars=upars,
+        cov=False,
+        total_shift=total_shift,
+        total_scaling=np.ones(param_size),
+        total_mapping=np.eye(param_size),
+        i=0,
+        reff=1.0,
+        log_prob_upars_fn=split_log_prob_fn(log_prob_calls),
+        log_lik_i_upars_fn=split_log_lik_i_fn,
+    )
+
+    original = stack_draw_major(upars)
+    half = original.shape[0] // 2
+    transformed = stack_draw_major(log_prob_calls[0])
+    inverted = stack_draw_major(log_prob_calls[1])
+
+    assert_allclose(transformed[:half], original[:half] + total_shift)
+    assert_allclose(transformed[half:], original[half:])
+    assert_allclose(inverted[:half], original[:half])
+    assert_allclose(inverted[half:], original[half:] - total_shift)
+
+
+def test_split_moment_match_scaling_inverse():
+    rng = np.random.default_rng(42)
+    chain_size, draw_size, param_size = 2, 100, 3
+    upars = xr.DataArray(
+        rng.normal(size=(chain_size, draw_size, param_size)),
+        dims=["chain", "draw", "param"],
+    )
+    total_scaling = rng.uniform(0.5, 2.0, param_size)
+    total_mapping = np.eye(param_size) + 0.1 * rng.normal(size=(param_size, param_size))
+    log_prob_calls = []
+
+    _split_moment_match(
+        upars=upars,
+        cov=True,
+        total_shift=np.zeros(param_size),
+        total_scaling=total_scaling,
+        total_mapping=total_mapping,
+        i=0,
+        reff=1.0,
+        log_prob_upars_fn=split_log_prob_fn(log_prob_calls),
+        log_lik_i_upars_fn=split_log_lik_i_fn,
+    )
+
+    original = stack_draw_major(upars)
+    half = original.shape[0] // 2
+    mean_original = original.mean(axis=0)
+    transformed = stack_draw_major(log_prob_calls[0])
+    inverted = stack_draw_major(log_prob_calls[1])
+    forward_of_original = forward_transform(original, mean_original, total_scaling, total_mapping)
+    forward_of_inverted = forward_transform(inverted, mean_original, total_scaling, total_mapping)
+
+    assert_allclose(transformed[:half], forward_of_original[:half])
+    assert_allclose(transformed[half:], original[half:])
+    assert_allclose(inverted[:half], original[:half])
+    assert_allclose(forward_of_inverted[half:], original[half:])
 
 
 @pytest.mark.parametrize("method", ["lpd", "plpd"])

--- a/tests/loo/test_loo_mm.py
+++ b/tests/loo/test_loo_mm.py
@@ -568,3 +568,83 @@ def test_loo_moment_match_flag_errors(roaches_r_example):
 
     with pytest.raises(ValueError, match="requires model"):
         loo(example["data_tree"], var_name="log_lik", moment_match=True)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_moment_match_max_iters_runs_last_iteration(roaches_r_example):
+    example = roaches_r_example
+    loo_orig = loo(example["data_tree"], pointwise=True, var_name="log_lik")
+    loo_inputs = _prepare_loo_inputs(example["data_tree"], "log_lik")
+
+    upars = example["upars"].transpose(*loo_inputs.sample_dims, "uparam")
+    orig_log_prob = example["log_prob_fn"](upars)
+    ks = (
+        loo_orig.pareto_k.stack(__pareto_obs_stacked__=loo_inputs.obs_dims)
+        .transpose("__pareto_obs_stacked__")
+        .values
+    )
+    k_threshold = min(1 - 1 / np.log10(loo_inputs.n_samples), 0.7)
+    i = int(np.argmax(ks))
+    assert ks[i] > k_threshold
+
+    log_prob_calls = []
+
+    def log_prob_fn(upars_in):
+        log_prob_calls.append(upars_in)
+        return example["log_prob_fn"](upars_in)
+
+    with pytest.warns(UserWarning, match="Maximum number of moment matching iterations"):
+        result = _loo_moment_match_i(
+            i=i,
+            upars=upars,
+            log_likelihood=loo_inputs.log_likelihood,
+            log_prob_upars_fn=log_prob_fn,
+            log_lik_i_upars_fn=example["log_lik_i_fn"],
+            max_iters=1,
+            k_threshold=k_threshold,
+            split=False,
+            cov=True,
+            orig_log_prob=orig_log_prob,
+            ks=ks,
+            log_weights=loo_orig.log_weights,
+            pareto_k=loo_orig.pareto_k,
+            r_eff=1.0,
+            sample_dims=loo_inputs.sample_dims,
+            obs_dims=loo_inputs.obs_dims,
+            n_samples=loo_inputs.n_samples,
+            n_params=upars.sizes["uparam"],
+            param_dim_name="uparam",
+            var_name="log_lik",
+        )
+
+    assert 1 <= len(log_prob_calls) <= 3
+    assert result.final_ki <= result.original_ki
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_moment_match_single_chain(roaches_r_example):
+    example = roaches_r_example
+    data_tree = xr.DataTree()
+    for group in ("posterior", "log_likelihood"):
+        group_ds = example["data_tree"][group].to_dataset().isel(chain=[0])
+        data_tree[group] = xr.DataTree(dataset=group_ds)
+    upars = example["upars"].isel(chain=[0])
+
+    loo_orig = loo(data_tree, pointwise=True, var_name="log_lik")
+    k_threshold = min(1 - 1 / np.log10(loo_orig.n_samples), 0.7)
+    assert np.any(loo_orig.pareto_k.values > k_threshold)
+
+    loo_mm = loo_moment_match(
+        data_tree,
+        loo_orig,
+        log_prob_upars_fn=example["log_prob_fn"],
+        log_lik_i_upars_fn=example["log_lik_i_fn"],
+        upars=upars,
+        var_name="log_lik",
+    )
+
+    assert np.isfinite(loo_mm.elpd)
+    assert loo_mm.pareto_k.sizes == loo_orig.pareto_k.sizes
+    assert np.all(loo_mm.pareto_k.values <= loo_orig.pareto_k.values + 1e-12)


### PR DESCRIPTION
Was revisiting `loo_moment_match()` and found a few small computational issues that are handled differently in the R loo package. These differences accounted for very small numerical differences (often VERY small) between our moment matching results and the R loo functions, but still seemed worth correcting.

Also interestingly, the Roaches example does not really surface these issues because the covariance step is rarely accepted there and the split error is tiny when shifts are small. So probably worth another audit of moment matching tests to maybe robustify them to harder edge cases.

Resolved with this PR:

- The covariance step was using the upper Cholesky factors instead of the lower ones, so the transformed draws didn't actually end up with the weighted covariance we were targeting. It was also using the ML divisor for the weighted covariance where R's `cov.wt` uses the unbiased one. See R's [`shift_and_cov`](https://github.com/stan-dev/loo/blob/a59519c224d592594f00489e7b705b799699e1a5/R/loo_moment_matching.R#L571-L586).
- The split inverse transformation was subtracting `total_shift` twice, so the mixture density for the untransformed half was being evaluated at the wrong point. Now it centers on the mean only, as in R's [`loo_moment_match_split`](https://github.com/stan-dev/loo/blob/a59519c224d592594f00489e7b705b799699e1a5/R/split_moment_matching.R#L59-L64).
- `max_iters` was off by one. We warned and broke before running the last iteration, so `max_iters=1` did nothing at all. R [warns and still runs it](https://github.com/stan-dev/loo/blob/a59519c224d592594f00489e7b705b799699e1a5/R/loo_moment_matching.R#L282-L283), so we do too now.
- A single chain crashed because `squeeze(drop=True)` was also dropping the chain dim. We only squeeze the observation dims now.
