### PR TITLE
Relax minimum draws for `rhat_nested`

### DIFF
--- a/src/arviz_stats/base/diagnostics.py
+++ b/src/arviz_stats/base/diagnostics.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines, too-many-function-args, redefined-outer-name
 """Diagnostic functions for ArviZ."""
 
+import logging
 import warnings
 from collections.abc import Sequence
 
@@ -11,6 +12,8 @@ from scipy.special import logsumexp
 from arviz_stats.base.circular_utils import circular_diff, circular_mean, circular_sd, circular_var
 from arviz_stats.base.core import _CoreBase
 from arviz_stats.base.stats_utils import not_valid as _not_valid
+
+_log = logging.getLogger(__name__)
 
 
 class _DiagnosticsBase(_CoreBase):
@@ -1416,7 +1419,7 @@ class _DiagnosticsBase(_CoreBase):
         Computation follows https://arxiv.org/abs/1903.08008
         """
         ary = np.asarray(ary)
-        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+        if _not_valid(ary, shape_kwargs={"min_draws": 2, "min_chains": 2}):
             return np.nan
         split_ary = self._split_chains(ary)
         # splitting we "duplicate the number of chains so we need to update
@@ -1434,7 +1437,7 @@ class _DiagnosticsBase(_CoreBase):
     def _rhat_nested_folded(self, ary, superchain_ids):
         """Calculate split-Rhat for folded z-values."""
         ary = np.asarray(ary)
-        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+        if _not_valid(ary, shape_kwargs={"min_draws": 2, "min_chains": 2}):
             return np.nan
         ary = self._z_fold(self._split_chains(ary))
         superchain_ids = np.hstack((superchain_ids, superchain_ids))
@@ -1442,7 +1445,7 @@ class _DiagnosticsBase(_CoreBase):
 
     def _rhat_nested_z_scale(self, ary, superchain_ids):
         ary = np.asarray(ary)
-        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+        if _not_valid(ary, shape_kwargs={"min_draws": 2, "min_chains": 2}):
             return np.nan
         ary = self._z_scale(self._split_chains(ary))
         superchain_ids = np.hstack((superchain_ids, superchain_ids))
@@ -1450,20 +1453,21 @@ class _DiagnosticsBase(_CoreBase):
 
     def _rhat_nested_split(self, ary, superchain_ids):
         ary = np.asarray(ary)
-        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+        if _not_valid(ary, shape_kwargs={"min_draws": 2, "min_chains": 2}):
             return np.nan
         superchain_ids = np.hstack((superchain_ids, superchain_ids))
         return self._rhat_nested(self._split_chains(ary), superchain_ids)
 
     def _rhat_nested_identity(self, ary, superchain_ids):
         ary = np.asarray(ary)
-        if _not_valid(ary, shape_kwargs={"min_draws": 4, "min_chains": 2}):
+        if _not_valid(ary, shape_kwargs={"min_draws": 1, "min_chains": 2}):
             return np.nan
         return self._rhat_nested(ary, superchain_ids)
 
     @staticmethod
     def _rhat_nested(ary, superchain_ids):
         ary = np.asarray(ary)
+        superchain_ids = np.asarray(superchain_ids)
         nchains, niterations = ary.shape
 
         # Check that all chains are assigned a superchain
@@ -1471,17 +1475,24 @@ class _DiagnosticsBase(_CoreBase):
             raise ValueError("Length of superchain_ids not equal to number of chains")
 
         # Check that superchains have equal length
-        superchain_counts = np.bincount(superchain_ids)
+        superchains, superchain_counts = np.unique(superchain_ids, return_counts=True)
         nchains_per_superchain = np.max(superchain_counts)
 
         if nchains_per_superchain != np.min(superchain_counts):
             raise ValueError("Number of chains per superchain is not the same for each superchain")
 
-        superchains = np.unique(superchain_ids)
+        if len(superchains) < 2:
+            _log.info("Nested rhat is undefined: need at least 2 superchains")
+            return np.nan
 
-        # Compute chain means and variances
+        if niterations == 1 and nchains_per_superchain == 1:
+            _log.info(
+                "Nested rhat is undefined: need at least 2 draws per chain "
+                "or 2 chains per superchain"
+            )
+            return np.nan
+
         chain_mean = np.mean(ary, axis=1)
-        chain_var = np.var(ary, axis=1, ddof=1)
 
         # mean of superchains calculated by only including specified chains
         # (equation 4 in Margossian et al. 2024)
@@ -1499,8 +1510,9 @@ class _DiagnosticsBase(_CoreBase):
         if niterations == 1:
             var_within_chain = np.zeros(len(superchains))
         else:
+            chain_var = np.var(ary, axis=1, ddof=1)
             var_within_chain = np.array(
-                [np.mean(chain_var[np.where(superchain_ids == k)[0]]) for k in superchains]
+                [np.mean(chain_var[superchain_ids == k]) for k in superchains]
             )
 
         # between-superchain variance (Bhat_nu in equation 6 in Margossian et al. 2024)

--- a/src/arviz_stats/base/stats_utils.py
+++ b/src/arviz_stats/base/stats_utils.py
@@ -245,7 +245,7 @@ def not_valid(ary, check_nan=True, check_shape=True, nan_kwargs=None, shape_kwar
     shape_kwargs : dict
         Valid kwargs are:
             min_chains : int
-                Defaults to 1.
+                Defaults to 2.
             min_draws : int
                 Defaults to 4.
 

--- a/src/arviz_stats/sampling_diagnostics.py
+++ b/src/arviz_stats/sampling_diagnostics.py
@@ -333,8 +333,12 @@ def rhat_nested(
         - xarray object: apply dimension aware function to all relevant subsets
         - others: passed to :func:`arviz_base.convert_to_dataset`
 
-        At least 2 posterior chains are needed to compute this diagnostic of one or more
-        stochastic parameters.
+        At least 2 superchains are needed to compute this diagnostic. Each superchain
+        must contain at least 2 chains, or each chain must have at least 2 draws, so that
+        the within-superchain variance can be estimated. The split-based methods ("rank",
+        "split", "folded", "z_scale") split each chain in two and therefore need at least
+        2 draws per chain. ``method="identity"`` works with a single draw per chain and is
+        the estimator exactly as defined in Margossian et al. (2024) [1]_.
 
     sample_dims : iterable of hashable, optional
         Dimensions to be considered sample dimensions and are to be reduced.
@@ -352,6 +356,9 @@ def rhat_nested(
         - "folded"
         - "z_scale"
         - "identity"
+
+        ``"identity"`` matches the definition in [1]_ and the ``posterior`` R package;
+        the other methods first apply the split/rank/fold transformations of [2]_.
     coords : dict, optional
         Dictionary of dimension/index names to coordinate values defining a subset
         of the data for which to perform the computation.
@@ -368,6 +375,27 @@ def rhat_nested(
     rhat : Compute split R-hat convergence diagnostic
     ess : Estimate the effective sample size (ess).
     plot_forest : Forest plot to compare HDI intervals from a number of distributions.
+
+    Examples
+    --------
+    Calculate nested R-hat with two superchains of two chains each:
+
+    .. ipython::
+
+        In [1]: from arviz_base import load_arviz_data
+           ...: import arviz_stats as azs
+           ...: data = load_arviz_data('centered_eight')
+           ...: azs.rhat_nested(data, superchain_ids=[0, 0, 1, 1])
+
+    With a single draw per chain the split-based methods return nan; use
+    ``method="identity"``:
+
+    .. ipython::
+
+        In [1]: import numpy as np
+           ...: rng = np.random.default_rng(0)
+           ...: samples = rng.normal(size=(8, 1))
+           ...: azs.rhat_nested(samples, superchain_ids=[0, 0, 0, 0, 1, 1, 1, 1], method="identity")
 
     References
     ----------

--- a/tests/base/test_diagnostics.py
+++ b/tests/base/test_diagnostics.py
@@ -204,6 +204,79 @@ def test_rhat_bad_method(rng):
         array_stats.rhat(ary, method="wrong_method")
 
 
+@pytest.mark.parametrize("method", ("rank", "split", "folded", "z_scale", "identity"))
+@pytest.mark.parametrize("draw", (1, 2, 3, 4))
+def test_rhat_nested_min_draws_by_method(rng, method, draw):
+    """Nested R-hat needs at least two draws per chain except for the identity method."""
+    ary = rng.normal(size=(4, draw))
+    rhat_data = array_stats.rhat_nested(ary, superchain_ids=[0, 0, 1, 1], method=method)
+    if method == "identity" or draw >= 2:
+        assert not np.isnan(rhat_data)
+    else:
+        assert np.isnan(rhat_data)
+
+
+def test_rhat_nested_single_draw_per_chain(rng):
+    """Single draw per chain with an extra dimension returns finite values."""
+    ary = rng.normal(size=(4, 1, 2))
+    rhat_data = array_stats.rhat_nested(
+        ary, superchain_ids=(0, 0, 1, 1), method="identity", chain_axis=0, draw_axis=1
+    )
+    assert rhat_data.shape == (2,)
+    assert np.all(np.isfinite(rhat_data))
+    assert np.all(rhat_data >= 1)
+
+
+def test_rhat_nested_undefined_returns_nan(rng):
+    """Nested R-hat is undefined without variation within and between superchains."""
+    assert np.isnan(array_stats.rhat_nested(rng.normal(size=(2, 1)), superchain_ids=[0, 1]))
+    assert np.isnan(array_stats.rhat_nested(rng.normal(size=(4, 10)), superchain_ids=[0, 0, 0, 0]))
+    assert np.isnan(array_stats.rhat_nested(rng.normal(size=(1, 10)), superchain_ids=[0]))
+
+
+@pytest.mark.parametrize("draw", (1, 5))
+def test_rhat_nested_identity_matches_formula(rng, draw):
+    ary = rng.normal(size=(4, draw))
+    superchain_ids = np.array([0, 0, 1, 1])
+
+    chain_mean = ary.mean(axis=1)
+    chain_var = ary.var(axis=1, ddof=1) if draw > 1 else np.zeros(ary.shape[0])
+
+    superchain_means = []
+    between_var = []
+    within_var = []
+    for label in np.unique(superchain_ids):
+        mask = superchain_ids == label
+        means = chain_mean[mask]
+        superchain_means.append(means.mean())
+        between_var.append(means.var(ddof=1) if means.size > 1 else 0.0)
+        within_var.append(chain_var[mask].mean())
+
+    var_between = np.var(superchain_means, ddof=1)
+    var_within = np.mean(np.asarray(within_var) + np.asarray(between_var))
+    expected = np.sqrt(1 + var_between / var_within)
+
+    result = array_stats.rhat_nested(ary, superchain_ids=superchain_ids, method="identity")
+    np.testing.assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize("method", ("identity", "rank"))
+def test_rhat_nested_noncontiguous_ids(rng, method):
+    ary = rng.normal(size=(4, 100))
+    contiguous = array_stats.rhat_nested(ary, superchain_ids=[0, 0, 1, 1], method=method)
+    noncontiguous = array_stats.rhat_nested(ary, superchain_ids=[0, 0, 5, 5], method=method)
+    np.testing.assert_allclose(contiguous, noncontiguous)
+
+
+@pytest.mark.parametrize("method", ("rank", "split", "folded", "z_scale", "identity"))
+def test_rhat_nested_nan(rng, method):
+    """Confirm nested R-hat statistic returns nan."""
+    data = rng.normal(size=(4, 100))
+    data[0, 0] = np.nan  #  pylint: disable=unsupported-assignment-operation
+    rhat_data = array_stats.rhat_nested(data, superchain_ids=[0, 0, 1, 1], method=method)
+    assert np.isnan(rhat_data)
+
+
 @pytest.mark.parametrize(
     "method",
     (

--- a/tests/test_sampling_diagnostics.py
+++ b/tests/test_sampling_diagnostics.py
@@ -109,6 +109,23 @@ def test_rhat_nested_dataarray_returns_dataarray(centered_eight):
     assert isinstance(result, xr.DataArray)
 
 
+def test_rhat_nested_dataset_single_draw():
+    rng = np.random.default_rng(0)
+    ds = xr.Dataset(
+        {
+            "a": (("chain", "draw"), rng.normal(size=(8, 1))),
+            "b": (("chain", "draw", "dim"), rng.normal(size=(8, 1, 3))),
+        }
+    )
+    superchain_ids = [0, 0, 0, 0, 1, 1, 1, 1]
+    identity = rhat_nested(ds, superchain_ids=superchain_ids, method="identity")
+    assert np.all(np.isfinite(identity["a"]))
+    assert np.all(np.isfinite(identity["b"]))
+    rank = rhat_nested(ds, superchain_ids=superchain_ids)
+    assert np.all(np.isnan(rank["a"]))
+    assert np.all(np.isnan(rank["b"]))
+
+
 def test_mcse_datatree_returns_datatree(centered_eight):
     result = mcse(centered_eight, group="posterior")
     assert isinstance(result, xr.DataTree)


### PR DESCRIPTION
As highlighted in #354, `rhat_nested` returned nan for fewer than 4 draws per chain because it reused the split-R-hat shape check. Nested R-hat (Margossian et al. 2024) is designed for many short chains, down to a single draw per chain, and `posterior::rhat_nested` has no draw minimum. The minimum now depends on what each method needs: `identity` works with 1 draw per chain, the split-based methods (`rank`, `split`, `folded`, `z_scale`) need 2 draws since they halve each chain. Worth noting that, like with split R-hat, an odd number of draws drops the middle draw when splitting. Behavior for 4 or more draws is unchanged.

The default method is still `rank`, so the snippet in #354 still returns nan unless `method="identity"` is passed. That is the estimator as defined in the paper and in `posterior`. The docstring now states the requirements and includes a single-draw example.

Other changes in the same code path:

- `_rhat_nested` now returns nan with an info log when there are fewer than 2 superchains, or when there is 1 draw and 1 chain per superchain, instead of dividing by zero.
- Superchain sizes are counted with `np.unique(return_counts=True)` instead of `np.bincount`. `bincount` raised a spurious "not the same for each superchain" error for non-contiguous labels such as `[0, 0, 5, 5]`, and rejected negative labels.
- The per-chain variance is only computed when there are at least 2 draws, avoiding a "Degrees of freedom <= 0" RuntimeWarning.
- Corrected the `min_chains` default in the `not_valid` docstring.

Closes #354
