### PR TITLE
Fix `loo_subsample` pointwise output for multi-dim observations

### DIFF
--- a/src/arviz_stats/loo/loo_helper.py
+++ b/src/arviz_stats/loo/loo_helper.py
@@ -1112,8 +1112,8 @@ def _prepare_full_arrays(
         indexers = {
             dim: xr.DataArray(idx, dims="__obs__") for dim, idx in zip(obs_dims, multi_indices)
         }
-        elpd_i_full.isel(indexers).values[:] = pointwise_values.values
-        pareto_k_full.isel(indexers).values[:] = pareto_k_values.values
+        elpd_i_full[indexers] = xr.DataArray(pointwise_values.values.ravel(), dims="__obs__")
+        pareto_k_full[indexers] = xr.DataArray(pareto_k_values.values.ravel(), dims="__obs__")
     else:
         elpd_i_full[{obs_dims[0]: indices}] = pointwise_values.values
         pareto_k_full[{obs_dims[0]: indices}] = pareto_k_values.values

--- a/tests/loo/test_loo_subsample.py
+++ b/tests/loo/test_loo_subsample.py
@@ -883,3 +883,19 @@ def test_loo_subsample_jacobian_errors(centered_eight):
     )
     with pytest.raises(ValueError, match="must contain only finite values"):
         loo_subsample(centered_eight, observations=4, var_name="obs", log_jacobian=nan_jacobian)
+
+
+def test_loo_subsample_multidim_obs_pointwise():
+    rng = np.random.default_rng(0)
+    log_lik = rng.normal(-1, 0.3, size=(2, 200, 3, 4))
+    idata = azb.from_dict(
+        {"posterior": {"mu": rng.normal(size=(2, 200))}, "log_likelihood": {"y": log_lik}},
+        dims={"y": ["row", "col"]},
+    )
+
+    result = loo_subsample(idata, observations=5, pointwise=True, method="lpd", seed=42)
+
+    assert result.elpd_i.dims == ("row", "col")
+    assert np.isfinite(result.elpd_i.values).sum() == 5
+    assert np.isfinite(result.pareto_k.values).sum() == 5
+    assert np.isfinite(result.elpd_i.values.ravel()[result.loo_subsample_observations]).all()


### PR DESCRIPTION
`loo_subsample(pointwise=True)` returned all-NaN `elpd_i` and `pareto_k` when the log-likelihood had more than one observation dim. Totals were fine, so nothing raised.