### PR TITLE
Fix reloo SE, log weights, and input checks

### DIFF
--- a/src/arviz_stats/loo/reloo.py
+++ b/src/arviz_stats/loo/reloo.py
@@ -90,7 +90,10 @@ def reloo(
         - **pareto_k**: :class:`~xarray.DataArray` with Pareto shape values,
           only if ``pointwise=True``
         - **approx_posterior**: False (not used for standard LOO)
-        - **log_weights**: Smoothed log weights.
+        - **log_weights**: Smoothed log weights. Set to NaN for refitted observations
+          when ``pointwise=True``.
+        - **p_loo_i**: :class:`~xarray.DataArray` with the pointwise effective number of
+          parameters, only if ``pointwise=True``.
 
     Notes
     -----
@@ -146,6 +149,12 @@ def reloo(
             "implemented and were not found."
         )
 
+    if wrapper.idata_orig is None:
+        raise ValueError(
+            "wrapper.idata_orig must contain the original inference data. "
+            "Pass idata_orig when creating the SamplingWrapper."
+        )
+
     pointwise = rcParams["stats.ic_pointwise"] if pointwise is None else pointwise
 
     if loo_orig is None:
@@ -189,6 +198,15 @@ def reloo(
     n_samples = loo_inputs.n_samples
     log_likelihood = loo_inputs.log_likelihood
 
+    obs_sizes = {dim: log_likelihood.sizes[dim] for dim in obs_dims}
+    loo_obs_sizes = {dim: loo_orig.pareto_k.sizes.get(dim) for dim in obs_dims}
+
+    if loo_obs_sizes != obs_sizes:
+        raise ValueError(
+            "Observation dimensions in loo_orig do not match the log likelihood in "
+            f"wrapper.idata_orig. loo_orig has {loo_obs_sizes}, idata_orig has {obs_sizes}."
+        )
+
     if k_threshold is None:
         k_threshold = min(1 - 1 / np.log10(n_samples), 0.7)
 
@@ -214,6 +232,7 @@ def reloo(
         obs_shape = [loo_orig.pareto_k.sizes[dim] for dim in obs_dims]
         bad_obs_indices = np.array(np.unravel_index(bad_obs_flat_indices, obs_shape)).T
 
+    refitted_obs = []
     for i, _ in enumerate(bad_obs_flat_indices):
         if len(obs_dims) == 1:
             obs_idx = bad_obs_indices[i]
@@ -235,14 +254,29 @@ def reloo(
         fit = wrapper.sample(new_obs)
         idata_idx = wrapper.get_inference_data(fit)
         log_lik_idx = wrapper.log_likelihood__i(excluded_obs, idata_idx)
+
+        if not all(dim in log_lik_idx.dims for dim in sample_dims):
+            raise ValueError(
+                f"log_likelihood__i must return a DataArray with dimensions {sample_dims}, "
+                f"found {log_lik_idx.dims}."
+            )
+        other_dims = [dim for dim in log_lik_idx.dims if dim not in sample_dims]
+
+        if any(log_lik_idx.sizes[dim] != 1 for dim in other_dims):
+            raise ValueError(
+                "log_likelihood__i must return a single observation per call, found "
+                f"dimensions {other_dims} with sizes "
+                f"{[log_lik_idx.sizes[dim] for dim in other_dims]}."
+            )
         elpd_loo_i = logsumexp(log_lik_idx, dims=sample_dims, b=1 / log_lik_idx.size).item()
 
         loo_refitted.elpd_i.loc[obs_idx_dict] = elpd_loo_i
         loo_refitted.pareto_k.loc[obs_idx_dict] = 0.0
         loo_refitted.p_loo_i.loc[obs_idx_dict] = hat_lpd_i - elpd_loo_i
+        refitted_obs.append(obs_idx_dict)
 
     loo_refitted.elpd = np.sum(loo_refitted.elpd_i.values)
-    loo_refitted.se = np.sqrt(n_data_points * np.var(loo_refitted.elpd_i.values))
+    loo_refitted.se = np.sqrt(n_data_points * np.var(loo_refitted.elpd_i.values, ddof=1))
     loo_refitted.p = np.sum(loo_refitted.p_loo_i.values)
 
     loo_refitted.warning = np.any(loo_refitted.pareto_k.values > loo_refitted.good_k)
@@ -255,12 +289,12 @@ def reloo(
             loo_refitted.log_weights = loo_orig.log_weights
     else:
         if hasattr(loo_orig, "log_weights") and loo_orig.log_weights is not None:
-            loo_refitted.log_weights = loo_orig.log_weights.copy()
-            for i, obs_idx in enumerate(bad_obs_flat_indices):
-                if len(obs_dims) == 1:
-                    loo_refitted.log_weights[bad_obs_indices[i]] = np.nan
-                else:
-                    obs_idx_tuple = tuple(bad_obs_indices[i])
-                    loo_refitted.log_weights[obs_idx_tuple] = np.nan
+            log_weights_refitted = loo_orig.log_weights
+            if isinstance(log_weights_refitted, xr.Dataset):
+                log_weights_refitted = log_weights_refitted[loo_inputs.var_name]
+            log_weights_refitted = log_weights_refitted.copy()
+            for obs_idx_dict in refitted_obs:
+                log_weights_refitted.loc[obs_idx_dict] = np.nan
+            loo_refitted.log_weights = log_weights_refitted
 
     return loo_refitted

--- a/tests/loo/test_reloo.py
+++ b/tests/loo/test_reloo.py
@@ -280,3 +280,65 @@ def test_reloo_dataset_log_weights(mock_2d_data, mock_wrapper_2d):
     loo_modified.pareto_k.loc[{"school": "school_0", "measurement": "meas_0"}] = 0.85
     result = reloo(mock_wrapper_2d, loo_orig=loo_modified, k_threshold=0.7)
     assert result.pareto_k.loc[{"school": "school_0", "measurement": "meas_0"}] == 0.0
+
+
+@pytest.mark.filterwarnings("ignore:Estimated shape parameter:UserWarning")
+def test_reloo_se_uses_sample_variance(mock_wrapper_reloo, high_k_loo_data):
+    result = reloo(mock_wrapper_reloo, loo_orig=high_k_loo_data, k_threshold=0.7, pointwise=True)
+    expected_se = np.sqrt(result.n_data_points * np.var(result.elpd_i.values, ddof=1))
+    assert result.se == pytest.approx(expected_se)
+
+
+@pytest.mark.filterwarnings("ignore:Estimated shape parameter:UserWarning")
+def test_reloo_log_weights_obs_dim_last(mock_wrapper_reloo, high_k_loo_data):
+    loo_orig = deepcopy(high_k_loo_data)
+    loo_orig.log_weights = loo_orig.log_weights.transpose("chain", "draw", "school")
+
+    result = reloo(mock_wrapper_reloo, loo_orig=loo_orig, k_threshold=0.7, pointwise=True)
+
+    bad_k_mask = high_k_loo_data.pareto_k.values > 0.7
+    all_nan_per_obs = np.isnan(result.log_weights).all(dim=("chain", "draw")).values
+    assert np.array_equal(all_nan_per_obs, bad_k_mask)
+    assert not np.isnan(result.log_weights).all(dim=("draw", "school")).values.any()
+
+
+@pytest.mark.filterwarnings("ignore:Estimated shape parameter:UserWarning")
+def test_reloo_dataset_log_weights_pointwise(mock_wrapper_reloo, high_k_loo_data):
+    loo_orig = deepcopy(high_k_loo_data)
+    loo_orig.log_weights = xr.Dataset({"obs": loo_orig.log_weights})
+
+    result = reloo(
+        mock_wrapper_reloo, loo_orig=loo_orig, var_name="obs", k_threshold=0.7, pointwise=True
+    )
+
+    bad_k_mask = high_k_loo_data.pareto_k.values > 0.7
+    assert isinstance(result.log_weights, xr.DataArray)
+    assert np.all(np.isnan(result.log_weights.values[bad_k_mask]))
+    assert not np.any(np.isnan(result.log_weights.values[~bad_k_mask]))
+
+
+@pytest.mark.filterwarnings("ignore:Estimated shape parameter:UserWarning")
+def test_reloo_log_likelihood_shape_error(mock_wrapper_reloo, high_k_loo_data):
+    class BadLogLikWrapper(type(mock_wrapper_reloo)):
+        def log_likelihood__i(self, excluded_obs, idata__i):
+            log_lik = super().log_likelihood__i(excluded_obs, idata__i)
+            return xr.concat([log_lik, log_lik], dim="extra")
+
+    wrapper = BadLogLikWrapper(None, idata_orig=mock_wrapper_reloo.idata_orig)
+    with pytest.raises(ValueError, match="log_likelihood__i"):
+        reloo(wrapper, loo_orig=high_k_loo_data, k_threshold=0.7)
+
+
+def test_reloo_requires_idata_orig(mock_wrapper_reloo, high_k_loo_data):
+    wrapper = type(mock_wrapper_reloo)(None, idata_orig=None)
+
+    with pytest.raises(ValueError, match="idata_orig"):
+        reloo(wrapper, loo_orig=high_k_loo_data, k_threshold=0.7)
+
+
+def test_reloo_loo_orig_size_mismatch(mock_wrapper_reloo, high_k_loo_data):
+    idata_subset = mock_wrapper_reloo.idata_orig.isel(school=slice(0, 7))
+    wrapper = type(mock_wrapper_reloo)(None, idata_orig=idata_subset)
+
+    with pytest.raises(ValueError, match="do not match"):
+        reloo(wrapper, loo_orig=high_k_loo_data, k_threshold=0.7)

--- a/tests/loo/test_reloo.py
+++ b/tests/loo/test_reloo.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose, assert_array_almost_equal
 
 from ..helpers import importorskip
 
@@ -286,7 +286,7 @@ def test_reloo_dataset_log_weights(mock_2d_data, mock_wrapper_2d):
 def test_reloo_se_uses_sample_variance(mock_wrapper_reloo, high_k_loo_data):
     result = reloo(mock_wrapper_reloo, loo_orig=high_k_loo_data, k_threshold=0.7, pointwise=True)
     expected_se = np.sqrt(result.n_data_points * np.var(result.elpd_i.values, ddof=1))
-    assert result.se == pytest.approx(expected_se)
+    assert_allclose(result.se, expected_se)
 
 
 @pytest.mark.filterwarnings("ignore:Estimated shape parameter:UserWarning")


### PR DESCRIPTION
Revisited `reloo()` against [`reloo.brmsfit`](https://github.com/paul-buerkner/brms/blob/d75e5e7e19bfd34df17992603a1533e0cc4307b1/R/reloo.R#L64) in brms and [`reloo`](https://github.com/stan-dev/rstanarm/blob/97fdba425ea0bd280c25928f118d247e617f43ae/R/loo.R#L603) in rstanarm. Corrected a few things and added some more validation.

- SE used `ddof=0`, so a refit silently changed the SE convention. Now `ddof=1` like `loo`, moment matching, k-fold, and the `sqrt(N * var)` used by [brms](https://github.com/paul-buerkner/brms/blob/d75e5e7e19bfd34df17992603a1533e0cc4307b1/R/reloo.R#L172) and [rstanarm](https://github.com/stan-dev/rstanarm/blob/97fdba425ea0bd280c25928f118d247e617f43ae/R/loo.R#L691).
- Log weights for refitted observations were NaN-ed by position, which breaks for `(chain, draw, obs)` weights and errors on the `Dataset` weights from `loo_subsample`. Now done by label.
- The observation dims of `loo_orig` and `wrapper.idata_orig` must match, like the [row count check in brms](https://github.com/paul-buerkner/brms/blob/d75e5e7e19bfd34df17992603a1533e0cc4307b1/R/reloo.R#L84).
- Clear errors for a wrong shape from `log_likelihood__i` and for a missing `idata_orig`.
- Docstring mentions `p_loo_i` and the NaN log weights.