### PR TITLE
Fix `num_samples` default in survival curves

### DIFF
--- a/src/arviz_stats/survival.py
+++ b/src/arviz_stats/survival.py
@@ -97,6 +97,7 @@ def generate_survival_curves(
         Group containing the predictive samples.
     num_samples : int, optional
         Number of samples to draw from the predictive distribution.
+        If None, all available samples are used.
     extrapolation_factor : float, default 1.2
         Factor by which to limit the survival curves beyond the maximum observed time.
         Set to None to show the unaffected posterior predictive draws.
@@ -122,7 +123,7 @@ def generate_survival_curves(
         max_points = 0
         sample_data_list = []
 
-        for i in range(num_samples):
+        for i in range(pp.sizes["sample"]):
             times = pp[var_name].isel(sample=i)
 
             # Filter times based on extrapolation factor

--- a/tests/test_survival.py
+++ b/tests/test_survival.py
@@ -179,6 +179,15 @@ def test_generate_survival_curves_output_shape(survival_datatree_predictive):
     assert times_data.shape[1] <= num_samples
 
 
+def test_generate_survival_curves_default_num_samples(survival_datatree_predictive):
+    result = generate_survival_curves(
+        survival_datatree_predictive,
+        var_names=["times"],
+        extrapolation_factor=None,
+    )
+    assert result.sizes["sample"] == 200
+
+
 def test_generate_survival_curves_unique_sorted(survival_datatree_predictive):
     result = generate_survival_curves(
         survival_datatree_predictive,


### PR DESCRIPTION
`generate_survival_curves()` has `num_samples=None` as its documented default, but the loop did `range(num_samples)`, so calling it without an explicit integer raised a `TypeError`. The loop now iterates over the extracted `sample` dim, so `None` means all draws, which is what `extract` already does with it.