### PR TITLE
Add bivariate histogram and hexbin statistics

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -51,7 +51,9 @@ you should jump to {ref}`array_stats_api` and read forward.
    arviz_stats.eti
    arviz_stats.iqr
    arviz_stats.hdi
+   arviz_stats.hexbin
    arviz_stats.histogram
+   arviz_stats.histogram2d
    arviz_stats.kde
    arviz_stats.kl_divergence
    arviz_stats.loo_expectations
@@ -148,6 +150,8 @@ In addition, many functions are also available via accessors:
    arviz_stats.base.dataarray_stats.rhat_nested
    arviz_stats.base.dataarray_stats.mcse
    arviz_stats.base.dataarray_stats.histogram
+   arviz_stats.base.dataarray_stats.histogram2d
+   arviz_stats.base.dataarray_stats.hexbin
    arviz_stats.base.dataarray_stats.kde
    arviz_stats.base.dataarray_stats.autocorr
 ```
@@ -198,6 +202,8 @@ refer you to other pages for the full argument or algorithm descriptions.
    arviz_stats.base.array_stats.eti
    arviz_stats.base.array_stats.hdi
    arviz_stats.base.array_stats.histogram
+   arviz_stats.base.array_stats.histogram2d
+   arviz_stats.base.array_stats.hexbin
    arviz_stats.base.array_stats.kde
    arviz_stats.base.array_stats.quantile
 ```

--- a/src/arviz_stats/__init__.py
+++ b/src/arviz_stats/__init__.py
@@ -30,7 +30,17 @@ try:
     from arviz_stats.summary import summary, ci_in_rope, mean, median, mode, std, var, iqr, mad
     from arviz_stats.manipulation import thin, weight_predictions
     from arviz_stats.bayes_factor import bayes_factor
-    from arviz_stats.visualization import ecdf, eti, hdi, histogram, kde, kde2d, qds
+    from arviz_stats.visualization import (
+        ecdf,
+        eti,
+        hdi,
+        hexbin,
+        histogram,
+        histogram2d,
+        kde,
+        kde2d,
+        qds,
+    )
     from arviz_stats.survival import kaplan_meier, generate_survival_curves
 
 except ModuleNotFoundError:

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -662,13 +662,16 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             density=density,
         )
 
-    def hexbin(self, x, y, gridsize=100, extent=None, axis=-1, density=True):
+    def hexbin(self, x, y, gridsize=100, extent=None, weights=None, axis=-1, density=True):
         """Compute a batched hexagonal histogram.
 
         Parameters
         ----------
         x, y : array-like
             Paired samples with identical shapes.
+        weights : array-like, optional
+            Sample weights with the same shape as ``x`` and ``y``. Values in each
+            cell are the sum of its sample weights.
         gridsize : int or pair of int, default 100
             Number of hexagons in the x and y directions. A scalar derives the
             y-direction size as ``int(gridsize / sqrt(3))``.
@@ -689,6 +692,7 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             x,
             y,
             axis,
+            weights=weights,
             gridsize=gridsize,
             extent=extent,
             density=density,

--- a/src/arviz_stats/base/array.py
+++ b/src/arviz_stats/base/array.py
@@ -50,6 +50,62 @@ def process_ary_axes(ary, axes):
     return ary, np.arange(-len(axes), 0, dtype=int)
 
 
+def _prepare_bivariate_inputs(x, y, axis, weights=None):
+    x = np.asarray(x)
+    y = np.asarray(y)
+    if x.shape != y.shape:
+        raise ValueError(f"`x` and `y` must have the same shape. Got {x.shape} and {y.shape}.")
+    if weights is not None:
+        weights = np.asarray(weights)
+        if weights.shape != x.shape:
+            raise ValueError(
+                "`weights` must have the same shape as `x` and `y`. "
+                f"Got {weights.shape} and {x.shape}."
+            )
+
+    x, axes = process_ary_axes(x, axis)
+    y, _ = process_ary_axes(y, axis)
+    if weights is not None:
+        weights, _ = process_ary_axes(weights, axis)
+
+    sample_ndim = len(axes)
+    batch_shape = x.shape[:-sample_ndim]
+    sample_size = int(np.prod(x.shape[-sample_ndim:]))
+    x = x.reshape(*batch_shape, sample_size)
+    y = y.reshape(*batch_shape, sample_size)
+    if weights is not None:
+        weights = weights.reshape(*batch_shape, sample_size)
+    return x, y, weights, batch_shape
+
+
+def _apply_bivariate_statistic(func, x, y, axis, weights=None, **func_kwargs):
+    x, y, weights, batch_shape = _prepare_bivariate_inputs(x, y, axis, weights)
+    results = []
+    for index in np.ndindex(batch_shape):
+        x_batch = x[index]
+        y_batch = y[index]
+        valid = np.isfinite(x_batch) & np.isfinite(y_batch)
+        batch_kwargs = func_kwargs
+        if weights is not None:
+            weights_batch = weights[index]
+            valid &= np.isfinite(weights_batch)
+            batch_kwargs = {**func_kwargs, "weights": weights_batch[valid]}
+        if not np.any(valid):
+            raise ValueError("No finite paired samples remain after removing invalid values.")
+        results.append(func(x_batch[valid], y_batch[valid], **batch_kwargs))
+
+    if not batch_shape:
+        return results[0]
+
+    output_count = len(results[0])
+    return tuple(
+        np.stack([result[output_index] for result in results]).reshape(
+            batch_shape + results[0][output_index].shape
+        )
+        for output_index in range(output_count)
+    )
+
+
 class BaseArray(_DensityBase, _DiagnosticsBase):
     """Class with numpy+scipy only functions that take array inputs.
 
@@ -570,6 +626,73 @@ class BaseArray(_DensityBase, _DiagnosticsBase):
             n_dims=len(axes),
         )
         return histogram_ufunc(ary, bins, range, shape_from_1st=True)
+
+    def histogram2d(self, x, y, bins=10, range=None, weights=None, axis=-1, density=True):
+        """Compute a batched two-dimensional histogram.
+
+        Parameters
+        ----------
+        x, y : array-like
+            Paired samples with identical shapes.
+        weights : array-like, optional
+            Sample weights with the same shape as ``x`` and ``y``.
+        bins : int or array-like or pair, default 10
+            Bin specification passed to :func:`numpy.histogram2d`.
+        range : array-like, optional
+            ``((xmin, xmax), (ymin, ymax))`` passed to :func:`numpy.histogram2d`.
+        axis : int, sequence of int or None, default -1
+            Axis or axes along which to reduce.
+        density : bool, default True
+            Normalize the histogram as a probability density.
+
+        Returns
+        -------
+        histogram, x_edges, y_edges : ndarray
+            Histogram values and bin edges, with output dimensions appended after
+            any batch dimensions.
+        """
+        return _apply_bivariate_statistic(
+            self._histogram2d,
+            x,
+            y,
+            axis,
+            weights=weights,
+            bins=bins,
+            range=range,
+            density=density,
+        )
+
+    def hexbin(self, x, y, gridsize=100, extent=None, axis=-1, density=True):
+        """Compute a batched hexagonal histogram.
+
+        Parameters
+        ----------
+        x, y : array-like
+            Paired samples with identical shapes.
+        gridsize : int or pair of int, default 100
+            Number of hexagons in the x and y directions. A scalar derives the
+            y-direction size as ``int(gridsize / sqrt(3))``.
+        extent : array-like, optional
+            Limits ``(xmin, xmax, ymin, ymax)`` of the hexagon grid.
+        axis : int, sequence of int or None, default -1
+            Axis or axes along which to reduce.
+        density : bool, default True
+            Divide counts by the valid sample count and hexagon area.
+
+        Returns
+        -------
+        values, offsets : ndarray
+            Values for every cell and their ``(x, y)`` center coordinates.
+        """
+        return _apply_bivariate_statistic(
+            self._hexbin,
+            x,
+            y,
+            axis,
+            gridsize=gridsize,
+            extent=extent,
+            density=density,
+        )
 
     def kde(self, ary, axis=-1, circular=False, grid_len=512, **kwargs):
         """Compute KDE on array-like inputs.

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -6,6 +6,7 @@ should go here. e.g. fft is used for kde bandwidth estimation and for ess.
 """
 
 import warnings
+from math import sqrt
 
 import numpy as np
 from scipy.fftpack import next_fast_len
@@ -268,6 +269,106 @@ class _CoreBase:
         if bins is None:
             bins = self._get_bins(ary)
         return np.histogram(ary, bins=bins, range=range, weights=weights, density=density)
+
+    def _histogram2d(self, x, y, bins=10, range=None, weights=None, density=True):
+        return np.histogram2d(
+            x,
+            y,
+            bins=bins,
+            range=range,
+            weights=weights,
+            density=density,
+        )
+
+    @staticmethod
+    def _nonsingular_extent(lower, upper):
+        if not np.isfinite(lower) or not np.isfinite(upper):
+            raise ValueError("Extent values must be finite.")
+        if lower > upper:
+            raise ValueError("Extent upper bounds must be greater than lower bounds.")
+        if lower == upper:
+            delta = 0.1 * abs(lower) if lower else 0.1
+            return lower - delta, upper + delta
+        return lower, upper
+
+    def _hexbin(self, x, y, gridsize=100, extent=None, density=True):
+        if np.isscalar(gridsize):
+            if not isinstance(gridsize, (int, np.integer)):
+                raise ValueError("`gridsize` values must be integers.")
+            nx = int(gridsize)
+            ny = int(nx / sqrt(3))
+        else:
+            try:
+                nx, ny = gridsize
+            except (TypeError, ValueError) as err:
+                raise ValueError("`gridsize` must be an integer or a pair of integers.") from err
+
+        if not isinstance(nx, (int, np.integer)) or not isinstance(ny, (int, np.integer)):
+            raise ValueError("`gridsize` values must be integers.")
+        nx, ny = int(nx), int(ny)
+        if nx <= 0 or ny <= 0:
+            raise ValueError("`gridsize` values must be positive.")
+
+        if extent is None:
+            xmin, xmax = self._nonsingular_extent(np.min(x), np.max(x))
+            ymin, ymax = self._nonsingular_extent(np.min(y), np.max(y))
+        else:
+            if np.size(extent) != 4:
+                raise ValueError("`extent` must contain (xmin, xmax, ymin, ymax).")
+            xmin, xmax, ymin, ymax = np.asarray(extent, dtype=float)
+            xmin, xmax = self._nonsingular_extent(xmin, xmax)
+            ymin, ymax = self._nonsingular_extent(ymin, ymax)
+
+        nx1, ny1 = nx + 1, ny + 1
+        nx2, ny2 = nx, ny
+
+        padding = 1e-9 * (xmax - xmin)
+        xmin -= padding
+        xmax += padding
+        sx = (xmax - xmin) / nx
+        sy = (ymax - ymin) / ny
+
+        ix = (x - xmin) / sx
+        iy = (y - ymin) / sy
+        ix1 = np.round(ix).astype(int)
+        iy1 = np.round(iy).astype(int)
+        ix2 = np.floor(ix).astype(int)
+        iy2 = np.floor(iy).astype(int)
+
+        i1 = np.where(
+            (0 <= ix1) & (ix1 < nx1) & (0 <= iy1) & (iy1 < ny1),
+            ix1 * ny1 + iy1 + 1,
+            0,
+        )
+        i2 = np.where(
+            (0 <= ix2) & (ix2 < nx2) & (0 <= iy2) & (iy2 < ny2),
+            ix2 * ny2 + iy2 + 1,
+            0,
+        )
+        d1 = (ix - ix1) ** 2 + 3 * (iy - iy1) ** 2
+        d2 = (ix - ix2 - 0.5) ** 2 + 3 * (iy - iy2 - 0.5) ** 2
+        use_first_grid = d1 < d2
+
+        counts1 = np.bincount(i1[use_first_grid], minlength=1 + nx1 * ny1)[1:]
+        counts2 = np.bincount(i2[~use_first_grid], minlength=1 + nx2 * ny2)[1:]
+        values = np.concatenate((counts1, counts2)).astype(float)
+
+        offsets = np.zeros((nx1 * ny1 + nx2 * ny2, 2), dtype=float)
+        offsets[: nx1 * ny1, 0] = np.repeat(np.arange(nx1), ny1)
+        offsets[: nx1 * ny1, 1] = np.tile(np.arange(ny1), nx1)
+        offsets[nx1 * ny1 :, 0] = np.repeat(np.arange(nx2) + 0.5, ny2)
+        offsets[nx1 * ny1 :, 1] = np.tile(np.arange(ny2), nx2) + 0.5
+        offsets[:, 0] = offsets[:, 0] * sx + xmin
+        offsets[:, 1] = offsets[:, 1] * sy + ymin
+
+        if density:
+            hexagon_area = sx * sy / 2
+            in_extent_count = values.sum()
+            if in_extent_count == 0:
+                raise ValueError("No samples fall inside the requested extent.")
+            values /= in_extent_count * hexagon_area
+
+        return values, offsets
 
     def _hdi_linear_nearest_common(self, ary, prob):
         n = len(ary)

--- a/src/arviz_stats/base/core.py
+++ b/src/arviz_stats/base/core.py
@@ -6,7 +6,6 @@ should go here. e.g. fft is used for kde bandwidth estimation and for ess.
 """
 
 import warnings
-from math import sqrt
 
 import numpy as np
 from scipy.fftpack import next_fast_len
@@ -291,12 +290,12 @@ class _CoreBase:
             return lower - delta, upper + delta
         return lower, upper
 
-    def _hexbin(self, x, y, gridsize=100, extent=None, density=True):
+    def _hexbin(self, x, y, gridsize=100, extent=None, weights=None, density=True):
         if np.isscalar(gridsize):
             if not isinstance(gridsize, (int, np.integer)):
                 raise ValueError("`gridsize` values must be integers.")
             nx = int(gridsize)
-            ny = int(nx / sqrt(3))
+            ny = int(nx / 1.732)
         else:
             try:
                 nx, ny = gridsize
@@ -349,8 +348,16 @@ class _CoreBase:
         d2 = (ix - ix2 - 0.5) ** 2 + 3 * (iy - iy2 - 0.5) ** 2
         use_first_grid = d1 < d2
 
-        counts1 = np.bincount(i1[use_first_grid], minlength=1 + nx1 * ny1)[1:]
-        counts2 = np.bincount(i2[~use_first_grid], minlength=1 + nx2 * ny2)[1:]
+        counts1 = np.bincount(
+            i1[use_first_grid],
+            weights=None if weights is None else weights[use_first_grid],
+            minlength=1 + nx1 * ny1,
+        )[1:]
+        counts2 = np.bincount(
+            i2[~use_first_grid],
+            weights=None if weights is None else weights[~use_first_grid],
+            minlength=1 + nx2 * ny2,
+        )[1:]
         values = np.concatenate((counts1, counts2)).astype(float)
 
         offsets = np.zeros((nx1 * ny1 + nx2 * ny2, 2), dtype=float)

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -288,9 +288,7 @@ class BaseDataArray:
             }
         )
 
-    def hexbin(
-        self, da_x, da_y, dim=None, gridsize=100, extent=None, weights=None, density=True
-    ):
+    def hexbin(self, da_x, da_y, dim=None, gridsize=100, extent=None, weights=None, density=True):
         """Compute a hexagonal histogram on paired DataArray inputs."""
         self._validate_bivariate_dataarrays(da_x, da_y)
         dims = validate_dims(dim)
@@ -298,19 +296,25 @@ class BaseDataArray:
             if not isinstance(weights, DataArray):
                 weights = DataArray(weights, dims=da_x.dims, coords=da_x.coords)
             assert weights.dims == da_x.dims
+
+        def hexbin_array(x, y, sample_weights):
+            return self.array_class.hexbin(
+                x,
+                y,
+                gridsize=gridsize,
+                extent=extent,
+                weights=sample_weights,
+                axis=np.arange(-len(dims), 0, 1),
+                density=density,
+            )
+
         values, offsets = apply_ufunc(
-            self.array_class.hexbin,
+            hexbin_array,
             da_x,
             da_y,
             weights,
             input_core_dims=[dims, dims, [] if weights is None else dims],
             output_core_dims=[["hexbin"], ["hexbin", "hexbin_coord"]],
-            kwargs={
-                "gridsize": gridsize,
-                "extent": extent,
-                "axis": np.arange(-len(dims), 0, 1),
-                "density": density,
-            },
         )
         return Dataset(
             {

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -26,6 +26,13 @@ class BaseDataArray:
     def __init__(self, array_class=None):
         self.array_class = array_stats if array_class is None else array_class
 
+    @staticmethod
+    def _validate_bivariate_dataarrays(da_x, da_y):
+        if set(da_x.sizes) != set(da_y.sizes) or any(
+            da_x.sizes[dim] != da_y.sizes[dim] for dim in da_x.sizes
+        ):
+            raise ValueError("`da_x` and `da_y` must have identical dimensions and shapes.")
+
     def eti(self, da, prob=None, dim=None, method="linear", **kwargs):
         """Compute eti on DataArray input."""
         dims = validate_dims(dim)
@@ -239,14 +246,12 @@ class BaseDataArray:
         density=True,
     ):
         """Compute a two-dimensional histogram on paired DataArray inputs."""
-        if set(da_x.sizes) != set(da_y.sizes) or any(
-            da_x.sizes[dim] != da_y.sizes[dim] for dim in da_x.sizes
-        ):
-            raise ValueError("`da_x` and `da_y` must have identical dimensions and shapes.")
+        self._validate_bivariate_dataarrays(da_x, da_y)
         dims = validate_dims(dim)
         if weights is not None:
             if not isinstance(weights, DataArray):
                 weights = DataArray(weights, dims=da_x.dims, coords=da_x.coords)
+            assert weights.dims == da_x.dims
             if set(weights.sizes) != set(da_x.sizes) or any(
                 weights.sizes[dim] != da_x.sizes[dim] for dim in da_x.sizes
             ):
@@ -283,18 +288,22 @@ class BaseDataArray:
             }
         )
 
-    def hexbin(self, da_x, da_y, dim=None, gridsize=100, extent=None, density=True):
+    def hexbin(
+        self, da_x, da_y, dim=None, gridsize=100, extent=None, weights=None, density=True
+    ):
         """Compute a hexagonal histogram on paired DataArray inputs."""
-        if set(da_x.sizes) != set(da_y.sizes) or any(
-            da_x.sizes[dim] != da_y.sizes[dim] for dim in da_x.sizes
-        ):
-            raise ValueError("`da_x` and `da_y` must have identical dimensions and shapes.")
+        self._validate_bivariate_dataarrays(da_x, da_y)
         dims = validate_dims(dim)
+        if weights is not None:
+            if not isinstance(weights, DataArray):
+                weights = DataArray(weights, dims=da_x.dims, coords=da_x.coords)
+            assert weights.dims == da_x.dims
         values, offsets = apply_ufunc(
             self.array_class.hexbin,
             da_x,
             da_y,
-            input_core_dims=[dims, dims],
+            weights,
+            input_core_dims=[dims, dims, [] if weights is None else dims],
             output_core_dims=[["hexbin"], ["hexbin", "hexbin_coord"]],
             kwargs={
                 "gridsize": gridsize,

--- a/src/arviz_stats/base/dataarray.py
+++ b/src/arviz_stats/base/dataarray.py
@@ -228,6 +228,89 @@ class BaseDataArray:
         )
         return out
 
+    def histogram2d(
+        self,
+        da_x,
+        da_y,
+        dim=None,
+        bins=10,
+        range=None,
+        weights=None,
+        density=True,
+    ):
+        """Compute a two-dimensional histogram on paired DataArray inputs."""
+        if set(da_x.sizes) != set(da_y.sizes) or any(
+            da_x.sizes[dim] != da_y.sizes[dim] for dim in da_x.sizes
+        ):
+            raise ValueError("`da_x` and `da_y` must have identical dimensions and shapes.")
+        dims = validate_dims(dim)
+        if weights is not None:
+            if not isinstance(weights, DataArray):
+                weights = DataArray(weights, dims=da_x.dims, coords=da_x.coords)
+            if set(weights.sizes) != set(da_x.sizes) or any(
+                weights.sizes[dim] != da_x.sizes[dim] for dim in da_x.sizes
+            ):
+                raise ValueError("`weights` must have the same dimensions and shape as the data.")
+
+        def histogram2d_array(x, y, sample_weights):
+            return self.array_class.histogram2d(
+                x,
+                y,
+                bins=bins,
+                range=range,
+                weights=sample_weights,
+                axis=np.arange(-len(dims), 0, 1),
+                density=density,
+            )
+
+        histogram, x_edges, y_edges = apply_ufunc(
+            histogram2d_array,
+            da_x,
+            da_y,
+            weights,
+            input_core_dims=[dims, dims, [] if weights is None else dims],
+            output_core_dims=[
+                ["histogram2d_x", "histogram2d_y"],
+                ["histogram2d_x_edge"],
+                ["histogram2d_y_edge"],
+            ],
+        )
+        return Dataset(
+            {
+                "histogram": histogram,
+                "x_edges": x_edges,
+                "y_edges": y_edges,
+            }
+        )
+
+    def hexbin(self, da_x, da_y, dim=None, gridsize=100, extent=None, density=True):
+        """Compute a hexagonal histogram on paired DataArray inputs."""
+        if set(da_x.sizes) != set(da_y.sizes) or any(
+            da_x.sizes[dim] != da_y.sizes[dim] for dim in da_x.sizes
+        ):
+            raise ValueError("`da_x` and `da_y` must have identical dimensions and shapes.")
+        dims = validate_dims(dim)
+        values, offsets = apply_ufunc(
+            self.array_class.hexbin,
+            da_x,
+            da_y,
+            input_core_dims=[dims, dims],
+            output_core_dims=[["hexbin"], ["hexbin", "hexbin_coord"]],
+            kwargs={
+                "gridsize": gridsize,
+                "extent": extent,
+                "axis": np.arange(-len(dims), 0, 1),
+                "density": density,
+            },
+        )
+        return Dataset(
+            {
+                "values": values,
+                "x_centers": offsets.isel(hexbin_coord=0, drop=True),
+                "y_centers": offsets.isel(hexbin_coord=1, drop=True),
+            }
+        )
+
     def kde(self, da, dim=None, circular=False, grid_len=512, **kwargs):
         """Compute KDE on DataArray input.
 

--- a/src/arviz_stats/visualization.py
+++ b/src/arviz_stats/visualization.py
@@ -4,7 +4,7 @@ import numpy as np
 import xarray as xr
 from arviz_base import convert_to_dataset
 
-from arviz_stats.utils import _apply_multi_input_function, get_function
+from arviz_stats.utils import _apply_multi_input_function, get_array_function, get_function
 from arviz_stats.validate import validate_ci_prob, validate_dims
 
 
@@ -428,6 +428,125 @@ def histogram(
     )
 
 
+def histogram2d(
+    x,
+    y,
+    bins=10,
+    range=None,  # pylint: disable=redefined-builtin
+    weights=None,
+    axis=-1,
+    density=True,
+    dim=None,
+):
+    """Compute a two-dimensional histogram for paired samples.
+
+    Plain arrays return ``(histogram, x_edges, y_edges)``. DataArray inputs return
+    a Dataset with variables named ``histogram``, ``x_edges``, and ``y_edges``.
+
+    Parameters
+    ----------
+    x, y : array-like or DataArray
+        Paired samples with identical shapes.
+    bins : int or array-like or pair, default 10
+        Bin specification passed to :func:`numpy.histogram2d`.
+    range : array-like, optional
+        ``((xmin, xmax), (ymin, ymax))`` passed to :func:`numpy.histogram2d`.
+    weights : array-like or DataArray, optional
+        Sample weights with the same shape as the samples.
+    axis : int, sequence of int or None, default -1
+        Array axis or axes along which to reduce.
+    density : bool, default True
+        Normalize the histogram as a probability density.
+    dim : str or sequence of str, optional
+        DataArray dimension or dimensions along which to reduce.
+
+    Returns
+    -------
+    tuple or xarray.Dataset
+        Histogram values and x and y bin edges.
+    """
+    x_is_dataarray = isinstance(x, xr.DataArray)
+    y_is_dataarray = isinstance(y, xr.DataArray)
+    if x_is_dataarray != y_is_dataarray:
+        raise TypeError("`x` and `y` must both be DataArrays or both be array-like.")
+    if x_is_dataarray:
+        if axis != -1:
+            raise ValueError("Use `dim` instead of `axis` with DataArray inputs.")
+        return get_function("histogram2d")(
+            x,
+            y,
+            dim=validate_dims(dim),
+            bins=bins,
+            range=range,
+            weights=weights,
+            density=density,
+        )
+    if dim is not None:
+        raise ValueError("Use `axis` instead of `dim` with array inputs.")
+    return get_array_function("histogram2d")(
+        np.asarray(x),
+        np.asarray(y),
+        bins=bins,
+        range=range,
+        weights=None if weights is None else np.asarray(weights),
+        axis=axis,
+        density=density,
+    )
+
+
+def hexbin(x, y, gridsize=100, extent=None, axis=-1, density=True, dim=None):
+    """Compute a hexagonal histogram for paired samples.
+
+    Plain arrays return ``(values, offsets)``. DataArray inputs return a Dataset
+    with variables named ``values``, ``x_centers``, and ``y_centers``.
+
+    Parameters
+    ----------
+    x, y : array-like or DataArray
+        Paired samples with identical shapes.
+    gridsize : int or pair of int, default 100
+        Number of hexagons in the x and y directions.
+    extent : array-like, optional
+        Limits ``(xmin, xmax, ymin, ymax)`` of the hexagon grid.
+    axis : int, sequence of int or None, default -1
+        Array axis or axes along which to reduce.
+    density : bool, default True
+        Divide counts by the valid sample count and hexagon area.
+    dim : str or sequence of str, optional
+        DataArray dimension or dimensions along which to reduce.
+
+    Returns
+    -------
+    tuple or xarray.Dataset
+        Hexagon values and center coordinates.
+    """
+    x_is_dataarray = isinstance(x, xr.DataArray)
+    y_is_dataarray = isinstance(y, xr.DataArray)
+    if x_is_dataarray != y_is_dataarray:
+        raise TypeError("`x` and `y` must both be DataArrays or both be array-like.")
+    if x_is_dataarray:
+        if axis != -1:
+            raise ValueError("Use `dim` instead of `axis` with DataArray inputs.")
+        return get_function("hexbin")(
+            x,
+            y,
+            dim=validate_dims(dim),
+            gridsize=gridsize,
+            extent=extent,
+            density=density,
+        )
+    if dim is not None:
+        raise ValueError("Use `axis` instead of `dim` with array inputs.")
+    return get_array_function("hexbin")(
+        np.asarray(x),
+        np.asarray(y),
+        gridsize=gridsize,
+        extent=extent,
+        axis=axis,
+        density=density,
+    )
+
+
 def kde(
     data,
     dim=None,
@@ -738,8 +857,6 @@ def kde2d(
            ...: )
     """
     if isinstance(da_x, np.ndarray | list | tuple) and isinstance(da_y, np.ndarray | list | tuple):
-        from arviz_stats.utils import get_array_function
-
         x = np.asarray(da_x)
         y = np.asarray(da_y)
         return get_array_function("kde2d")(

--- a/src/arviz_stats/visualization.py
+++ b/src/arviz_stats/visualization.py
@@ -494,7 +494,7 @@ def histogram2d(
     )
 
 
-def hexbin(x, y, gridsize=100, extent=None, axis=-1, density=True, dim=None):
+def hexbin(x, y, gridsize=100, extent=None, weights=None, axis=-1, density=True, dim=None):
     """Compute a hexagonal histogram for paired samples.
 
     Plain arrays return ``(values, offsets)``. DataArray inputs return a Dataset
@@ -508,6 +508,9 @@ def hexbin(x, y, gridsize=100, extent=None, axis=-1, density=True, dim=None):
         Number of hexagons in the x and y directions.
     extent : array-like, optional
         Limits ``(xmin, xmax, ymin, ymax)`` of the hexagon grid.
+    weights : array-like or DataArray, optional
+        Sample weights with the same shape as the samples. Values in each cell
+        are the sum of its sample weights.
     axis : int, sequence of int or None, default -1
         Array axis or axes along which to reduce.
     density : bool, default True
@@ -533,6 +536,7 @@ def hexbin(x, y, gridsize=100, extent=None, axis=-1, density=True, dim=None):
             dim=validate_dims(dim),
             gridsize=gridsize,
             extent=extent,
+            weights=weights,
             density=density,
         )
     if dim is not None:
@@ -542,6 +546,7 @@ def hexbin(x, y, gridsize=100, extent=None, axis=-1, density=True, dim=None):
         np.asarray(y),
         gridsize=gridsize,
         extent=extent,
+        weights=None if weights is None else np.asarray(weights),
         axis=axis,
         density=density,
     )

--- a/tests/base/test_bivariate_histograms.py
+++ b/tests/base/test_bivariate_histograms.py
@@ -1,0 +1,369 @@
+# pylint: disable=redefined-outer-name, no-self-use
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from arviz_stats.base.array import BaseArray
+
+from ..helpers import importorskip
+
+
+@pytest.fixture
+def array_stats():
+    return BaseArray()
+
+
+@pytest.fixture(scope="module")
+def _xr():
+    return importorskip("xarray")
+
+
+class TestHistogram2D:
+    def test_positional_bins(self, array_stats):
+        histogram, x_edges, y_edges = array_stats.histogram2d(
+            np.arange(6), np.arange(6), 3, density=False
+        )
+
+        assert histogram.shape == (3, 3)
+        assert x_edges.shape == (4,)
+        assert y_edges.shape == (4,)
+
+    @pytest.mark.parametrize("density", [False, True])
+    def test_matches_numpy(self, array_stats, density):
+        rng = np.random.default_rng(42)
+        x = rng.normal(size=500)
+        y = 0.5 * x + rng.normal(size=500)
+        weights = rng.uniform(0.5, 1.5, size=500)
+        kwargs = {
+            "bins": (np.linspace(-2, 2, 9), np.linspace(-3, 3, 7)),
+            "range": ((-2, 2), (-3, 3)),
+            "weights": weights,
+            "density": density,
+        }
+
+        actual = array_stats.histogram2d(x, y, **kwargs)
+        expected = np.histogram2d(x, y, **kwargs)
+
+        for actual_item, expected_item in zip(actual, expected):
+            assert_allclose(actual_item, expected_item)
+
+    def test_batched_axes(self, array_stats):
+        rng = np.random.default_rng(42)
+        x = rng.normal(size=(3, 4, 20))
+        y = rng.normal(size=(3, 4, 20))
+
+        histogram, x_edges, y_edges = array_stats.histogram2d(
+            x,
+            y,
+            bins=(5, 7),
+            range=((-3, 3), (-3, 3)),
+            axis=(1, 2),
+            density=False,
+        )
+
+        assert histogram.shape == (3, 5, 7)
+        assert x_edges.shape == (3, 6)
+        assert y_edges.shape == (3, 8)
+        for index in range(3):
+            expected = np.histogram2d(
+                x[index].ravel(),
+                y[index].ravel(),
+                bins=(5, 7),
+                range=((-3, 3), (-3, 3)),
+                density=False,
+            )
+            assert_allclose(histogram[index], expected[0])
+            assert_allclose(x_edges[index], expected[1])
+            assert_allclose(y_edges[index], expected[2])
+
+    def test_removes_nonfinite_pairs_and_weights(self, array_stats):
+        x = np.array([0.1, 0.2, np.nan, 0.8, 0.9])
+        y = np.array([0.1, np.inf, 0.3, 0.8, 0.9])
+        weights = np.array([1.0, 2.0, 3.0, np.nan, 5.0])
+
+        actual = array_stats.histogram2d(
+            x,
+            y,
+            bins=2,
+            range=((0, 1), (0, 1)),
+            weights=weights,
+            density=False,
+        )
+        expected = np.histogram2d(
+            x[[0, 4]],
+            y[[0, 4]],
+            bins=2,
+            range=((0, 1), (0, 1)),
+            weights=weights[[0, 4]],
+            density=False,
+        )
+
+        for actual_item, expected_item in zip(actual, expected):
+            assert_allclose(actual_item, expected_item)
+
+    @pytest.mark.parametrize(
+        ("x", "y", "weights", "message"),
+        [
+            (np.ones(3), np.ones(4), None, "same shape"),
+            (np.ones(3), np.ones(3), np.ones(4), "same shape"),
+            (np.array([np.nan]), np.array([1.0]), None, "No finite paired samples"),
+        ],
+    )
+    def test_invalid_inputs(self, array_stats, x, y, weights, message):
+        with pytest.raises(ValueError, match=message):
+            array_stats.histogram2d(x, y, weights=weights)
+
+
+class TestHexbin:
+    def test_matches_fixed_matplotlib_reference(self, array_stats):
+        x = np.array([0.0, 0.2, 0.8, 1.0])
+        y = np.array([0.0, 0.8, 0.2, 1.0])
+        expected_values = np.array([1, 0, 0, 0, 0, 1, 1, 1], dtype=float)
+        expected_offsets = np.array(
+            [
+                [-1e-9, 0.0],
+                [-1e-9, 1.0],
+                [0.5000000000000001, 0.0],
+                [0.5000000000000001, 1.0],
+                [1.000000001, 0.0],
+                [1.000000001, 1.0],
+                [0.24999999950000004, 0.5],
+                [0.7500000005000002, 0.5],
+            ]
+        )
+
+        values, offsets = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            density=False,
+        )
+
+        assert_array_equal(values, expected_values)
+        assert_allclose(offsets, expected_offsets, rtol=0, atol=1e-15)
+
+    @pytest.mark.parametrize(("gridsize", "expected_cells"), [(4, 23), ((4, 3), 32)])
+    def test_grid_shapes_and_zero_cells(self, array_stats, gridsize, expected_cells):
+        values, offsets = array_stats.hexbin(
+            np.array([0.25, 0.75]),
+            np.array([0.25, 0.75]),
+            gridsize=gridsize,
+            extent=(0, 1, 0, 1),
+            density=False,
+        )
+
+        assert values.shape == (expected_cells,)
+        assert offsets.shape == (expected_cells, 2)
+        assert values.sum() == 2
+        assert np.count_nonzero(values == 0) == expected_cells - 2
+
+    def test_extent_clips_samples(self, array_stats):
+        x = np.array([0.25, 0.75, 2.0])
+        y = np.array([0.25, 0.75, 2.0])
+        values, _ = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            density=False,
+        )
+
+        assert_array_equal(values, [0, 0, 0, 0, 0, 0, 1, 1])
+
+    def test_density_normalizes_samples_inside_extent(self, array_stats):
+        x = np.array([0.25, 0.75, 2.0])
+        y = np.array([0.25, 0.75, 2.0])
+        values, _ = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            density=True,
+        )
+        assert_allclose(values, [0, 0, 0, 0, 0, 0, 2, 2])
+
+    def test_empty_extent(self, array_stats):
+        x = np.array([2.0, 3.0])
+        y = np.array([2.0, 3.0])
+
+        with pytest.raises(ValueError, match="No samples fall inside"):
+            array_stats.hexbin(
+                x,
+                y,
+                gridsize=(2, 1),
+                extent=(0, 1, 0, 1),
+                density=True,
+            )
+
+        values, _ = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            density=False,
+        )
+
+        assert_array_equal(values, np.zeros_like(values))
+
+    def test_batched_axis(self, array_stats):
+        x = np.array([[0.1, 0.9], [0.2, 0.8]])
+        y = np.array([[0.1, 0.9], [0.8, 0.2]])
+        values, offsets = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            axis=1,
+            density=False,
+        )
+
+        for index in range(2):
+            expected_values, expected_offsets = array_stats.hexbin(
+                x[index],
+                y[index],
+                gridsize=(2, 1),
+                extent=(0, 1, 0, 1),
+                density=False,
+            )
+            assert_array_equal(values[index], expected_values)
+            assert_allclose(offsets[index], expected_offsets)
+
+    def test_singular_and_nonfinite_data(self, array_stats):
+        values, offsets = array_stats.hexbin(
+            np.array([1.0, 1.0, np.nan]),
+            np.array([0.0, 0.0, 1.0]),
+            gridsize=(2, 1),
+            density=False,
+        )
+
+        assert values.sum() == 2
+        assert np.all(np.isfinite(offsets))
+
+    @pytest.mark.parametrize("gridsize", [0, -1, (2, 0), (2, 1.5), (1, 2, 3)])
+    def test_invalid_gridsize(self, array_stats, gridsize):
+        with pytest.raises(ValueError, match="gridsize"):
+            array_stats.hexbin([0], [0], gridsize=gridsize)
+
+    @pytest.mark.parametrize("extent", [(0, 1, 0), (1, 0, 0, 1), (0, np.inf, 0, 1)])
+    def test_invalid_extent(self, array_stats, extent):
+        with pytest.raises(ValueError, match="Extent|extent"):
+            array_stats.hexbin([0], [0], extent=extent)
+
+
+class TestLabeledBivariateHistograms:
+    @pytest.mark.parametrize("method", ["histogram2d", "hexbin"])
+    def test_aligns_transposed_dimensions(self, method, _xr):
+        import arviz_stats as azs
+
+        x = _xr.DataArray(
+            [[0, 1, 2], [10, 11, 12]],
+            dims=("batch", "sample"),
+            coords={"batch": ["a", "b"], "sample": [0, 1, 2]},
+        )
+        y = _xr.DataArray(
+            [[3, 1, 2], [13, 10, 12]],
+            dims=("batch", "sample"),
+            coords={"batch": ["a", "b"], "sample": [0, 1, 2]},
+        ).transpose()
+
+        kwargs = {"bins": 2} if method == "histogram2d" else {"gridsize": (2, 1)}
+        result = getattr(azs, method)(x, y, dim=("batch", "sample"), density=False, **kwargs)
+        aligned_x, aligned_y = _xr.align(x, y)
+        expected = getattr(BaseArray(), method)(
+            aligned_x.values,
+            aligned_y.transpose(*aligned_x.dims).values,
+            axis=(0, 1),
+            density=False,
+            **kwargs,
+        )
+
+        if method == "histogram2d":
+            assert_allclose(result.histogram.values, expected[0])
+            assert_allclose(result.x_edges.values, expected[1])
+            assert_allclose(result.y_edges.values, expected[2])
+        else:
+            assert_allclose(result["values"].values, expected[0])
+            assert_allclose(result.x_centers.values, expected[1][:, 0])
+            assert_allclose(result.y_centers.values, expected[1][:, 1])
+
+    def test_histogram2d_dataarray_and_top_level(self, _xr):
+        import arviz_stats as azs
+
+        x = _xr.DataArray(np.arange(12).reshape(2, 6), dims=("batch", "sample"))
+        y = _xr.DataArray(np.arange(12).reshape(2, 6), dims=("batch", "sample"))
+
+        result = azs.histogram2d(x, y, bins=(3, 2), dim="sample", density=False)
+        expected = BaseArray().histogram2d(
+            x.values,
+            y.values,
+            bins=(3, 2),
+            axis=1,
+            density=False,
+        )
+
+        assert set(result.data_vars) == {"histogram", "x_edges", "y_edges"}
+        assert result.histogram.dims == ("batch", "histogram2d_x", "histogram2d_y")
+        assert_allclose(result.histogram.values, expected[0])
+        assert_allclose(result.x_edges.values, expected[1])
+        assert_allclose(result.y_edges.values, expected[2])
+
+    def test_hexbin_dataarray_and_top_level(self, _xr):
+        import arviz_stats as azs
+
+        x = _xr.DataArray(np.arange(12).reshape(2, 6), dims=("batch", "sample"))
+        y = _xr.DataArray(np.arange(12).reshape(2, 6), dims=("batch", "sample"))
+
+        result = azs.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 12, 0, 12),
+            dim="sample",
+            density=False,
+        )
+        expected_values, expected_offsets = BaseArray().hexbin(
+            x.values,
+            y.values,
+            gridsize=(2, 1),
+            extent=(0, 12, 0, 12),
+            axis=1,
+            density=False,
+        )
+
+        assert set(result.data_vars) == {"values", "x_centers", "y_centers"}
+        assert result["values"].dims == ("batch", "hexbin")
+        assert_allclose(result["values"].values, expected_values)
+        assert_allclose(result.x_centers.values, expected_offsets[..., 0])
+        assert_allclose(result.y_centers.values, expected_offsets[..., 1])
+
+    def test_array_top_level_dispatch(self, _xr):
+        import arviz_stats as azs
+
+        x = np.arange(12).reshape(2, 6)
+        y = np.arange(12).reshape(2, 6)
+
+        actual_histogram = azs.histogram2d(x, y, bins=3, axis=1, density=False)
+        expected_histogram = BaseArray().histogram2d(x, y, bins=3, axis=1, density=False)
+        values, offsets = azs.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 12, 0, 12),
+            axis=1,
+            density=False,
+        )
+        expected_values, expected_offsets = BaseArray().hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 12, 0, 12),
+            axis=1,
+            density=False,
+        )
+
+        for actual, expected in zip(actual_histogram, expected_histogram):
+            assert_allclose(actual, expected)
+        assert_allclose(values, expected_values)
+        assert_allclose(offsets, expected_offsets)

--- a/tests/base/test_bivariate_histograms.py
+++ b/tests/base/test_bivariate_histograms.py
@@ -116,6 +116,26 @@ class TestHistogram2D:
 
 
 class TestHexbin:
+    @pytest.mark.parametrize("density", [False, True])
+    def test_weights(self, array_stats, density):
+        x = np.array([0.25, 0.75, 0.75])
+        y = np.array([0.25, 0.75, 0.75])
+        weights = np.array([1.0, 2.0, 3.0])
+
+        values, _ = array_stats.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            weights=weights,
+            density=density,
+        )
+
+        expected = np.array([0, 0, 0, 0, 0, 0, 1, 5], dtype=float)
+        if density:
+            expected /= weights.sum() / 4
+        assert_allclose(values, expected)
+
     def test_matches_fixed_matplotlib_reference(self, array_stats):
         x = np.array([0.0, 0.2, 0.8, 1.0])
         y = np.array([0.0, 0.8, 0.2, 1.0])
@@ -337,6 +357,25 @@ class TestLabeledBivariateHistograms:
         assert_allclose(result["values"].values, expected_values)
         assert_allclose(result.x_centers.values, expected_offsets[..., 0])
         assert_allclose(result.y_centers.values, expected_offsets[..., 1])
+
+    def test_hexbin_dataarray_weights(self, _xr):
+        import arviz_stats as azs
+
+        x = _xr.DataArray([0.25, 0.75, 0.75], dims="sample")
+        y = _xr.DataArray([0.25, 0.75, 0.75], dims="sample")
+        weights = _xr.DataArray([1.0, 2.0, 3.0], dims="sample")
+
+        result = azs.hexbin(
+            x,
+            y,
+            gridsize=(2, 1),
+            extent=(0, 1, 0, 1),
+            weights=weights,
+            dim="sample",
+            density=False,
+        )
+
+        assert_allclose(result["values"], [0, 0, 0, 0, 0, 0, 1, 5])
 
     def test_array_top_level_dispatch(self, _xr):
         import arviz_stats as azs


### PR DESCRIPTION
## Description

Add public `histogram2d` and `hexbin` functions for computing bivariate histograms from paired samples.

- Support NumPy arrays and xarray `DataArray` inputs
- Support batched computation across array axes or named dimensions
- Return bin edges or hexagon centers for visualization
- Handle density normalization, explicit extents, weights, and nonfinite samples
- Add API documentation and behavioral tests against NumPy and fixed Matplotlib reference results

Closes #298.

## Visuals

### `histogram2d`

<img width="1440" height="1120" alt="histogram2d" src="https://github.com/user-attachments/assets/bd10a498-901b-4e0f-8f42-8a06451d60fa" />



### `hexbin`


<img width="1440" height="1120" alt="hexbin" src="https://github.com/user-attachments/assets/18758243-6ec7-4507-affe-dc6057491383" />


