### PR TITLE
Only build the summary's LaTeX repr when asked for

### DIFF
--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -415,7 +415,6 @@ class SummaryDataFrame(pd.DataFrame):
         return self._display_df().to_html()
 
     def _repr_latex_(self):  # pylint: disable=overridden-final-method
-        # Like pandas, only when asked for: IPython calls every repr, and to_latex needs jinja2.
         if self._fmt_map is None or pd.get_option("styler.render.repr") != "latex":
             return super()._repr_latex_()
         return self.to_latex(escape=True)

--- a/src/arviz_stats/summary.py
+++ b/src/arviz_stats/summary.py
@@ -415,7 +415,8 @@ class SummaryDataFrame(pd.DataFrame):
         return self._display_df().to_html()
 
     def _repr_latex_(self):  # pylint: disable=overridden-final-method
-        if self._fmt_map is None:
+        # Like pandas, only when asked for: IPython calls every repr, and to_latex needs jinja2.
+        if self._fmt_map is None or pd.get_option("styler.render.repr") != "latex":
             return super()._repr_latex_()
         return self.to_latex(escape=True)
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -596,8 +596,6 @@ def test_summary_data_frame():
     assert "0.123" in html
     assert "1.06" in html
 
-    # As for a plain DataFrame, the LaTeX repr is only built when asked for,
-    # since IPython calls every repr on display and to_latex needs jinja2.
     assert sdf._repr_latex_() is None
     with pd.option_context("styler.render.repr", "latex"):
         latex = sdf._repr_latex_()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -596,7 +596,11 @@ def test_summary_data_frame():
     assert "0.123" in html
     assert "1.06" in html
 
-    latex = sdf._repr_latex_()
+    # As for a plain DataFrame, the LaTeX repr is only built when asked for,
+    # since IPython calls every repr on display and to_latex needs jinja2.
+    assert sdf._repr_latex_() is None
+    with pd.option_context("styler.render.repr", "latex"):
+        latex = sdf._repr_latex_()
     assert "0.123" in latex
     assert "-1.988" in latex
     assert "1.00" in latex
@@ -612,7 +616,8 @@ def test_summary_data_frame():
 
     sdf_t = sdf.T
     assert sdf_t._fmt_map is not None
-    latex_t = sdf_t._repr_latex_()
+    with pd.option_context("styler.render.repr", "latex"):
+        latex_t = sdf_t._repr_latex_()
     assert "0.123" in latex_t
     assert "1.06" in latex_t
     assert "r\\_hat" in latex_t


### PR DESCRIPTION
Closes #447.

`_repr_latex_` now returns LaTeX only when `styler.render.repr == "latex"`, as pandas does; the test checks both cases.

Checked: `tests/test_summary.py` and pre-commit pass; with no jinja2, displaying a summary gives no traceback.