### PR TITLE
Accept coords in ci_in_rope, as its docstring documents

### DIFF
--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -450,6 +450,7 @@ def ci_in_rope(
     var_names=None,
     filter_vars=None,
     group="posterior",
+    coords=None,
     dim=None,
     ci_prob=None,
     ci_kind=None,
@@ -535,6 +536,9 @@ def ci_in_rope(
         combined=False,
         keep_dataset=True,
     )
+
+    if coords is not None:
+        dataset = dataset.sel(coords)
 
     if isinstance(rope, dict):
         if not all(var in dataset.data_vars for var in rope.keys()):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from .helpers import importorskip
 
@@ -119,6 +119,24 @@ def test_rope_multiple(fake_dt):
     assert result["b"] > 90
     assert "a" in result.data_vars
     assert "b" in result.data_vars
+
+
+def test_rope_coords(centered_eight):
+    """`coords` must subset the selected group, as it does for `summary`.
+
+    It was documented but not accepted, so passing it raised TypeError.
+    """
+    schools = ["Choate", "Deerfield"]
+    full = ci_in_rope(centered_eight, var_names=["theta"], rope=(-0.5, 0.5))
+    subset = ci_in_rope(
+        centered_eight, var_names=["theta"], rope=(-0.5, 0.5), coords={"school": schools}
+    )
+
+    assert full["theta"].sizes["school"] == 8
+    assert subset["theta"].sizes["school"] == 2
+    assert list(subset["theta"].coords["school"].values) == schools
+    # subsetting must not change the values computed for the retained schools
+    assert_allclose(subset["theta"].values, full["theta"].sel(school=schools).values)
 
 
 def test_hdi(datatree):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -122,10 +122,6 @@ def test_rope_multiple(fake_dt):
 
 
 def test_rope_coords(centered_eight):
-    """`coords` must subset the selected group, as it does for `summary`.
-
-    It was documented but not accepted, so passing it raised TypeError.
-    """
     schools = ["Choate", "Deerfield"]
     full = ci_in_rope(centered_eight, var_names=["theta"], rope=(-0.5, 0.5))
     subset = ci_in_rope(
@@ -135,7 +131,6 @@ def test_rope_coords(centered_eight):
     assert full["theta"].sizes["school"] == 8
     assert subset["theta"].sizes["school"] == 2
     assert list(subset["theta"].coords["school"].values) == schools
-    # subsetting must not change the values computed for the retained schools
     assert_allclose(subset["theta"].values, full["theta"].sel(school=schools).values)
 
 


### PR DESCRIPTION
### What this fixes

`ci_in_rope` documents a `coords` argument:

> `coords : dict, optional` — Coordinates defining a subset over the selected group.

but never accepted one, and the function has no `**kwargs` to absorb it:

```python
>>> ci_in_rope(data, rope=(-0.5, 0.5), var_names=["theta"],
...            coords={"school": ["Choate", "Deerfield"]})
TypeError: ci_in_rope() got an unexpected keyword argument 'coords'
```

It's the only function in `summary.py` that documents `coords` without taking it — `summary`, `mean` and `median` all accept it, and `summary`'s signature places it in exactly the position `ci_in_rope`'s docstring does (right after `group`).

### The change

`coords=None` added after `group`, and applied to the extracted dataset. `extract` has no `coords` argument, so the subset is applied to what it returns — the same two lines `summary` already uses:

```python
if coords is not None:
    dataset = dataset.sel(coords)
```

With `centered_eight`:

| | schools in result |
|---|---|
| `ci_in_rope(..., var_names=["theta"])` | 8 |
| `... coords={"school": ["Choate", "Deerfield"]}` | 2 (before: `TypeError`) |

and the retained values are identical to the corresponding slice of the unsubset result.

I took "make the code match the docs" rather than "delete the docs entry" because every sibling in the module supports `coords` and the docstring places it consistently with them — but if you'd rather the line just came out of the docstring, that's a one-line change and I'm happy to switch.

### Testing

Added `test_rope_coords` to `tests/test_summary.py`, asserting the subset has the requested schools and that subsetting doesn't change the values computed for them.

- without the change: `TypeError: ci_in_rope() got an unexpected keyword argument 'coords'`
- with it: `tests/test_summary.py` 82 passed, `tests/base` 1628 passed, 2 skipped
- `ruff check` and `ruff format --check` clean

No overlap with #314, which only touches `tests/base/test_stats.py`.
